### PR TITLE
added buffer reset

### DIFF
--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -493,6 +493,7 @@ func (r *Runner) handleOutput() {
 		buffer := bytes.Buffer{}
 		writer := csv.NewWriter(&buffer)
 		for _, host := range dt {
+			buffer.Reset()
 			if host == "ip" {
 				host = hostIP
 			}


### PR DESCRIPTION
This PR fixes redundancy in json output.
Test: naabu -l domains.txt -p 80,443 -ec -c 2 -silent -json