### PR TITLE
Add health-check

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/projectdiscovery/clistats v0.0.8
 	github.com/projectdiscovery/dnsx v1.0.7-0.20210927160546-05f957862698
 	github.com/projectdiscovery/fdmax v0.0.3
-	github.com/projectdiscovery/fileutil v0.0.0-20220506114156-c4ab20801483
+	github.com/projectdiscovery/fileutil v0.0.0-20220609085820-4e9293717b1e
 	github.com/projectdiscovery/goflags v0.0.8-0.20220411122653-4f7127a41268
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/ipranger v0.0.3-0.20220527173555-3bd361b7ad93
@@ -27,6 +27,7 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/miekg/dns v1.1.49
 	github.com/pkg/errors v0.9.1
+	github.com/projectdiscovery/folderutil v0.0.0-20220212074351-38f1c1d2fdd4
 	github.com/projectdiscovery/retryablehttp-go v1.0.2
 	github.com/projectdiscovery/uncover v0.0.5
 	github.com/stretchr/testify v1.7.2
@@ -39,7 +40,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/karrick/godirwalk v1.16.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/projectdiscovery/dnsx v1.0.7-0.20210927160546-05f957862698
 	github.com/projectdiscovery/fdmax v0.0.3
 	github.com/projectdiscovery/fileutil v0.0.0-20220609085820-4e9293717b1e
-	github.com/projectdiscovery/goflags v0.0.8-0.20220411122653-4f7127a41268
+	github.com/projectdiscovery/goflags v0.0.8-0.20220610065908-6a16a6bc848c
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/ipranger v0.0.3-0.20220527173555-3bd361b7ad93
 	github.com/projectdiscovery/iputil v0.0.0-20220523155204-a04b03c5a533

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -41,7 +41,6 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -95,8 +94,10 @@ github.com/projectdiscovery/fdmax v0.0.3/go.mod h1:NWRcaR7JTO7fC27H4jCl9n7Z+KIre
 github.com/projectdiscovery/fileutil v0.0.0-20210926202739-6050d0acf73c/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
 github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
 github.com/projectdiscovery/fileutil v0.0.0-20220214145203-ee3ead95c0b9/go.mod h1:Pm0f+MWgDFMSSI9NBedNh48LyYPs8gD3Jd8DXGmp4aQ=
-github.com/projectdiscovery/fileutil v0.0.0-20220506114156-c4ab20801483 h1:0as/e36wk1cnnqK3FojbdOx7fsm9yH6Gy5q9v6Sg/88=
 github.com/projectdiscovery/fileutil v0.0.0-20220506114156-c4ab20801483/go.mod h1:wjS/oBWbzlayJ/aTK0KW0oOHGO03G8oEYzuN6stI8Ho=
+github.com/projectdiscovery/fileutil v0.0.0-20220609085820-4e9293717b1e h1:Xe/e4sQv08fCh+CuKCbPsAVlG0Mf1bZ9ZGR4BEHic18=
+github.com/projectdiscovery/fileutil v0.0.0-20220609085820-4e9293717b1e/go.mod h1:qcx3tdBzVDlUvr5nMKrgzNkCNQpCV7kGbYlXBAtXz0o=
+github.com/projectdiscovery/folderutil v0.0.0-20220212074351-38f1c1d2fdd4 h1:rPA+enZtrHCBO0XVGsvoGzBKv9TlqZyqZguh1AOT+gs=
 github.com/projectdiscovery/folderutil v0.0.0-20220212074351-38f1c1d2fdd4/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/goconfig v0.0.0-20210804090219-f893ccd0c69c/go.mod h1:mBv7GRD5n3WNbFE9blG8ynzXTM5eh9MmwaK6EOyn6Pk=
 github.com/projectdiscovery/goflags v0.0.7/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -103,6 +103,8 @@ github.com/projectdiscovery/goconfig v0.0.0-20210804090219-f893ccd0c69c/go.mod h
 github.com/projectdiscovery/goflags v0.0.7/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=
 github.com/projectdiscovery/goflags v0.0.8-0.20220411122653-4f7127a41268 h1:Y1lK/BRa58vy/3rsYjGD3+BIo4Z3hw+9eRqCNEOsvXM=
 github.com/projectdiscovery/goflags v0.0.8-0.20220411122653-4f7127a41268/go.mod h1:uN+pHMLsWQoiZHUg/l0tqf/VdbX3+ecKfYz/H7b/+NA=
