### PR TITLE
Fix log.Warningf content

### DIFF
--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -66,7 +66,7 @@ func (r *Runner) EnumerateSingleHost(host string, ports map[int]struct{}, output
 	log.Infof("Found %d ports on host %s (%s) with latency %s\n", len(foundPorts), host, hostIP, scanner.Latency)
 
 	if len(foundPorts) <= 0 {
-		log.Warningf("Could not scan on host %s (%s)\n", host)
+		log.Warningf("Could not scan on host %s (%s)\n", host, hostIP)
 		return
 	}
 


### PR DESCRIPTION
fix error:
```
pkg/runner/enumerate.go:69: Warningf format %s reads arg #2, but call has 1 arg
```

Add hostIP to log.