### PR TITLE
Fix excluding cdn in output with -ec flag

### DIFF
--- a/v2/pkg/runner/output_test.go
+++ b/v2/pkg/runner/output_test.go
@@ -18,7 +18,7 @@ func TestWriteHostOutput(t *testing.T) {
 	}
 	var s string
 	buf := bytes.NewBufferString(s)
-	assert.Nil(t, WriteHostOutput(host, ports, "", buf))
+	assert.Nil(t, WriteHostOutput(host, ports, false, "", buf))
 	assert.Contains(t, buf.String(), "127.0.0.1:80")
 	assert.Contains(t, buf.String(), "127.0.0.1:8080")
 }
@@ -32,6 +32,6 @@ func TestWriteJSONOutput(t *testing.T) {
 	}
 	var s string
 	buf := bytes.NewBufferString(s)
-	assert.Nil(t, WriteJSONOutput(host, ip, ports, false, "", buf))
+	assert.Nil(t, WriteJSONOutput(host, ip, ports, true, false, "", buf))
 	assert.Equal(t, 3, len(strings.Split(buf.String(), "\n")))
 }

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -709,7 +709,11 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 				gologger.Info().Msgf("Found %d ports on host %s (%s)\n", len(hostResult.Ports), host, hostResult.IP)
 				// console output
 				if r.options.JSON || r.options.CSV {
-					data := &Result{IP: hostResult.IP, TimeStamp: time.Now().UTC(), IsCDNIP: isCDNIP, CDNName: cdnName}
+					data := &Result{IP: hostResult.IP, TimeStamp: time.Now().UTC()}
+					if r.options.OutputCDN {
+						data.IsCDNIP = isCDNIP
+						data.CDNName = cdnName
+					}
 					if host != hostResult.IP {
 						data.Host = host
 					}
@@ -747,11 +751,11 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 				// file output
 				if file != nil {
 					if r.options.JSON {
-						err = WriteJSONOutput(host, hostResult.IP, hostResult.Ports, isCDNIP, cdnName, file)
+						err = WriteJSONOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, isCDNIP, cdnName, csvFileHeaderEnabled, file)
+						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file)
 					} else {
-						err = WriteHostOutput(host, hostResult.Ports, cdnName, file)
+						err = WriteHostOutput(host, hostResult.Ports, r.options.OutputCDN, cdnName, file)
 					}
 					if err != nil {
 						gologger.Error().Msgf("Could not write results to file %s for %s: %s\n", output, host, err)
@@ -781,7 +785,11 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 				gologger.Info().Msgf("Found alive host %s (%s)\n", host, hostIP)
 				// console output
 				if r.options.JSON || r.options.CSV {
-					data := &Result{IP: hostIP, TimeStamp: time.Now().UTC(), IsCDNIP: isCDNIP, CDNName: cdnName}
+					data := &Result{IP: hostIP, TimeStamp: time.Now().UTC()}
+					if r.options.OutputCDN {
+						data.IsCDNIP = isCDNIP
+						data.CDNName = cdnName
+					}
 					if host != hostIP {
 						data.Host = host
 					}
@@ -801,11 +809,11 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 				// file output
 				if file != nil {
 					if r.options.JSON {
-						err = WriteJSONOutput(host, hostIP, nil, isCDNIP, cdnName, file)
+						err = WriteJSONOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						err = WriteCsvOutput(host, hostIP, nil, isCDNIP, cdnName, csvFileHeaderEnabled, file)
+						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file)
 					} else {
-						err = WriteHostOutput(host, nil, cdnName, file)
+						err = WriteHostOutput(host, nil, r.options.OutputCDN, cdnName, file)
 					}
 					if err != nil {
 						gologger.Error().Msgf("Could not write results to file %s for %s: %s\n", output, host, err)


### PR DESCRIPTION
#587 `-exclude-cdn` flag implicitly adds the CDN name to the output