### PR TITLE
support for comma separated hosts

### DIFF
--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -28,7 +28,7 @@ type Options struct {
 	Rate              int    // Rate is the rate of port scan requests
 	Timeout           int    // Timeout is the seconds to wait for ports to respond
 	WarmUpTime        int    // WarmUpTime between scan phases
-	Host              string // Host is the host to find ports for
+	Host              goflags.NormalizedStringSlice // Host is the single host or comma-separated list of hosts to find ports for
 	HostsFile         string // HostsFile is the file containing list of hosts to find port for
 	Output            string // Output is the file to write found ports to.
 	Ports             string // Ports is the ports to use for enumeration
@@ -62,7 +62,7 @@ func ParseOptions() *Options {
 	flagSet.SetDescription(`Naabu is a port scanning tool written in Go that allows you to enumerate open ports for hosts in a fast and reliable manner.`)
 
 	createGroup(flagSet, "input", "Input",
-		flagSet.StringVar(&options.Host, "host", "", "Host to scan ports for"),
+		flagSet.NormalizedStringSliceVarP(&options.Host, "host", "",[]string{}, "Single Host or comma-separated list of hosts to scan ports for"),
 		flagSet.StringVarP(&options.HostsFile, "l", "list", "", "File containing list of hosts to scan ports"),
 		flagSet.StringVarP(&options.ExcludeIps, "eh", "exclude-hosts", "", "Specifies a comma-separated list of targets to be excluded from the scan (ip, cidr)"),
 		flagSet.StringVarP(&options.ExcludeIpsFile, "ef", "exclude-file", "", "Specifies a newline-delimited file with targets to be excluded from the scan (ip, cidr)"),

--- a/v2/pkg/runner/targets.go
+++ b/v2/pkg/runner/targets.go
@@ -43,8 +43,10 @@ func (r *Runner) mergeToFile() (string, error) {
 	defer tempInput.Close()
 
 	// target defined via CLI argument
-	if r.options.Host != "" {
-		fmt.Fprintf(tempInput, "%s\n", r.options.Host)
+	if len(r.options.Host) > 0 {
+		for _,v :=range r.options.Host {
+			fmt.Fprintf(tempInput, "%s\n", v)
+		}
 	}
 
 	// Targets from file

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -24,7 +24,7 @@ var (
 func (options *Options) validateOptions() error {
 	// Check if Host, list of domains, or stdin info was provided.
 	// If none was provided, then return.
-	if options.Host == "" && options.HostsFile == "" && !options.Stdin && len(flag.Args()) == 0 {
+	if options.Host == nil && options.HostsFile == "" && !options.Stdin && len(flag.Args()) == 0 {
 		return errNoInputList
 	}
 

--- a/v2/pkg/runner/validate_test.go
+++ b/v2/pkg/runner/validate_test.go
@@ -11,7 +11,7 @@ func TestOptions(t *testing.T) {
 	options := Options{}
 	assert.ErrorIs(t, errNoInputList, options.validateOptions())
 
-	options.Host = "target"
+	options.Host = []string{"target1", "target2"}
 	assert.EqualError(t, options.validateOptions(), errors.Wrap(errZeroValue, "timeout").Error())
 
 	options.Timeout = 2


### PR DESCRIPTION
This PR provides support for comma separated hosts.
./naabu -host yahoo.com,hackerone.com,hp.com,dell.com can be used to test this.

<img width="938" alt="Screen Shot 2021-12-06 at 1 35 29 PM" src="https://user-images.githubusercontent.com/85764322/144914979-f4123ab3-ec29-41c7-892c-15d3a2b30f95.png">
