### PR TITLE
Adding support for hostnames

### DIFF
--- a/v2/pkg/runner/ips_test.go
+++ b/v2/pkg/runner/ips_test.go
@@ -6,23 +6,26 @@ import (
 	"testing"
 
 	fileutil "github.com/projectdiscovery/utils/file"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseExcludedIps(t *testing.T) {
 	tmpFileName, err := fileutil.GetTempFileName()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	expectedIpsFromCLI := []string{"8.8.8.0/24", "7.7.7.7"}
 	expectedIpsFromFile := []string{"10.10.10.0/24", "192.168.1.0/24"}
-	assert.Nil(t, os.WriteFile(tmpFileName, []byte(strings.Join(expectedIpsFromFile, "\n")), 0755))
+	require.Nil(t, os.WriteFile(tmpFileName, []byte(strings.Join(expectedIpsFromFile, "\n")), 0755))
 	expected := append(expectedIpsFromCLI, expectedIpsFromFile...)
 
-	actual, err := parseExcludedIps(&Options{
+	r, err := NewRunner(&Options{})
+	require.Nil(t, err)
+
+	actual, err := r.parseExcludedIps(&Options{
 		ExcludeIps:     strings.Join(expectedIpsFromCLI, ","),
 		ExcludeIpsFile: tmpFileName,
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, expected, actual)
+	require.Nil(t, err)
+	require.Equal(t, expected, actual)
 
 	defer os.RemoveAll(tmpFileName)
 }
@@ -31,9 +34,9 @@ func TestIsIpOrCidr(t *testing.T) {
 	valid := []string{"1.1.1.1", "2.2.2.2", "1.1.1.0/24"}
 	invalid := []string{"1.1.1.1.1", "a.a.a.a", "77"}
 	for _, validItem := range valid {
-		assert.True(t, isIpOrCidr(validItem))
+		require.True(t, isIpOrCidr(validItem))
 	}
 	for _, invalidItem := range invalid {
-		assert.False(t, isIpOrCidr(invalidItem))
+		require.False(t, isIpOrCidr(invalidItem))
 	}
 }

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -71,7 +71,7 @@ func NewRunner(options *Options) (*Runner, error) {
 	}
 	runner.streamChannel = make(chan Target)
 
-	excludedIps, err := parseExcludedIps(options)
+	excludedIps, err := runner.parseExcludedIps(options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (r *Runner) RunEnumeration() error {
 		}
 
 		// get excluded ips
-		excludedIPs, err := parseExcludedIps(r.options)
+		excludedIPs, err := r.parseExcludedIps(r.options)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #821 

```console
$ echo www.scanme.sh | go run . -exclude-hosts scanme.sh -p 80 -verbose

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.1.8 (latest)
[WRN] Skipping host www.scanme.sh as ip 128.199.158.128 was excluded
[INF] Running CONNECT scan with non root privileges
[FTL] Could not run enumeration: no valid ipv4 or ipv6 targets were found
exit status 1
```