### PR TITLE
build: update to use go1.17

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       - name: Install libpcap-dev
         run: sudo apt install libpcap-dev

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Install Dependences
         run: brew install libpcap
       - name: Run GoReleaser
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Install Dependences
         run: sudo apt install libpcap-dev
 
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.16.5-alpine AS builder
+FROM golang:1.17.0-alpine AS builder
 RUN apk add build-base libpcap-dev
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/naabu/v2/cmd/naabu
 
-FROM alpine
+FROM alpine:3.14
 RUN apk add nmap libpcap-dev bind-tools ca-certificates
 COPY --from=builder /go/bin/naabu /usr/local/bin/naabu
 ENTRYPOINT ["naabu"]

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/naabu/v2
 
-go 1.14
+go 1.17
 
 require (
 	github.com/google/gopacket v1.1.19
@@ -22,4 +22,21 @@ require (
 	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1
 	golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/karrick/godirwalk v1.16.1 // indirect
+	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
+	github.com/miekg/dns v1.1.41 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/projectdiscovery/executil v0.0.0-20210414225944-2ad029b6a1fd // indirect
+	github.com/projectdiscovery/hmap v0.0.1 // indirect
+	github.com/projectdiscovery/retryabledns v1.0.10 // indirect
+	github.com/syndtr/goleveldb v1.0.0 // indirect
+	github.com/yl2chen/cidranger v1.0.2 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -24,7 +24,6 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -35,7 +34,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
@@ -100,12 +98,6 @@ github.com/projectdiscovery/gologger v1.1.4/go.mod h1:Bhb6Bdx2PV1nMaFLoXNBmHIU85
 github.com/projectdiscovery/hmap v0.0.1 h1:VAONbJw5jP+syI5smhsfkrq9XPGn4aiYy5pR6KR1wog=
 github.com/projectdiscovery/hmap v0.0.1/go.mod h1:VDEfgzkKQdq7iGTKz8Ooul0NuYHQ8qiDs6r8bPD1Sb0=
 github.com/projectdiscovery/ipranger v0.0.2/go.mod h1:kcAIk/lo5rW+IzUrFkeYyXnFJ+dKwYooEOHGVPP/RWE=
-github.com/projectdiscovery/ipranger v0.0.3-0.20210617094855-9f69a5447f7f h1:9+WOis0hi24l77QmsALVdHrPUFm5KqET5pLeF0x3Oic=
-github.com/projectdiscovery/ipranger v0.0.3-0.20210617094855-9f69a5447f7f/go.mod h1:oLFGr1vNeVX+nnNtpBDZs83gdPMftepBT2MID5ZqZpo=
-github.com/projectdiscovery/ipranger v0.0.3-0.20210617100928-8be9d49fa47b h1:JAcPJoJbRcR6Vth7VXuaxeMnLYGXtbL6GNo9QZaWXHY=
-github.com/projectdiscovery/ipranger v0.0.3-0.20210617100928-8be9d49fa47b/go.mod h1:prNZB2gIc/r1BjxM+Tb3Hf5JiiRkQKMJ05PeUlonSlA=
-github.com/projectdiscovery/ipranger v0.0.3-0.20210618195032-5aea1b67f55f h1:YpL9yzoYyrSNlofZGkJ7FIGan9rYqMDHSqnTvobOoPQ=
-github.com/projectdiscovery/ipranger v0.0.3-0.20210618195032-5aea1b67f55f/go.mod h1:J1iJbIhUvLKIhRuosEyI0wzjmsLaG4m7jQjx42u82So=
 github.com/projectdiscovery/ipranger v0.0.3-0.20210619173509-f9b366d18ac6 h1:NaQMBS3GN7PM0+nC+rYDLeLMbQt6YVoZU9QlxQKShLg=
 github.com/projectdiscovery/ipranger v0.0.3-0.20210619173509-f9b366d18ac6/go.mod h1:J1iJbIhUvLKIhRuosEyI0wzjmsLaG4m7jQjx42u82So=
 github.com/projectdiscovery/iputil v0.0.0-20210414194613-4b4d2517acf0 h1:OVOfLV23PbqzxTm+nPmeAhgFuxk4ich22zFxpOw+YC8=
@@ -113,7 +105,6 @@ github.com/projectdiscovery/iputil v0.0.0-20210414194613-4b4d2517acf0/go.mod h1:
 github.com/projectdiscovery/mapcidr v0.0.4/go.mod h1:ALOIj6ptkWujNoX8RdQwB2mZ+kAmKuLJBq9T5gR5wG0=
 github.com/projectdiscovery/mapcidr v0.0.6 h1:RRIrqNakUEF/pstIXWTD6yvCMF9N6SnOb9m4ju4xavc=
 github.com/projectdiscovery/mapcidr v0.0.6/go.mod h1:ZEBhMmBU3laUl3g9QGTrzJku1VJOzjdFwW01f/zVVzM=
-github.com/projectdiscovery/networkpolicy v0.0.0-20210414200240-b3fa8abf324c h1:WbnjctvqNZQjMBJjoZ3WEpp658dFU/559RCWNonjHeQ=
 github.com/projectdiscovery/networkpolicy v0.0.0-20210414200240-b3fa8abf324c/go.mod h1:KZIP5x7t+bH2dASgnYaqbiLI4z0gxXzekwUtarrQMdc=
 github.com/projectdiscovery/networkpolicy v0.0.0-20210617100800-060573865df4 h1:W9XcJV3lhDo29yuHsFejwCqZ4QETtQKzcRagmgqfZDM=
 github.com/projectdiscovery/networkpolicy v0.0.0-20210617100800-060573865df4/go.mod h1:asvdg5wMy3LPVMGALatebKeOYH5n5fV5RCTv6DbxpIs=
@@ -211,7 +202,6 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -229,7 +219,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=


### PR DESCRIPTION
bump the project to use go1.17 and also refresh the workflow and dockerfile setup