### PR TITLE
Removing unstable architectures

### DIFF
--- a/v2/.goreleaser/windows.yml
+++ b/v2/.goreleaser/windows.yml
@@ -9,18 +9,13 @@ builds:
     ldflags:
       - -s -w
     binary: naabu
-    env:
-      - CGO_ENABLED=1
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=x86_64-w64-mingw32-g++
+    # env:
+    # - CGO_ENABLED=1 # necessary only with winpcap
     main: ./cmd/naabu/main.go
     goos:
       - windows
     goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
+      - amd64 # arm+arm64 => incompatible with https://github.com/akrylysov/pogreb, 386 => problems with build GH build toolchain
 
 archives:
 - format: zip


### PR DESCRIPTION
## Description
This PR removes unstable architectures from the goreleaser workflow for windows. In detail:
- **arm+arm64** are incompatible with `https://github.com/akrylysov/pogreb` as mmap size is not defined
- **386** doesn't seem sufficiently supported/stable with the MinGW build toolchain