### PR TITLE
Resolve hostnames | Remove duplicate IPs | Pass to nmap

### DIFF
--- a/scripts/naabu2nmap.sh
+++ b/scripts/naabu2nmap.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+## This script will resolve all hostnames and remove any duplicate IPs before sending to NMAP.
 TARGETSFILE="$1"
 PORTSFILE="$2"
+IPSFILE=="$3"
 
 if [ -z "$1" ]
   then
@@ -11,12 +13,20 @@ if [ -z "$2" ]
   then
     PORTSFILE="naabu_output_ports.txt"
 fi
+if [ -z "$3" ]
+  then
+    IPSFILE="naabu_output_ips.txt"
+fi
 
+IPSTOSCAN="ips_to_scan.txt"
 
 # clean files files
 echo -n "" > $TARGETSFILE
 echo -n "" > $PORTSFILE
+echo -n "" > $IPSFILE
+echo -n "" > $IPSTOSCAN
 
+# Split IPs and Ports into seperate files
 while IFS=: read ip port; do
   echo $ip>>$TARGETSFILE
   echo $port>>$PORTSFILE
@@ -26,12 +36,20 @@ done
 sort -u -o $TARGETSFILE $TARGETSFILE
 sort -u -o $PORTSFILE $PORTSFILE
 
+# Get IPS from hosts
+while IFS= read -r line
+do
+  ping -c 1 $line | egrep -o -m 1 '\([0-9]+\.[^\(\r\n]*\)' | gsed 's/^.\(.*\).$/\1/' >> $IPSFILE
+done < $TARGETSFILE
+
+# Remove duplicate IPs
+awk '!seen[$0]++' $IPSFILE > $IPSTOSCAN
+
 # in ports replace newline with comma
 ports=`cat $PORTSFILE | tr '\n' ','`
 
-# Running nmap on found results.
-
+# Running nmap on found IPs
 echo "Running nmap service scan on found results."
-echo "Executing nmap -iL $TARGETSFILE -p ${ports:0:-1} -sV"
+echo "Executing nmap -iL $IPSFILE -p ${ports:0:-1} -sV"
 
-nmap -iL $TARGETSFILE -p ${ports:0:-1} -sV
+nmap -iL $IPSTOSCAN -p ${ports:0:-1} -sV


### PR DESCRIPTION
I was doing recon and came across multiple hostnames that map to the same IP, so decided to change the script to resolve all hostnames to IP into a separate file.
Remove any duplicates and then only pass to NMAP.
The scripts reserves the original naabu_output_targets.txt to cross reference with IPs.
Creates a 2 new files:
-  naabu_output_ips.txt - contains all resolved IPs
- ips_to_scan.txt - All duplicate IPs removed and is the file send to NMAP.