### PR TITLE
Adding source port support via source-ip

### DIFF
--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -40,6 +40,7 @@ type Options struct {
 	ExcludeIpsFile    string                        // File containing Ips or cidr to exclude from the scan
 	TopPorts          string                        // Tops ports to scan
 	SourceIP          string                        // SourceIP to use in TCP packets
+	SourcePort        string                        // Source Port to use in packets
 	Interface         string                        // Interface to use for TCP packets
 	ConfigFile        string                        // Config file contains a scan configuration
 	NmapCLI           string                        // Nmap command (has priority over config file)
@@ -102,7 +103,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ScanAllIPS, "sa", "scan-all-ips", false, "scan all the IP's associated with DNS record"),
 		flagSet.BoolVarP(&options.IncludeIPv6, "ipv6", "resolve-ipv6", false, "DNS names are also resolved to IPv6"),
 		flagSet.StringVarP(&options.ScanType, "s", "scan-type", SynScan, "type of port scan (SYN/CONNECT)"),
-		flagSet.StringVar(&options.SourceIP, "source-ip", "", "source ip"),
+		flagSet.StringVar(&options.SourceIP, "source-ip", "", "source ip and port (x.x.x.x:yyy)"),
 		flagSet.BoolVarP(&options.InterfacesList, "il", "interface-list", false, "list available interfaces and public ip"),
 		flagSet.StringVarP(&options.Interface, "i", "interface", "", "network Interface to use for port scan"),
 		flagSet.BoolVar(&options.Nmap, "nmap", false, "invoke nmap scan on targets (nmap must be installed) - Deprecated"),

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -123,6 +124,12 @@ func (r *Runner) RunEnumeration() error {
 		}
 		if r.options.Interface != "" {
 			err := r.SetInterface(r.options.Interface)
+			if err != nil {
+				return err
+			}
+		}
+		if r.options.SourcePort != "" {
+			err := r.SetSourcePort(r.options.SourcePort)
 			if err != nil {
 				return err
 			}
@@ -485,6 +492,22 @@ func (r *Runner) SetSourceIP(sourceIP string) error {
 	default:
 		return errors.New("invalid ip type")
 	}
+
+	return nil
+}
+
+func (r *Runner) SetSourcePort(sourcePort string) error {
+	isValidPort := iputil.IsPort(sourcePort)
+	if !isValidPort {
+		return errors.New("invalid source port")
+	}
+
+	port, err := strconv.Atoi(sourcePort)
+	if err != nil {
+		return err
+	}
+
+	r.scanner.SourcePort = port
 
 	return nil
 }

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/fileutil"
+	"github.com/projectdiscovery/iputil"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 
 	"github.com/projectdiscovery/gologger"
@@ -96,6 +97,18 @@ func (options *Options) validateOptions() error {
 	// stream passive
 	if options.Verify && !options.Passive {
 		return errors.New("verify not supported in stream active mode")
+	}
+
+	// Parse and validate source ip and source port
+	// checks if source ip is ip only
+	isOnlyIP := iputil.IsIP(options.SourceIP)
+	if options.SourceIP != "" && !isOnlyIP {
+		ip, port, err := net.SplitHostPort(options.SourceIP)
+		if err != nil {
+			return err
+		}
+		options.SourceIP = ip
+		options.SourcePort = port
 	}
 
 	return nil

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -61,7 +61,7 @@ type Scanner struct {
 	icmpPacketListener net.PacketConn
 	retries            int
 	rate               int
-	listenPort         int
+	SourcePort         int
 	timeout            time.Duration
 	proxyDialer        proxy.Dialer
 
@@ -517,7 +517,7 @@ func (s *Scanner) sendAsync4(ip string, port int, pkgFlag PkgFlag) {
 	}
 
 	tcp := layers.TCP{
-		SrcPort: layers.TCPPort(s.listenPort),
+		SrcPort: layers.TCPPort(s.SourcePort),
 		DstPort: layers.TCPPort(port),
 		Window:  1024,
 		Seq:     s.tcpsequencer.Next(),
@@ -575,7 +575,7 @@ func (s *Scanner) sendAsync6(ip string, port int, pkgFlag PkgFlag) {
 	}
 
 	tcp := layers.TCP{
-		SrcPort: layers.TCPPort(s.listenPort),
+		SrcPort: layers.TCPPort(s.SourcePort),
 		DstPort: layers.TCPPort(port),
 		Window:  1024,
 		Seq:     s.tcpsequencer.Next(),

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -28,20 +28,26 @@ type Handlers struct {
 	Inactive []*pcap.InactiveHandle
 }
 
-func NewScannerUnix(scanner *Scanner) error {
-	rawPort, err := freeport.GetFreePort()
-	if err != nil {
-		return err
-	}
-	scanner.listenPort = rawPort
+func getFreePort() (int, error) {
+	return freeport.GetFreePort()
+}
 
-	tcpConn4, err := net.ListenIP("ip4:tcp", &net.IPAddr{IP: net.ParseIP(fmt.Sprintf("0.0.0.0:%d", rawPort))})
+func NewScannerUnix(scanner *Scanner) error {
+	if scanner.SourcePort <= 0 {
+		rawport, err := getFreePort()
+		if err != nil {
+			return err
+		}
+		scanner.SourcePort = rawport
+	}
+
+	tcpConn4, err := net.ListenIP("ip4:tcp", &net.IPAddr{IP: net.ParseIP(fmt.Sprintf("0.0.0.0:%d", scanner.SourcePort))})
 	if err != nil {
 		return err
 	}
 	scanner.tcpPacketlistener4 = tcpConn4
 
-	tcpConn6, err := net.ListenIP("ip6:tcp", &net.IPAddr{IP: net.ParseIP(fmt.Sprintf(":::%d", rawPort))})
+	tcpConn6, err := net.ListenIP("ip6:tcp", &net.IPAddr{IP: net.ParseIP(fmt.Sprintf(":::%d", scanner.SourcePort))})
 	if err != nil {
 		return err
 	}
@@ -91,7 +97,7 @@ func SetupHandlerUnix(s *Scanner, interfaceName string) error {
 
 	// Strict BPF filter
 	// + Destination port equals to sender socket source port
-	err = handle.SetBPFFilter(fmt.Sprintf("tcp and dst port %d", s.listenPort))
+	err = handle.SetBPFFilter(fmt.Sprintf("tcp and dst port %d", s.SourcePort))
 	if err != nil {
 		s.CleanupHandlers()
 		return err
@@ -162,7 +168,7 @@ func TCPReadWorkerPCAPUnix(s *Scanner) {
 							}
 
 							// We consider only incoming packets
-							if tcp.DstPort != layers.TCPPort(s.listenPort) {
+							if tcp.DstPort != layers.TCPPort(s.SourcePort) {
 								continue
 							} else if tcp.SYN && tcp.ACK {
 								s.tcpChan <- &PkgResult{ip: ip, port: int(tcp.SrcPort)}


### PR DESCRIPTION
## Description
This PR adds support for source port via the existing `source-ip` parameter

## Example
```console
$ sudo go run . -source 192.168.1.2:15000
```