### PR TITLE
WIP: Fix golangci linter issues

### DIFF
--- a/v2/pkg/scan/icmp.go
+++ b/v2/pkg/scan/icmp.go
@@ -1,6 +1,5 @@
 // +build linux darwin
-// It contains global variables
-// nolint: gochecknoglobals, gochecknoinits, unused
+// nolint: gochecknoglobals, gochecknoinits, unused // It contains global variables
 
 package scan
 

--- a/v2/pkg/scan/icmp.go
+++ b/v2/pkg/scan/icmp.go
@@ -1,4 +1,5 @@
 // +build linux darwin
+// nolint: gochecknoglobals, gochecknoinits
 
 package scan
 

--- a/v2/pkg/scan/icmp.go
+++ b/v2/pkg/scan/icmp.go
@@ -1,5 +1,6 @@
 // +build linux darwin
-// nolint: gochecknoglobals, gochecknoinits
+// It contains global variables
+// nolint: gochecknoglobals, gochecknoinits, unused
 
 package scan
 

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -92,9 +92,7 @@ var (
 	setupHandlerCallback                  func(s *Scanner, interfaceName string) error
 	tcpReadWorkerPCAPCallback             func(s *Scanner)
 	cleanupHandlersCallback               func(s *Scanner)
-	pingIcmpEchoRequestCallback           func(ip string, timeout time.Duration) bool
 	pingIcmpEchoRequestAsyncCallback      func(s *Scanner, ip string)
-	pingIcmpTimestampRequestCallback      func(ip string, timeout time.Duration) bool
 	pingIcmpTimestampRequestAsyncCallback func(s *Scanner, ip string)
 )
 

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -92,7 +92,9 @@ var (
 	setupHandlerCallback                  func(s *Scanner, interfaceName string) error
 	tcpReadWorkerPCAPCallback             func(s *Scanner)
 	cleanupHandlersCallback               func(s *Scanner)
+	pingIcmpEchoRequestCallback           func(ip string, timeout time.Duration) bool
 	pingIcmpEchoRequestAsyncCallback      func(s *Scanner, ip string)
+	pingIcmpTimestampRequestCallback      func(ip string, timeout time.Duration) bool
 	pingIcmpTimestampRequestAsyncCallback func(s *Scanner, ip string)
 )
 

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -1,6 +1,5 @@
 // +build linux darwin
-// It contains global variables
-// nolint: gochecknoglobals, gochecknoinits, unused
+// nolint: gochecknoglobals, gochecknoinits, unused // It contains global variables
 
 package scan
 

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -1,4 +1,5 @@
 // +build linux darwin
+// nolint: gochecknoglobals, gochecknoinits
 
 package scan
 

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -1,5 +1,6 @@
 // +build linux darwin
-// nolint: gochecknoglobals, gochecknoinits
+// It contains global variables
+// nolint: gochecknoglobals, gochecknoinits, unused
 
 package scan
 


### PR DESCRIPTION
* Remove unused functions from v2/pkg/scan/scan.go
* Add commands for golangci linter to ignore Globals and Init functions