### PR TITLE
Fix for top ports options

### DIFF
--- a/v2/cmd/functional-test/testcases.txt
+++ b/v2/cmd/functional-test/testcases.txt
@@ -1,6 +1,6 @@
 127.0.0.1 {{binary}} -p 8000
 127.0.0.1 {{binary}} -p 8000,443
-127.0.0.1 {{binary}} -tp top-100
+127.0.0.1 {{binary}} -tp 100
 127.0.0.1 {{binary}} -ep 80 -p 8000
 127.0.0.1 {{binary}} -c 25 -p 8000
 127.0.0.1 {{binary}} -nmap-cli 'nmap -Pn -sT' -p 8000

--- a/v2/pkg/runner/ports.go
+++ b/v2/pkg/runner/ports.go
@@ -55,7 +55,7 @@ func ParsePorts(options *Options) ([]int, error) {
 			if err != nil {
 				return nil, fmt.Errorf("could not read ports: %s", err)
 			}
-		case "top-100": // If the user has specfied top-100, use them
+		case "100": // If the user has specfied 100, use them
 			ports, err := parsePortsList(NmapTop100)
 			if err != nil {
 				return nil, fmt.Errorf("could not read ports: %s", err)
@@ -64,7 +64,7 @@ func ParsePorts(options *Options) ([]int, error) {
 			if err != nil {
 				return nil, fmt.Errorf("could not read ports: %s", err)
 			}
-		case "top-1000": // If the user has specfied top-1000, use them
+		case "1000": // If the user has specfied 1000, use them
 			ports, err := parsePortsList(NmapTop1000)
 			if err != nil {
 				return nil, fmt.Errorf("could not read ports: %s", err)

--- a/v2/pkg/runner/ports_test.go
+++ b/v2/pkg/runner/ports_test.go
@@ -62,8 +62,8 @@ func TestParsePorts(t *testing.T) {
 		wantErr bool
 	}{
 		{"full", 65535, false},
-		{"top-100", 100, false},
-		{"top-1000", 1000, false},
+		{"100", 100, false},
+		{"1000", 1000, false},
 		{"a", 0, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Minor fix for top ports options to make it simple to write/use pervasively it was a bit repetitive.

- Previously: `top-ports top-1000`
- Now: `top-ports 1000`