### PR TITLE
Fix -exclude-hosts not working when performing Only Host Discovery

### DIFF
--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -187,9 +187,9 @@ func (r *Runner) RunEnumeration() error {
 		}
 
 		// store exclued ips to a map
-		excludedIPsMap := make(map[string]bool)
+		excludedIPsMap := make(map[string]struct{})
 		for _, ipString := range excludedIPs {
-			excludedIPsMap[ipString] = true
+			excludedIPsMap[ipString] = struct{}{}
 		}
 
 		discoverCidr := func(cidr *net.IPNet) {

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -180,10 +180,25 @@ func (r *Runner) RunEnumeration() error {
 			return err
 		}
 
+		// get excluded ips
+		excludedIPs, err := parseExcludedIps(r.options)
+		if err != nil {
+			return err
+		}
+
+		// store exclued ips to a map
+		excludedIPsMap := make(map[string]bool)
+		for _, ipString := range excludedIPs {
+			excludedIPsMap[ipString] = true
+		}
+
 		discoverCidr := func(cidr *net.IPNet) {
 			ipStream, _ := mapcidr.IPAddressesAsStream(cidr.String())
 			for ip := range ipStream {
-				r.handleHostDiscovery(ip)
+				// only run host discovery if the ip is not present in the excludedIPsMap
+				if _, exists := excludedIPsMap[ip]; !exists {
+					r.handleHostDiscovery(ip)
+				}
 			}
 		}
 


### PR DESCRIPTION
- Get excuded IPs from Options
    - Create a map with the IPs as key
- Only execute Host Discovery if the IP is not in the excludedIPs map.
- In Dev Branch:
![image](https://user-images.githubusercontent.com/77744293/231989303-dfe2324d-2901-4063-80c0-edfc1eeef9e1.png)
- After changes :
![image](https://user-images.githubusercontent.com/77744293/231989425-05f95ac7-57fc-4b5e-91d4-7a0f6dfd2b19.png)