### PR TITLE
Adding support for passive stream scan

### DIFF
--- a/v2/cmd/functional-test/testcases.txt
+++ b/v2/cmd/functional-test/testcases.txt
@@ -5,3 +5,5 @@
 127.0.0.1 {{binary}} -c 25 -p 8000
 127.0.0.1 {{binary}} -nmap-cli 'nmap -Pn -sT' -p 8000
 127.0.0.1 {{binary}} -json
+scanme.nmap.org {{binary}} -stream -passive
+scanme.nmap.org {{binary}} -stream -passive -verify

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/projectdiscovery/dnsx v1.0.7-0.20210927160546-05f957862698
 	github.com/projectdiscovery/fdmax v0.0.3
 	github.com/projectdiscovery/fileutil v0.0.0-20220215113056-ba188a0c8abc
-	github.com/projectdiscovery/goflags v0.0.8-0.20220304165250-2530b305a4a9
+	github.com/projectdiscovery/goflags v0.0.8-0.20220411122653-4f7127a41268
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/ipranger v0.0.3-0.20210831161617-ac80efae0961
 	github.com/projectdiscovery/iputil v0.0.0-20210804143329-3a30fcde43f3
@@ -26,6 +26,8 @@ require (
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/projectdiscovery/retryablehttp-go v1.0.2
+	github.com/projectdiscovery/uncover v0.0.5
 	github.com/stretchr/testify v1.7.1
 )
 
@@ -43,7 +45,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/projectdiscovery/hmap v0.0.1 // indirect
 	github.com/projectdiscovery/retryabledns v1.0.13-0.20210927160332-db15799e2e4d // indirect
-	github.com/projectdiscovery/retryablehttp-go v1.0.2 // indirect
 	github.com/projectdiscovery/stringsutil v0.0.0-20210830151154-f567170afdd9 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/yl2chen/cidranger v1.0.2 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -34,6 +34,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -92,12 +93,14 @@ github.com/projectdiscovery/fdmax v0.0.3 h1:FM6lv9expZ/rEEBI9tkRh6tx3DV0gtpwzdc0
 github.com/projectdiscovery/fdmax v0.0.3/go.mod h1:NWRcaR7JTO7fC27H4jCl9n7Z+KIredwpgw1fV+4KrKI=
 github.com/projectdiscovery/fileutil v0.0.0-20210926202739-6050d0acf73c/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
 github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
+github.com/projectdiscovery/fileutil v0.0.0-20220214145203-ee3ead95c0b9/go.mod h1:Pm0f+MWgDFMSSI9NBedNh48LyYPs8gD3Jd8DXGmp4aQ=
 github.com/projectdiscovery/fileutil v0.0.0-20220215113056-ba188a0c8abc h1:dbDgsj26PW06L3zMo7AT08IbEqMd2u8QQ1BvlfMAY2w=
 github.com/projectdiscovery/fileutil v0.0.0-20220215113056-ba188a0c8abc/go.mod h1:Pm0f+MWgDFMSSI9NBedNh48LyYPs8gD3Jd8DXGmp4aQ=
+github.com/projectdiscovery/folderutil v0.0.0-20220212074351-38f1c1d2fdd4/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/goconfig v0.0.0-20210804090219-f893ccd0c69c/go.mod h1:mBv7GRD5n3WNbFE9blG8ynzXTM5eh9MmwaK6EOyn6Pk=
 github.com/projectdiscovery/goflags v0.0.7/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=
-github.com/projectdiscovery/goflags v0.0.8-0.20220304165250-2530b305a4a9 h1:J05G/rKDM/MSWI3FrXbnCFM7PtZeV+gRic6wzS8eLqI=
-github.com/projectdiscovery/goflags v0.0.8-0.20220304165250-2530b305a4a9/go.mod h1:37KhVbVLllyuIAgpXGqcvE/hsFEwJ+ctEUSHawjhsBY=
+github.com/projectdiscovery/goflags v0.0.8-0.20220411122653-4f7127a41268 h1:Y1lK/BRa58vy/3rsYjGD3+BIo4Z3hw+9eRqCNEOsvXM=
+github.com/projectdiscovery/goflags v0.0.8-0.20220411122653-4f7127a41268/go.mod h1:uN+pHMLsWQoiZHUg/l0tqf/VdbX3+ecKfYz/H7b/+NA=
 github.com/projectdiscovery/gologger v1.0.1/go.mod h1:Ok+axMqK53bWNwDSU1nTNwITLYMXMdZtRc8/y1c7sWE=
 github.com/projectdiscovery/gologger v1.1.4 h1:qWxGUq7ukHWT849uGPkagPKF3yBPYAsTtMKunQ8O2VI=
 github.com/projectdiscovery/gologger v1.1.4/go.mod h1:Bhb6Bdx2PV1nMaFLoXNBmHIU85iROS9y1tBuv7T5pMY=
