### PR TITLE
Fixing resume issue condition

### DIFF
--- a/v2/pkg/runner/nmap.go
+++ b/v2/pkg/runner/nmap.go
@@ -116,7 +116,7 @@ func isCommandExecutable(args []string) bool {
 		// windows has a hard limit of
 		// - 2048 characters in XP
 		// - 32768 characters in Win7
-		return commandLength < 2040
+		return commandLength < 2048
 	}
 	// linux and darwin
 	return true

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -311,6 +311,10 @@ func (r *Runner) RunEnumeration() error {
 			if r.options.ResumeCfg.Seed > 0 {
 				r.options.ResumeCfg.Seed = 0
 			}
+			if r.options.ResumeCfg.Index > 0 {
+				// zero also the current index as we are restarting the scan
+				r.options.ResumeCfg.Index = 0
+			}
 			r.options.ResumeCfg.Unlock()
 		}
 

--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -47,6 +47,10 @@ func isLinux() bool {
 	return runtime.GOOS == "linux"
 }
 
+func isWindows() bool {
+	return runtime.GOOS == "windows"
+}
+
 func mapKeysToSliceInt(m map[int]struct{}) (s []int) {
 	for k := range m {
 		s = append(s, k)


### PR DESCRIPTION
## Description
This PR fixes the following issues:
- Index not zeroed per blackrock iteration (Fixes #326 )
- Adds maximum length check on Windows (Fixes #316 )

## Example
Blackrock iteration:
```console
echo 192.168.1.1 | go run .
# Hit CTRL+C to interrupt scanning
echo 192.168.1.1 | go run . -resume
# Observe that the resume point starts at the exact index if the retry iteration is > 1
```

Length Check on windows:
```console
# On a windows system use a target with a lot of open ports (eg. 1000) and observe that if the total nmap command length exceeds 2048 characters the command is only suggested
$ echo 192.168.1.1 | go run . -tp 1000 -v -nmap-cli "nmap -o nmap.txt"
...
[INF] Running CONNECT scan with non root privileges
[INF] Found 1000 ports on host 192.168.1.1 (192.168.1.1)
192.168.1.1:443
...
[INF] Suggested nmap command: nmap -o nmap.txt -p 1,2,3,4,5,6,...,1000 192.168.1.1
```