### PR TITLE
End-to-end implementation of socks5 proxy authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ CONFIGURATION:
    -nmap                  invoke nmap scan on targets (nmap must be installed) - Deprecated
    -nmap-cli string       nmap command to run on found results (-nmap-cli 'nmap -sV')
    -r string              list of custom resolver dns resolution (comma separated or from file)
-   -proxy string          socks5 proxy
+   -proxy string          socks5 proxy (ip[:port] / fqdn[:port]
+   -proxy-auth string     socks5 proxy authentication (username:password)
    -resume                resume scan using resume.cfg
    -stream                stream mode (disables resume, nmap, verify, retries, shuffling, etc)
    -passive               display passive open ports using shodan internetdb api

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -50,6 +50,7 @@ type Options struct {
 	IncludeIPv6       bool                          // Include resolved IP6 for dns records
 	ScanType          string                        // Scan Type
 	Proxy             string                        // Socks5 proxy
+	ProxyAuth         string                        // Socks5 proxy authentication (username:password)
 	Resolvers         string                        // Resolvers (comma separated or file)
 	baseResolvers     []string
 	OnResult          OnResultCallback // OnResult callback
@@ -110,7 +111,8 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.Nmap, "nmap", false, "invoke nmap scan on targets (nmap must be installed) - Deprecated"),
 		flagSet.StringVar(&options.NmapCLI, "nmap-cli", "", "nmap command to run on found results (example: -nmap-cli 'nmap -sV')"),
 		flagSet.StringVar(&options.Resolvers, "r", "", "list of custom resolver dns resolution (comma separated or from file)"),
-		flagSet.StringVar(&options.Proxy, "proxy", "", "socks5 proxy"),
+		flagSet.StringVar(&options.Proxy, "proxy", "", "socks5 proxy (ip[:port] / fqdn[:port]"),
+		flagSet.StringVar(&options.ProxyAuth, "proxy-auth", "", "socks5 proxy authentication (username:password)"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "resume scan using resume.cfg"),
 		flagSet.BoolVar(&options.Stream, "stream", false, "stream mode (disables resume, nmap, verify, retries, shuffling, etc)"),
 		flagSet.BoolVar(&options.Passive, "passive", false, "display passive open ports using shodan internetdb api"),

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -68,6 +68,7 @@ func NewRunner(options *Options) (*Runner, error) {
 		OutputCdn:   options.OutputCDN,
 		ExcludedIps: excludedIps,
 		Proxy:       options.Proxy,
+		ProxyAuth:   options.ProxyAuth,
 		Stream:      options.Stream,
 	})
 	if err != nil {

--- a/v2/pkg/scan/option.go
+++ b/v2/pkg/scan/option.go
@@ -14,5 +14,6 @@ type Options struct {
 	OutputCdn   bool
 	ExcludedIps []string
 	Proxy       string
+	ProxyAuth   string
 	Stream      bool
 }

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -151,8 +151,15 @@ func NewScanner(options *Options) (*Scanner, error) {
 		}
 	}
 
+	var auth *proxy.Auth = nil
+
+	if (options.ProxyAuth != "") && (strings.Contains(options.ProxyAuth, ":")) {
+		credentials := strings.Split(options.ProxyAuth, ":")
+		auth = &proxy.Auth{User: credentials[0], Password: credentials[1]}
+	}
+
 	if options.Proxy != "" {
-		proxyDialer, err := proxy.SOCKS5("tcp", options.Proxy, nil, &net.Dialer{Timeout: options.Timeout})
+		proxyDialer, err := proxy.SOCKS5("tcp", options.Proxy, auth, &net.Dialer{Timeout: options.Timeout})
 		if err != nil {
 			return nil, err
 		}

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -153,9 +153,14 @@ func NewScanner(options *Options) (*Scanner, error) {
 
 	var auth *proxy.Auth = nil
 
-	if (options.ProxyAuth != "") && (strings.Contains(options.ProxyAuth, ":")) {
-		credentials := strings.Split(options.ProxyAuth, ":")
-		auth = &proxy.Auth{User: credentials[0], Password: credentials[1]}
+	if options.ProxyAuth != "" && strings.Contains(options.ProxyAuth, ":") {
+		credentials := strings.SplitN(options.ProxyAuth, ":", 2)
+		var user, password string
+		user = credentials[0]
+		if len(credentials) == 2 {
+			password = credentials[1]
+		}
+		auth = &proxy.Auth{User: user, Password: password}
 	}
 
 	if options.Proxy != "" {


### PR DESCRIPTION
### Description

This PR implements support of SOCKS5 proxy authentication. 

Added `proxy-auth` option allows the user to supply a set of credentials (username:password) that may be used to authenticate against the socks5 proxy. 

In case the `proxy-auth` option is not set, the code will interact with the proxy without authentication, exactly how it worked before. 