### PR TITLE
Add support for [host|ip]:port

### DIFF
--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/projectdiscovery/gologger"
 	iputil "github.com/projectdiscovery/utils/ip"
@@ -41,4 +42,13 @@ func (r *Runner) host2ips(target string) (targetIPsV4 []string, targetIPsV6 []st
 
 func isOSSupported() bool {
 	return osutil.IsLinux() || osutil.IsOSX()
+}
+
+func getPort(target string) (string, string, bool) {
+	host, port, err := net.SplitHostPort(target)
+	if err == nil && iputil.IsPort(port) {
+		return host, port, true
+	}
+
+	return target, "", false
 }


### PR DESCRIPTION
## Description
This PR extends naabu capabilities to accept unitary input targets in the following formats:
```
ip:port
host:port
```

While other targets are network-coalesced into minimal range(s) and iterated randomly with blackrock cipher (just like masscan) picking randomly from vectorized ips and ports spaces, for these new items with port the flow should be the following:
- No host discovery
- Connect|Syn scan only towards the specific port