### PR TITLE
Replace unprivileged udp with privileged icmp

### DIFF
--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -69,7 +69,7 @@ func NewScannerUnix(scanner *Scanner) error {
 	}
 	scanner.icmpPacketListener4 = icmpConn4
 
-	icmpConn6, err := icmp.ListenPacket("udp6", "::")
+	icmpConn6, err := icmp.ListenPacket("ip6:icmp", "::")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
This PR replaceds `udp6` with privileged `ip6:icmp` which doesn't require custom ICMP configuration within linux systems

## Notes
```console
$ sysctl net.ipv4.ping_group_range
net.ipv4.ping_group_range = 1   0
$ sudo go run . -host 192.168.1.1
...
192.168.1.1:80
...
```
                           