@@ -127,6 +130,8 @@ github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe/go.mo
 github.com/projectdiscovery/stringsutil v0.0.0-20210823090203-2f5f137e8e1d/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
 github.com/projectdiscovery/stringsutil v0.0.0-20210830151154-f567170afdd9 h1:xbL1/7h0k6HE3RzPdYk9W/8pUxESrGWewTaZdIB5Pes=
 github.com/projectdiscovery/stringsutil v0.0.0-20210830151154-f567170afdd9/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
+github.com/projectdiscovery/uncover v0.0.5 h1:x6+96/5WwHhZxkWubTnUdNmoGdg/UIO2rwkL9VOxwmk=
+github.com/projectdiscovery/uncover v0.0.5/go.mod h1:LF8NewLQXa0mI5H/6ASDy9/4sxghCTAXAhGkhKG1kb8=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -188,6 +193,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210419170143-37df388d1f33/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210915083310-ed5796bab164 h1:7ZDGnxgHAMw7thfC5bEos0RDAccZKxioiWBhfIe+tvw=
 golang.org/x/sys v0.0.0-20210915083310-ed5796bab164/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/v2/pkg/runner/banners.go
+++ b/v2/pkg/runner/banners.go
@@ -30,16 +30,23 @@ func showBanner() {
 
 // showNetworkCapabilities shows the network capabilities/scan types possible with the running user
 func showNetworkCapabilities(options *Options) {
-	accessLevel := "non root"
-	scanType := "CONNECT"
-	if privileges.IsPrivileged && options.ScanType == SynScan {
+	var accessLevel, scanType string
+
+	switch {
+	case privileges.IsPrivileged && options.ScanType == SynScan:
 		accessLevel = "root"
 		if isLinux() {
 			accessLevel = "CAP_NET_RAW"
 		}
-
 		scanType = "SYN"
+	case options.Passive:
+		accessLevel = "non root"
+		scanType = "PASSIVE"
+	default:
+		accessLevel = "non root"
+		scanType = "CONNECT"
 	}
+
 	gologger.Info().Msgf("Running %s scan with %s privileges\n", scanType, accessLevel)
 }
 

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -56,6 +56,7 @@ type Options struct {
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool
+	Passive           bool
 }
 
 // OnResultCallback (hostname, ip, ports)
@@ -106,6 +107,7 @@ func ParseOptions() *Options {
 		flagSet.StringVar(&options.Proxy, "proxy", "", "socks5 proxy"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "resume scan using resume.cfg"),
 		flagSet.BoolVar(&options.Stream, "stream", false, "stream mode (disables resume, nmap, verify, retries, shuffling, etc)"),
+		flagSet.BoolVar(&options.Passive, "passive", false, "Pulls ports from shodan internetdb"),
 	)
 
 	flagSet.CreateGroup("optimization", "Optimization",

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -3,8 +3,11 @@ package runner
 import (
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,11 +18,14 @@ import (
 	"github.com/projectdiscovery/blackrock"
 	"github.com/projectdiscovery/clistats"
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/fileutil"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/ipranger"
 	"github.com/projectdiscovery/mapcidr"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 	"github.com/projectdiscovery/naabu/v2/pkg/scan"
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/projectdiscovery/uncover/uncover/agent/shodanidb"
 	"github.com/remeh/sizedwaitgroup"
 	"go.uber.org/ratelimit"
 )
@@ -132,7 +138,8 @@ func (r *Runner) RunEnumeration() error {
 
 	shouldUseRawPackets := isOSSupported() && privileges.IsPrivileged && r.options.ScanType == SynScan
 
-	if r.options.Stream {
+	switch {
+	case r.options.Stream && !r.options.Passive: // stream active
 		r.scanner.State = scan.Scan
 		for cidr := range r.streamChannel {
 			if err := r.scanner.IPRanger.Add(cidr.String()); err != nil {
@@ -157,7 +164,61 @@ func (r *Runner) RunEnumeration() error {
 		r.wgscan.Wait()
 		r.handleOutput()
 		return nil
-	} else {
+	case r.options.Stream && r.options.Passive: // stream passive
+		// create retryablehttp instance
+		httpClient := retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)
+		r.scanner.State = scan.Scan
+		for cidr := range r.streamChannel {
+			if err := r.scanner.IPRanger.Add(cidr.String()); err != nil {
+				gologger.Warning().Msgf("Couldn't track %s in scan results: %s\n", cidr, err)
+			}
+			ipStream, _ := mapcidr.IPAddressesAsStream(cidr.String())
+			for ip := range ipStream {
+				r.wgscan.Add()
+				go func(ip string) {
+					defer r.wgscan.Done()
+
+					// obtain ports from shodan idb
+					shodanURL := fmt.Sprintf(shodanidb.URL, url.QueryEscape(ip))
+					request, err := retryablehttp.NewRequest(http.MethodGet, shodanURL, nil)
+					if err != nil {
+						gologger.Warning().Msgf("Couldn't create http request for %s: %s\n", ip, err)
+						return
+					}
+					r.limiter.Take()
+					response, err := httpClient.Do(request)
+					if err != nil {
+						gologger.Warning().Msgf("Couldn't retrieve http response for %s: %s\n", ip, err)
+						return
+					}
+					if response.StatusCode != http.StatusOK {
+						gologger.Warning().Msgf("Couldn't retrieve data for %s, server replied with status code: %d\n", ip, response.StatusCode)
+						return
+					}
+
+					// unmarshal the response
+					data := &shodanidb.ShodanResponse{}
+					if err := json.NewDecoder(response.Body).Decode(data); err != nil {
+						gologger.Warning().Msgf("Couldn't unmarshal json data for %s: %s\n", ip, err)
+						return
+					}
+
+					for _, port := range data.Ports {
+						r.scanner.ScanResults.AddPort(ip, port)
+					}
+				}(ip)
+			}
+		}
+		r.wgscan.Wait()
+
+		// Validate the hosts if the user has asked for second step validation
+		if r.options.Verify {
+			r.ConnectVerification()
+		}
+
+		r.handleOutput()
+		return nil
+	default:
 		// shrinks the ips to the minimum amount of cidr
 		var targets []*net.IPNet
 		r.scanner.IPRanger.Hosts.Scan(func(k, v []byte) error {
@@ -407,7 +468,7 @@ func (r *Runner) handleOutput() {
 
 		// create path if not existing
 		outputFolder := filepath.Dir(output)
-		if _, statErr := os.Stat(outputFolder); os.IsNotExist(statErr) {
+		if fileutil.FolderExists(outputFolder) {
 			mkdirErr := os.MkdirAll(outputFolder, 0700)
 			if mkdirErr != nil {
 				gologger.Error().Msgf("Could not create output folder %s: %s\n", outputFolder, mkdirErr)

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -75,19 +75,22 @@ func (options *Options) validateOptions() error {
 		}
 	}
 
+	// stream
 	if options.Stream {
 		if options.Resume {
-			return errors.New("resume not supported in stream mode")
+			return errors.New("resume not supported in stream active mode")
 		}
 		if options.EnableProgressBar {
-			return errors.New("stats not supported in stream mode")
-		}
-		if options.Verify {
-			return errors.New("verify not supported in stream mode")
+			return errors.New("stats not supported in stream active mode")
 		}
 		if options.Nmap {
-			return errors.New("nmap not supported in stream mode")
+			return errors.New("nmap not supported in stream active mode")
 		}
+	}
+
+	// stream passive
+	if options.Verify && !options.Passive {
+		return errors.New("verify not supported in stream active mode")
 	}
 
 	return nil

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -75,6 +75,11 @@ func (options *Options) validateOptions() error {
 		}
 	}
 
+	// passive is available only with stream
+	if options.Passive && !options.Stream {
+		return errors.New("passive supported in stream mode only")
+	}
+
 	// stream
 	if options.Stream {
 		if options.Resume {

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -75,9 +75,9 @@ func (options *Options) validateOptions() error {
 		}
 	}
 
-	// passive is available only with stream
-	if options.Passive && !options.Stream {
-		return errors.New("passive supported in stream mode only")
+	// passive mode enables automatically stream
+	if options.Passive {
+		options.Stream = true
 	}
 
 	// stream


### PR DESCRIPTION
## Description
This PR adds support for **passive** stream scan using results from [shodan internetdb](https://internetdb.shodan.io/)

## Example
```console
$ echo hackerone.com | go run . -stream -passive -verify

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/ v2.0.6

                projectdiscovery.io

Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
[INF] Running PASSIVE scan with non root privileges
[INF] Found 10 ports on host hackerone.com (104.16.99.52)
hackerone.com:8080
hackerone.com:8443
hackerone.com:2082
hackerone.com:2086
hackerone.com:2083
hackerone.com:2087
hackerone.com:2096
hackerone.com:8880
hackerone.com:80
hackerone.com:443
```