### PR TITLE
Upgrade from Alpine 3.12 to Alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.14-alpine3.12 AS builder
+FROM golang:1.14-alpine3.13 AS builder
 RUN apk add build-base libpcap-dev
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/naabu/v2/cmd/naabu
 
-FROM alpine:3.12
+FROM alpine:3.13
 RUN apk add nmap libpcap-dev
 COPY --from=builder /go/bin/naabu /usr/local/bin/naabu
 ENTRYPOINT ["naabu"]


### PR DESCRIPTION
* Alpine 3.13 was released on 2021-01-14 this PR takes care of updating the Dockerfile to use Alpine 3.13