### PR TITLE
fix printing issue with hostname in passive mode

### DIFF
--- a/v2/cmd/integration-test/cli.go
+++ b/v2/cmd/integration-test/cli.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/projectdiscovery/naabu/v2/internal/testutils"
+)
+
+var cliTestcases = map[string]testutils.TestCase{
+	"cli with passive flag": &cliWithPassiveFlag{},
+}
+
+type cliWithPassiveFlag struct {
+}
+
+func (h *cliWithPassiveFlag) Execute() error {
+	results, err := testutils.RunNaabuAndGetResults("projectdiscovery.io", false, "-ec", "-passive")
+	if err != nil {
+		return err
+	}
+
+	if len(results) <= 0 {
+		return errIncorrectResultsCount(results)
+	}
+
+	return nil
+}

--- a/v2/cmd/integration-test/integration-test.go
+++ b/v2/cmd/integration-test/integration-test.go
@@ -23,6 +23,7 @@ func main() {
 
 	tests := map[string]map[string]testutils.TestCase{
 		"library": libraryTestcases,
+		"cli":     cliTestcases,
 	}
 	for proto, tests := range tests {
 		if protocol == "" || protocol == proto {
@@ -47,11 +48,11 @@ func main() {
 	}
 }
 
-// Currently not used
-// func errIncorrectResultsCount(results []string) error {
-// 	return fmt.Errorf("incorrect number of results %s", strings.Join(results, "\n\t"))
-// }
+func errIncorrectResultsCount(results []string) error {
+	return fmt.Errorf("incorrect number of results %s", strings.Join(results, "\n\t"))
+}
 
+// Currently not used
 // func errIncorrectResult(expected, got string) error {
 // 	return fmt.Errorf("incorrect result: expected \"%s\" got \"%s\"", expected, got)
 // }


### PR DESCRIPTION
Closes #787.

before:
```console
$ go run . -host projectdiscovery.io -ec -silent -passive

104.26.7.152:2087
104.26.7.152:8443
104.26.7.152:8880
104.26.7.152:80
104.26.7.152:443
104.26.7.152:2082
104.26.7.152:2083
```

after:
```console
$ go run . -host projectdiscovery.io -ec -silent -passive
projectdiscovery.io:443
projectdiscovery.io:2052
projectdiscovery.io:2082
projectdiscovery.io:2083
projectdiscovery.io:2087
projectdiscovery.io:2095
projectdiscovery.io:8443
projectdiscovery.io:80
```