### PR TITLE
Fixing wrong boolean check on verify condition

### DIFF
--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -96,8 +96,10 @@ func (options *Options) validateOptions() error {
 	}
 
 	// stream passive
-	if options.Verify && !options.Passive {
-		return errors.New("verify not supported in stream active mode")
+	if options.Verify {
+		if options.Stream && !options.Passive {
+			return errors.New("verify not supported in stream active mode")
+		}
 	}
 
 	// Parse and validate source ip and source port

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -96,10 +96,8 @@ func (options *Options) validateOptions() error {
 	}
 
 	// stream passive
-	if options.Verify {
-		if options.Stream && !options.Passive {
-			return errors.New("verify not supported in stream active mode")
-		}
+	if options.Verify && options.Stream && !options.Passive {
+		return errors.New("verify not supported in stream active mode")
 	}
 
 	// Parse and validate source ip and source port


### PR DESCRIPTION
## Description
This PR fixes a wrong check with `-verify` flag what is incorrectly flagged as not supported in active scan mode