### PR TITLE
Adding freebsd

### DIFF
--- a/v2/pkg/privileges/privileges_freebsd.go
+++ b/v2/pkg/privileges/privileges_freebsd.go
@@ -1,0 +1,12 @@
+//go:build freebsd
+
+package privileges
+
+import (
+	"os"
+)
+
+// isPrivileged checks if the current process is root
+func isPrivileged() bool {
+	return os.Geteuid() == 0
+}


### PR DESCRIPTION
Closes #782 

```console
$ vagrant init generic/freebsd13
$ vagrant up
$ vagrant ssh
...
$ wget https://go.dev/dl/go1.21.4.linux-amd64.tar.gz
$ rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.4.linux-amd64.tar.gz
$ export PATH=$PATH:/usr/local/go/bin
$ go install -v github.com/projectdiscovery/naabu/v2/cmd/naabu@7bb31527659805b3865f7cae00543d41f7bdc8f6
...
github.com/projectdiscovery/naabu/v2/pkg/runner
github.com/projectdiscovery/naabu/v2/cmd/naabu
[vagrant@freebsd13 ~]$ 
```