### PR TITLE
Fixing exclude port/ip

### DIFF
--- a/v2/pkg/runner/ports.go
+++ b/v2/pkg/runner/ports.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -87,7 +88,9 @@ func ParsePorts(options *Options) ([]*port.Port, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not read ports: %s", err)
 		}
+		log.Println(ports)
 		portsCLIMap, err = excludePorts(options, ports)
+		log.Fatal(portsCLIMap)
 		if err != nil {
 			return nil, fmt.Errorf("could not read ports: %s", err)
 		}
@@ -135,10 +138,8 @@ func excludePorts(options *Options, ports []*port.Port) ([]*port.Port, error) {
 			}
 		}
 		if !found {
-			continue
+			filteredPorts = append(filteredPorts, port)
 		}
-
-		filteredPorts = append(filteredPorts, port)
 	}
 	return filteredPorts, nil
 }

--- a/v2/pkg/runner/ports.go
+++ b/v2/pkg/runner/ports.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -88,9 +87,7 @@ func ParsePorts(options *Options) ([]*port.Port, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not read ports: %s", err)
 		}
-		log.Println(ports)
 		portsCLIMap, err = excludePorts(options, ports)
-		log.Fatal(portsCLIMap)
 		if err != nil {
 			return nil, fmt.Errorf("could not read ports: %s", err)
 		}

--- a/v2/pkg/runner/ports_test.go
+++ b/v2/pkg/runner/ports_test.go
@@ -56,7 +56,7 @@ func TestExcludePorts(t *testing.T) {
 	filteredPorts, err = excludePorts(&options, ports)
 	assert.Nil(t, err)
 	expectedPorts := []*port.Port{
-		{Port: 1, Protocol: protocol.TCP},
+		{Port: 10, Protocol: protocol.TCP},
 	}
 	assert.EqualValues(t, expectedPorts, filteredPorts)
 }


### PR DESCRIPTION
- [x] Exclude Port => Fixed
```console
$ go run . -host 192.168.1.1 -p 80,443 -v -debug -ep 80
...
[INF] Found 1 ports on host 192.168.1.1 (192.168.1.1)
192.168.1.1:443
```
- [x] Exclude IP => Working
```console
$ go run . -host 192.168.1.1 -p 80 -v -debug -eh 192.168.1.1/24
...
[FTL] Could not run enumeration: no valid ipv4 or ipv6 targets were found
```