### PR TITLE
Added nmap support to passive scan mode

### DIFF
--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -217,7 +217,9 @@ func (r *Runner) RunEnumeration() error {
 		}
 
 		r.handleOutput()
-		return nil
+
+		// handle nmap
+		return r.handleNmap()
 	default:
 		// shrinks the ips to the minimum amount of cidr
 		var targets []*net.IPNet


### PR DESCRIPTION
Closes #306 

Example run - 

```console
echo hackerone.com | ./naabu  -nmap-cli 'nmap -sT' -passive 


                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/ v2.0.7

                projectdiscovery.io

Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
[INF] Running PASSIVE scan with non root privileges
[INF] Found 10 ports on host hackerone.com (104.16.100.52)
hackerone.com:8443
hackerone.com:80
hackerone.com:443
hackerone.com:2052
hackerone.com:2086
hackerone.com:2087
hackerone.com:2095
hackerone.com:2082
hackerone.com:2083
hackerone.com:8080
[INF] Running nmap command: nmap -sT -p 80,2086,8080,2087,2095,2082,2083,8443,443,2052 104.16.100.52
```