### PR TITLE
Update JSON representation of Port and Protocol

### DIFF
--- a/v2/pkg/port/port.go
+++ b/v2/pkg/port/port.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Port struct {
-	Port     int
-	Protocol protocol.Protocol
-	TLS      bool
+	Port     int               `json:"port"`
+	Protocol protocol.Protocol `json:"protocol"`
+	TLS      bool              `json:"tls"`
 }
 
 func (p *Port) String() string {

--- a/v2/pkg/protocol/protocol.go
+++ b/v2/pkg/protocol/protocol.go
@@ -20,3 +20,7 @@ func (p Protocol) String() string {
 		panic("uknown type")
 	}
 }
+
+func (p Protocol) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + p.String() + `"`), nil
+}

--- a/v2/pkg/runner/output.go
+++ b/v2/pkg/runner/output.go
@@ -25,8 +25,27 @@ type Result struct {
 	TimeStamp time.Time  `json:"timestamp" csv:"timestamp"`
 }
 
+type jsonResult struct {
+	Result
+	PortNumber int    `json:"port"`
+	Protocol   string `json:"protocol"`
+	TLS        bool   `json:"tls"`
+}
+
 func (r *Result) JSON() ([]byte, error) {
-	return json.Marshal(r)
+	data := jsonResult{}
+	data.TimeStamp = r.TimeStamp
+	if r.Host != r.IP {
+		data.Host = r.Host
+	}
+	data.IP = r.IP
+	data.IsCDNIP = r.IsCDNIP
+	data.CDNName = r.CDNName
+	data.PortNumber = r.Port.Port
+	data.Protocol = r.Port.Protocol.String()
+	data.TLS = r.Port.TLS
+
+	return json.Marshal(data)
 }
 
 var NumberOfCsvFieldsErr = errors.New("exported fields don't match csv tags")
@@ -87,7 +106,8 @@ func WriteHostOutput(host string, ports []*port.Port, outputCDN bool, cdnName st
 // WriteJSONOutput writes the output list of subdomain in JSON to an io.Writer
 func WriteJSONOutput(host, ip string, ports []*port.Port, outputCDN bool, isCdn bool, cdnName string, writer io.Writer) error {
 	encoder := json.NewEncoder(writer)
-	data := Result{TimeStamp: time.Now().UTC()}
+	data := jsonResult{}
+	data.TimeStamp = time.Now().UTC()
 	if host != ip {
 		data.Host = host
 	}
@@ -97,7 +117,9 @@ func WriteJSONOutput(host, ip string, ports []*port.Port, outputCDN bool, isCdn 
 		data.CDNName = cdnName
 	}
 	for _, p := range ports {
-		data.Port = p
+		data.PortNumber = p.Port
+		data.Protocol = p.Protocol.String()
+		data.TLS = p.TLS
 		if err := encoder.Encode(&data); err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request improves the JSON representation of the `Port` and `Protocol` fields in the `Result` struct.

Previously, the JSON output was:
```json
{
  "host": "example.com",
  "ip": "1.2.3.4",
  "port": {"Port": 80, "Protocol": 0, "TLS": false},
  "timestamp": "2023-07-06T19:48:56.838968371Z"
}
```

With the proposed changes, the JSON output will be:
```json
{
  "host": "example.com",
  "ip": "1.2.3.4",
  "port": 80,
  "protocol": "tcp",
  "tls": false,
  "timestamp": "2023-07-06T19:48:56.838968371Z"
}
```

This change makes the JSON output more consistent and user-friendly, by displaying Protocol as its string representation ("tcp", "udp", or "arp") and making field names in the Port struct lowercase.