### PR TITLE
Adding temporary check and skip for IPV6 addresses

### DIFF
--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -227,8 +227,14 @@ func (r *Runner) RunEnumeration() error {
 			return nil
 		})
 		targets, _ = mapcidr.CoalesceCIDRs(targets)
+		if len(targets) == 0 {
+			return errors.New("no valid ipv4 targets were found")
+		}
 		var targetsCount, portsCount uint64
 		for _, target := range targets {
+			if target == nil {
+				continue
+			}
 			targetsCount += mapcidr.AddressCountIpnet(target)
 		}
 		portsCount = uint64(len(r.scanner.Ports))

--- a/v2/pkg/runner/targets.go
+++ b/v2/pkg/runner/targets.go
@@ -108,13 +108,15 @@ func (r *Runner) AddTarget(target string) error {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return nil
+	} else if iputil.IsIPv6(target) {
+		return fmt.Errorf("Skipping IPV6 address: %s", target)
 	} else if ipranger.IsCidr(target) {
 		if r.options.Stream {
 			r.streamChannel <- iputil.ToCidr(target)
 		} else if err := r.scanner.IPRanger.AddHostWithMetadata(target, "cidr"); err != nil { // Add cidr directly to ranger, as single ips would allocate more resources later
 			gologger.Warning().Msgf("%s\n", err)
 		}
-	} else if ipranger.IsIP(target) && !r.scanner.IPRanger.Contains(target) {
+	} else if iputil.IsIPv4(target) && !r.scanner.IPRanger.Contains(target) {
 		if r.options.Stream {
 			r.streamChannel <- iputil.ToCidr(target)
 		} else if err := r.scanner.IPRanger.AddHostWithMetadata(target, "ip"); err != nil {

--- a/v2/pkg/runner/targets_test.go
+++ b/v2/pkg/runner/targets_test.go
@@ -1,0 +1,24 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AddTarget(t *testing.T) {
+	r := &Runner{}
+
+	// IPV6 Compressed should generate a warning
+	err := r.AddTarget("::ffff:c0a8:101")
+	require.NotNil(t, err, "compressed ipv6 incorrectly parsed")
+
+	// IPV6 Expanded (Shortened)
+	err = r.AddTarget("0:0:0:0:0:ffff:c0a8:0101")
+	require.NotNil(t, err, "expanded shortened ipv6 incorrectly parsed")
+
+	// IPV6 Expanded
+	err = r.AddTarget("0000:0000:0000:0000:0000:ffff:c0a8:0101")
+	require.NotNil(t, err, "fully expanded ipv6 incorrectly parsed")
+
+}


### PR DESCRIPTION
## Description
This PR implements a skip scan check for IPV6 addresses

## Example
```console
$ cat targets.txt 
::ffff:c0a8:101
0:0:0:0:0:ffff:c0a8:0101
0000:0000:0000:0000:0000:ffff:c0a8:0101
192.168.1.1
$ cat targets.txt | go run . -v
...
[INF] Running CONNECT scan with non root privileges
[WRN] Skipping IPV6 address: ::ffff:c0a8:101
[WRN] Skipping IPV6 address: 0:0:0:0:0:ffff:c0a8:0101
[WRN] Skipping IPV6 address: 0000:0000:0000:0000:0000:ffff:c0a8:0101
[INF] Found 1 ports on host 192.168.1.1 (192.168.1.1)
192.168.1.1:1234
```

## Notes
This will be reworked as part of https://github.com/projectdiscovery/naabu/issues/103