### PR TITLE
Fix error when config dir does not exists

### DIFF
--- a/v2/pkg/runner/resume.go
+++ b/v2/pkg/runner/resume.go
@@ -14,12 +14,16 @@ import (
 // Default resume file
 const defaultResumeFileName = "resume.cfg"
 
-func DefaultResumeFilePath() string {
+func DefaultResumeFolderPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return defaultResumeFileName
 	}
 	return filepath.Join(home, ".config", "naabu", defaultResumeFileName)
+}
+
+func DefaultResumeFilePath() string {
+	return filepath.Join(DefaultResumeFolderPath(), defaultResumeFileName)
 }
 
 // ResumeCfg contains the scan progression
@@ -38,6 +42,10 @@ func NewResumeCfg() *ResumeCfg {
 // SaveResumeConfig to file
 func (resumeCfg *ResumeCfg) SaveResumeConfig() error {
 	data, _ := json.MarshalIndent(resumeCfg, "", "\t")
+ 	err := os.MkdirAll(DefaultResumeFolderPath(), os.ModePerm)
+ 	if err != nil{
+ 	 	return err
+	}
 	return os.WriteFile(DefaultResumeFilePath(), data, os.ModePerm)
 }
 

--- a/v2/pkg/runner/resume.go
+++ b/v2/pkg/runner/resume.go
@@ -14,14 +14,16 @@ import (
 // Default resume file
 const defaultResumeFileName = "resume.cfg"
 
+// DefaultResumeFolderPath returns the default resume folder path
 func DefaultResumeFolderPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return defaultResumeFileName
 	}
-	return filepath.Join(home, ".config", "naabu", defaultResumeFileName)
+	return filepath.Join(home, ".config", "naabu")
 }
 
+// DefaultResumeFilePath returns the default resume file full path
 func DefaultResumeFilePath() string {
 	return filepath.Join(DefaultResumeFolderPath(), defaultResumeFileName)
 }
@@ -41,12 +43,16 @@ func NewResumeCfg() *ResumeCfg {
 
 // SaveResumeConfig to file
 func (resumeCfg *ResumeCfg) SaveResumeConfig() error {
-	data, _ := json.MarshalIndent(resumeCfg, "", "\t")
- 	err := os.MkdirAll(DefaultResumeFolderPath(), os.ModePerm)
- 	if err != nil{
- 	 	return err
+	data, err := json.MarshalIndent(resumeCfg, "", "\t")
+	if err != nil {
+		return err
 	}
-	return os.WriteFile(DefaultResumeFilePath(), data, os.ModePerm)
+	resumeFolderPath := DefaultResumeFolderPath()
+	if !fileutil.FolderExists(resumeFolderPath) {
+		_ = os.MkdirAll(DefaultResumeFolderPath(), 0644)
+	}
+
+	return os.WriteFile(DefaultResumeFilePath(), data, 0644)
 }
 
 // ConfigureResume read the resume config file


### PR DESCRIPTION
On Linux when the folder `/$HOME/.config/naabu/` does not exist and the user press CTRL+C `naabu` is unable to write the resume file and exit with an error.

```
$ sudo ./tools/naabu_2.0.7_linux_amd64 -l targets.txt  
[INF] Running SYN scan with CAP_NET_RAW privileges
^C[INF] CTRL+C pressed: Exiting
[INF] Creating resume file: /root/.config/naabu/resume.cfg
[ERR] Couldn't create resume file: open /root/.config/naabu/resume.cfg: no such file or directory
```

This PR fix this issue by:
* Spliting `DefaultResumeFilePath` function with a new on that return the folder only
* Creating the folder if it does not exist already

Not sure on the effect of these modifications for other operating systems.