### PR TITLE
Fix inconsistent Golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.0-alpine3.13 AS builder
+FROM golang:1.15-alpine3.13 AS builder
 RUN apk add build-base libpcap-dev
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/naabu/v2/cmd/naabu
 


### PR DESCRIPTION
Docker image is using Golang 1.16, while everything else in the code is using Golang 1.15. This could lead to inconsistencies between running naabu using the Docker Image and the release artifacts.