### PR TITLE
Added multi-stage build in Dockerfile for minimization.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
-FROM golang:1.14
+# BUILDER
+FROM golang:1.14 AS builder
+WORKDIR /app
+COPY . .
+RUN go get -d -v ./...
+RUN go build -o naabu ./v2/cmd/naabu/
+
+# RUNNER
+FROM debian:buster
+RUN mkdir /app
+WORKDIR /app
 RUN apt update && apt install -y nmap
-WORKDIR /go/src/app
+COPY --from=builder /app/naabu /app/naabu
+COPY --from=builder /app/scripts /app/scripts
 
-# Install
-RUN go get -v -u github.com/projectdiscovery/naabu/v2/cmd/naabu
-
-ENTRYPOINT ["naabu"]
+ENTRYPOINT ["/app/naabu"]


### PR DESCRIPTION
Hi team!
I added multi-stage build in Dockerfile for minimization.
With multi-stage build, you can reduce the amount of docker image from `933MB` to `178MB`. There was no problem when I tested it 😄

## Diff
[ before ]
```
$ docker build .
$ docker images
4d216e10c92f        9 seconds ago       933MB
```

[ after ]
```
$ docker build .
$ docker images
19835a228ded        6 seconds ago        178MB
```

## Testing
```
$ docker run 19835a228ded -host www.hahwul.com                                                        

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/ v2.0.2

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Configuration file saved to /root/.config/naabu/naabu.conf
[INF] Running TCP/ICMP/SYN scan with root privileges
[INF] Fastest host found for target: 185.199.109.153 (33.799362ms)
[INF] Found 2 ports on host www.hahwul.com (185.199.109.153)
www.hahwul.com:443
www.hahwul.com:80
```

## References
https://docs.docker.com/develop/develop-images/multistage-build/
https://github.com/hahwul/dalfox/blob/master/Dockerfile
https://www.hahwul.com/2020/10/07/docker-multistage-build-for-optimazation/