### PR TITLE
Updating cdncheck

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/projectdiscovery/blackrock v0.0.0-20210415162320-b38689ae3a2e
-	github.com/projectdiscovery/cdncheck v0.0.2
+	github.com/projectdiscovery/cdncheck v0.0.4-0.20220322144854-b2d8ce308abb
 	github.com/projectdiscovery/clistats v0.0.8
 	github.com/projectdiscovery/dnsx v1.0.7-0.20210927160546-05f957862698
 	github.com/projectdiscovery/fdmax v0.0.3
@@ -35,11 +35,11 @@ require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/karrick/godirwalk v1.16.1 // indirect
 	github.com/miekg/dns v1.1.43 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/projectdiscovery/hmap v0.0.1 // indirect
 	github.com/projectdiscovery/retryabledns v1.0.13-0.20210927160332-db15799e2e4d // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -36,8 +36,9 @@ github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
@@ -57,8 +58,9 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -80,8 +82,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/projectdiscovery/blackrock v0.0.0-20210415162320-b38689ae3a2e h1:7bwaFH1jvtOo5ndhTQgoA349ozhX+1dc4b6tbaPnBOA=
 github.com/projectdiscovery/blackrock v0.0.0-20210415162320-b38689ae3a2e/go.mod h1:/IsapnEYiWG+yEDPXp0e8NWj3npzB9Ccy9lXEUJwMZs=
-github.com/projectdiscovery/cdncheck v0.0.2 h1:ZAaezMvVioC/8fC8iilylGT4FBBryzQdXHow+lHnPOE=
-github.com/projectdiscovery/cdncheck v0.0.2/go.mod h1:+vB8400d1Kxq5aDoi/XkVcdvpiqQjSrYJ8bRfUDdymQ=
+github.com/projectdiscovery/cdncheck v0.0.4-0.20220322144854-b2d8ce308abb h1:Q7tb/p2ts+dT+v4nQpxTR0DSng2C1Hlnrw/NE4tgGZw=
+github.com/projectdiscovery/cdncheck v0.0.4-0.20220322144854-b2d8ce308abb/go.mod h1:EevMeCG1ogBoUJYaa0Mv9R1VUboDm/DiynId7DboKy0=
 github.com/projectdiscovery/clistats v0.0.8 h1:tjmWb15mqsPf/yrQXVHLe2ThZX/5+mgKSfZBKWWLh20=
 github.com/projectdiscovery/clistats v0.0.8/go.mod h1:lV6jUHAv2bYWqrQstqW8iVIydKJhWlVaLl3Xo9ioVGg=
 github.com/projectdiscovery/dnsx v1.0.7-0.20210927160546-05f957862698 h1:LSE8Fu47mp1VcuQ2tb7K2H3UpWdSt/OvxpPiQ7+yC/k=

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -188,7 +188,6 @@ func (r *Runner) RunEnumeration() error {
 				continue
 			}
 
-			r.limiter.Take()
 			//resume cfg logic
 			r.options.ResumeCfg.Lock()
 			r.options.ResumeCfg.Index = index
@@ -325,6 +324,7 @@ func (r *Runner) handleHostPort(host string, port int) {
 		return
 	}
 
+	r.limiter.Take()
 	open, err := r.scanner.ConnectPort(host, port, time.Duration(r.options.Timeout)*time.Millisecond)
 	if open && err == nil {
 		r.scanner.ScanResults.AddPort(host, port)
@@ -338,6 +338,7 @@ func (r *Runner) handleHostPortSyn(host string, port int) {
 		return
 	}
 
+	r.limiter.Take()
 	r.scanner.EnqueueTCP(host, port, scan.SYN)
 }
 

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -304,7 +304,7 @@ func (r *Runner) canIScanIfCDN(host string, port int) bool {
 	}
 
 	// if exclusion is enabled, but the ip is not part of the CDN ips range we can scan
-	if ok, err := r.scanner.CdnCheck(host); err == nil && !ok {
+	if ok, _, err := r.scanner.CdnCheck(host); err == nil && !ok {
 		return true
 	}
 

--- a/v2/pkg/scan/cdn.go
+++ b/v2/pkg/scan/cdn.go
@@ -4,12 +4,16 @@ import (
 	"net"
 
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/iputil"
 )
 
 // CdnCheck verifies if the given ip is part of Cdn ranges
 func (s *Scanner) CdnCheck(ip string) (bool, string, error) {
 	if s.cdn == nil {
 		return false, "", errors.New("cdn client not initialized")
+	}
+	if !iputil.IsIP(ip) {
+		return false, "", errors.Errorf("%s is not a valid ip", ip)
 	}
 	return s.cdn.Check(net.ParseIP((ip)))
 }

--- a/v2/pkg/scan/cdn.go
+++ b/v2/pkg/scan/cdn.go
@@ -1,14 +1,15 @@
 package scan
 
 import (
-	"fmt"
 	"net"
+
+	"github.com/pkg/errors"
 )
 
 // CdnCheck verifies if the given ip is part of Cdn ranges
-func (s *Scanner) CdnCheck(ip string) (bool, error) {
+func (s *Scanner) CdnCheck(ip string) (bool, string, error) {
 	if s.cdn == nil {
-		return false, fmt.Errorf("cdn client not initialized")
+		return false, "", errors.New("cdn client not initialized")
 	}
 	return s.cdn.Check(net.ParseIP((ip)))
 }

--- a/v2/pkg/scan/cdn_test.go
+++ b/v2/pkg/scan/cdn_test.go
@@ -20,7 +20,7 @@ func TestCdnCheck(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.args, func(t *testing.T) {
-			isCdn, err := s.CdnCheck(tt.args)
+			isCdn, _, err := s.CdnCheck(tt.args)
 			if tt.wantErr {
 				assert.NotNil(t, err)
 			} else {


### PR DESCRIPTION
## Description
This bumps cdncheck version in order to fix a logic bug that prevented the library to work correctly for uncached cdn cidrs.

Closes  https://github.com/projectdiscovery/cdncheck/pull/19