### PR TITLE
Fix the golangci-lint stage in github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.31
+          working-directory: v2
           args: --timeout 5m
 
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install libpcap-dev
+        run: sudo apt install libpcap-dev
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.1
         with:


### PR DESCRIPTION
Added working directory to golangci-lint-action. The reason the lint stage was failing is because the root of the git repo contains no Golang code. 