### PR TITLE
Adding customizable stats interval

### DIFF
--- a/v2/pkg/runner/default.go
+++ b/v2/pkg/runner/default.go
@@ -12,6 +12,7 @@ const (
 
 	ExternalTargetForTune = "8.8.8.8"
 
-	SynScan     = "s"
-	ConnectScan = "c"
+	SynScan             = "s"
+	ConnectScan         = "c"
+	DefautStatsInterval = 5
 )

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -49,6 +49,7 @@ type Options struct {
 	Resolvers         string                        // Resolvers (comma separated or file)
 	baseResolvers     []string
 	OnResult          OnResultCallback // OnResult callback
+	StatsInterval     int              // StatsInterval is the number of seconds to display stats after
 }
 
 // OnResultCallback (hostname, ip, ports)
@@ -113,6 +114,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.Silent, "silent", false, "display only results in output"),
 		flagSet.BoolVar(&options.Version, "version", false, "display version of naabu"),
 		flagSet.BoolVar(&options.EnableProgressBar, "stats", false, "display stats of the running scan"),
+		flagSet.IntVarP(&options.StatsInterval, "stats-interval", "si", DefautStatsInterval, "number of seconds to wait between showing a statistics update"),
 	)
 
 	_ = flagSet.Parse()

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -22,10 +22,6 @@ import (
 	"go.uber.org/ratelimit"
 )
 
-const (
-	tickduration = 5
-)
-
 // Runner is an instance of the port enumeration
 // client used to orchestrate the whole process.
 type Runner struct {
@@ -148,7 +144,7 @@ func (r *Runner) RunEnumeration() error {
 		r.stats.AddCounter("packets", uint64(0))
 		r.stats.AddCounter("errors", uint64(0))
 		r.stats.AddCounter("total", Range*uint64(r.options.Retries))
-		if err := r.stats.Start(makePrintCallback(), tickduration*time.Second); err != nil {
+		if err := r.stats.Start(makePrintCallback(), time.Duration(r.options.StatsInterval)*time.Second); err != nil {
 			gologger.Warning().Msgf("Couldn't start statistics: %s\n", err)
 		}
 	}


### PR DESCRIPTION
## Description
This PR adds the "stats-interval/si" option, making the stats printing interval configurable (in seconds)

## Notes
known `pcap` lint errors fixed in https://github.com/projectdiscovery/naabu/pull/265