+github.com/projectdiscovery/goflags v0.0.8-0.20220610065908-6a16a6bc848c h1:GZUkYnfOzvANILYlsqbdzT6SIGH0y0k3OG+mxmaeByg=
+github.com/projectdiscovery/goflags v0.0.8-0.20220610065908-6a16a6bc848c/go.mod h1:Np0EwqmopHDDb1cY4/NEBaC4fornMIWc6dr5yL91kzM=
 github.com/projectdiscovery/gologger v1.0.1/go.mod h1:Ok+axMqK53bWNwDSU1nTNwITLYMXMdZtRc8/y1c7sWE=
 github.com/projectdiscovery/gologger v1.1.4 h1:qWxGUq7ukHWT849uGPkagPKF3yBPYAsTtMKunQ8O2VI=
 github.com/projectdiscovery/gologger v1.1.4/go.mod h1:Bhb6Bdx2PV1nMaFLoXNBmHIU85iROS9y1tBuv7T5pMY=

--- a/v2/pkg/runner/healthcheck.go
+++ b/v2/pkg/runner/healthcheck.go
@@ -3,22 +3,23 @@ package runner
 import (
 	"fmt"
 	"net"
-	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/projectdiscovery/fileutil"
-	"github.com/projectdiscovery/folderutil"
+	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 )
 
 func DoHealthCheck(options *Options) string {
 	// RW permissions on config file
-	cfgFilePath := filepath.Join(folderutil.HomeDirOrDefault("$home"), ".config/naabu/config.yaml")
+	cfgFilePath, _ := goflags.GetConfigFilePath()
 	var test strings.Builder
 	test.WriteString(fmt.Sprintf("Version: %s\n", Version))
 	test.WriteString(fmt.Sprintf("Operative System: %s\n", runtime.GOOS))
 	test.WriteString(fmt.Sprintf("Architecture: %s\n", runtime.GOARCH))
+	test.WriteString(fmt.Sprintf("Go Version: %s\n", runtime.Version()))
+	test.WriteString(fmt.Sprintf("Compiler: %s\n", runtime.Compiler))
 
 	var testResult string
 	if privileges.IsPrivileged {

--- a/v2/pkg/runner/healthcheck.go
+++ b/v2/pkg/runner/healthcheck.go
@@ -37,7 +37,7 @@ func DoHealthCheck(options *Options) string {
 	if err != nil {
 		testResult += fmt.Sprintf(" (%s)", err)
 	}
-	test.WriteString(fmt.Sprintf("config file \"%s\" Read => %s\n", cfgFilePath, testResult))
+	test.WriteString(fmt.Sprintf("Config file \"%s\" Read => %s\n", cfgFilePath, testResult))
 	ok, err = fileutil.IsWriteable(cfgFilePath)
 	if ok {
 		testResult = "Ok"
@@ -47,7 +47,7 @@ func DoHealthCheck(options *Options) string {
 	if err != nil {
 		testResult += fmt.Sprintf(" (%s)", err)
 	}
-	test.WriteString(fmt.Sprintf("config file \"%s\" Write => %s\n", cfgFilePath, testResult))
+	test.WriteString(fmt.Sprintf("Config file \"%s\" Write => %s\n", cfgFilePath, testResult))
 	c4, err := net.Dial("tcp4", "scanme.sh:80")
 	if err == nil && c4 != nil {
 		c4.Close()

--- a/v2/pkg/runner/healthcheck.go
+++ b/v2/pkg/runner/healthcheck.go
@@ -1,0 +1,71 @@
+package runner
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/projectdiscovery/fileutil"
+	"github.com/projectdiscovery/folderutil"
+	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
+)
+
+func DoHealthCheck(options *Options) string {
+	// RW permissions on config file
+	cfgFilePath := filepath.Join(folderutil.HomeDirOrDefault("$home"), ".config/naabu/config.yaml")
+	var test strings.Builder
+	test.WriteString(fmt.Sprintf("Version: %s\n", Version))
+	test.WriteString(fmt.Sprintf("Operative System: %s\n", runtime.GOOS))
+	test.WriteString(fmt.Sprintf("Architecture: %s\n", runtime.GOARCH))
+
+	var testResult string
+	if privileges.IsPrivileged {
+		testResult = "Ok"
+	} else {
+		testResult = "Ko"
+	}
+	test.WriteString(fmt.Sprintf("Privileged/NET_RAW: %s\n", testResult))
+
+	ok, err := fileutil.IsReadable(cfgFilePath)
+	if ok {
+		testResult = "Ok"
+	} else {
+		testResult = "Ko"
+	}
+	if err != nil {
+		testResult += fmt.Sprintf(" (%s)", err)
+	}
+	test.WriteString(fmt.Sprintf("config file \"%s\" Read => %s\n", cfgFilePath, testResult))
+	ok, err = fileutil.IsWriteable(cfgFilePath)
+	if ok {
+		testResult = "Ok"
+	} else {
+		testResult = "Ko"
+	}
+	if err != nil {
+		testResult += fmt.Sprintf(" (%s)", err)
+	}
+	test.WriteString(fmt.Sprintf("config file \"%s\" Write => %s\n", cfgFilePath, testResult))
+	c4, err := net.Dial("tcp4", "scanme.sh:80")
+	if err == nil && c4 != nil {
+		c4.Close()
+	}
+	testResult = "Ok"
+	if err != nil {
+		testResult = fmt.Sprintf("Ko (%s)", err)
+	}
+	test.WriteString(fmt.Sprintf("IPv4 connectivity to scanme.sh:80 => %s\n", testResult))
+	c6, err := net.Dial("tcp6", "scanme.sh:80")
+	if err == nil && c6 != nil {
+		c6.Close()
+	}
+	testResult = "Ok"
+	if err != nil {
+		testResult = fmt.Sprintf("Ko (%s)", err)
+	}
+	test.WriteString(fmt.Sprintf("IPv6 connectivity to scanme.sh:80 => %s\n", testResult))
+
+	return test.String()
+}

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -124,7 +124,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("debug", "Debug",
-		flagSet.BoolVar(&options.HealthCheck, "health-check", false, "health check"),
+		flagSet.BoolVarP(&options.HealthCheck, "hc", "health-check", false, "run diagnostic check up"),
 		flagSet.BoolVar(&options.Debug, "debug", false, "display debugging information"),
 		flagSet.BoolVarP(&options.Verbose, "v", "verbose", false, "display verbose output"),
 		flagSet.BoolVarP(&options.NoColor, "nc", "no-color", false, "disable colors in CLI output"),

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	Stream            bool
 	Passive           bool
 	OutputCDN         bool // display cdn in use
+	HealthCheck       bool
 }
 
 // OnResultCallback (hostname, ip, ports)
@@ -123,6 +124,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("debug", "Debug",
+		flagSet.BoolVar(&options.HealthCheck, "health-check", false, "health check"),
 		flagSet.BoolVar(&options.Debug, "debug", false, "display debugging information"),
 		flagSet.BoolVarP(&options.Verbose, "v", "verbose", false, "display verbose output"),
 		flagSet.BoolVarP(&options.NoColor, "nc", "no-color", false, "disable colors in CLI output"),
@@ -133,6 +135,11 @@ func ParseOptions() *Options {
 	)
 
 	_ = flagSet.Parse()
+
+	if options.HealthCheck {
+		gologger.Print().Msgf("%s\n", DoHealthCheck(options))
+		os.Exit(0)
+	}
 
 	// Check if stdin pipe was given
 	options.Stdin = fileutil.HasStdin()


### PR DESCRIPTION
## Description
This PR implements health-check functionality

## Example
```console
$ go run . -health-check
Version: 2.0.7
Operative System: darwin
Architecture: arm64
Go Version: go1.18.2
Compiler: gc
Privileged/NET_RAW: Ok
Config file "/Users/user/.config/naabu/config.yaml" Read => Ok
Config file "/Users/user/.config/naabu/config.yaml" Write => Ok
IPv4 connectivity to scanme.sh:80 => Ko (dial tcp4 128.199.158.128:80: connect: connection refused)
IPv6 connectivity to scanme.sh:80 => Ko (dial tcp6 [2400:6180:0:d0::91:1001]:80: connect: connection refused)
```

Depends on https://github.com/projectdiscovery/goflags/pull/55