### PR TITLE
Using osutil + improving error message with -sn on windows

### DIFF
--- a/v2/pkg/runner/banners.go
+++ b/v2/pkg/runner/banners.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 	"github.com/projectdiscovery/naabu/v2/pkg/scan"
+	osutil "github.com/projectdiscovery/utils/os"
 )
 
 const banner = `
@@ -32,7 +33,7 @@ func showNetworkCapabilities(options *Options) {
 	switch {
 	case privileges.IsPrivileged && options.ScanType == SynScan:
 		accessLevel = "root"
-		if isLinux() {
+		if osutil.IsLinux() {
 			accessLevel = "CAP_NET_RAW"
 		}
 		scanType = "SYN"

--- a/v2/pkg/runner/nmap.go
+++ b/v2/pkg/runner/nmap.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/naabu/v2/pkg/result"
+	osutil "github.com/projectdiscovery/utils/os"
 )
 
 func (r *Runner) handleNmap() error {
@@ -96,7 +97,7 @@ func (r *Runner) handleNmap() error {
 				}
 
 				// if it's windows search for the executable
-				if isWindows() {
+				if osutil.IsWindows() {
 					nmapCommand = "nmap.exe"
 				}
 
@@ -120,7 +121,7 @@ func (r *Runner) handleNmap() error {
 
 func isCommandExecutable(args []string) bool {
 	commandLength := calculateCmdLength(args)
-	if isWindows() {
+	if osutil.IsWindows() {
 		// windows has a hard limit of
 		// - 2048 characters in XP
 		// - 32768 characters in Win7

--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -2,10 +2,10 @@ package runner
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/projectdiscovery/gologger"
 	iputil "github.com/projectdiscovery/utils/ip"
+	osutil "github.com/projectdiscovery/utils/os"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 )
 
@@ -40,17 +40,5 @@ func (r *Runner) host2ips(target string) (targetIPsV4 []string, targetIPsV6 []st
 }
 
 func isOSSupported() bool {
-	return isLinux() || isOSX()
-}
-
-func isOSX() bool {
-	return runtime.GOOS == "darwin"
-}
-
-func isLinux() bool {
-	return runtime.GOOS == "linux"
-}
-
-func isWindows() bool {
-	return runtime.GOOS == "windows"
+	return osutil.IsLinux() || osutil.IsOSX()
 }

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 	fileutil "github.com/projectdiscovery/utils/file"
 	iputil "github.com/projectdiscovery/utils/ip"
+	osutil "github.com/projectdiscovery/utils/os"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 
 	"github.com/projectdiscovery/gologger"
@@ -122,6 +123,9 @@ func (options *Options) validateOptions() error {
 
 	// Host Discovery mode needs provileged access
 	if options.OnlyHostDiscovery && !privileges.IsPrivileged {
+		if osutil.IsWindows() {
+			return errors.New("host discovery not (yet) supported on windows")
+		}
 		return errors.New("sudo access required to perform host discovery")
 	}
 


### PR DESCRIPTION
## Description
`-sn` is not yet supported on windows (even though theoretically it is, since it already supports winpcap, which needs to be preinstalled on the machine, but it's not yet tested and activated). Hence this PR makes the error message more explicit