### PR TITLE
Add timeout to scan through SOCKS proxy

### DIFF
--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -558,7 +559,9 @@ func (s *Scanner) ConnectPort(host string, p *port.Port, timeout time.Duration) 
 		conn net.Conn
 	)
 	if s.proxyDialer != nil {
-		conn, err = s.proxyDialer.Dial(p.Protocol.String(), hostport)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		conn, err = s.proxyDialer.(proxy.ContextDialer).DialContext(ctx, p.Protocol.String(), hostport)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Currently when scanning through a SOCKS proxy, only the timeout between the scanner and proxy is configurable, whereas the remote connection between proxy and target is not. This is undesirable as scans can take a long time if the remote connection takes a long time.

This change adds a context to the proxyDialer, which sets this timeout for the connection as per the main configuration option.

Alternative:
We could potentially expose this timeout as a separate CLI argument, but it was not needed for my use case.