### PR TITLE
Making pcap handlers shared globally

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,26 +19,26 @@ updates:
     labels:
       - "Type: Maintenance"
 
-#  # Maintain dependencies for docker
-#  - package-ecosystem: "docker"
-#    directory: "/"
-#    schedule:
-#      interval: "weekly"
-#    target-branch: "dev"
-#    commit-message:
-#      prefix: "chore"
-#      include: "scope"
-#    labels:
-#      - "Type: Maintenance"
-#
-#  # Maintain dependencies for GitHub Actions
-#  - package-ecosystem: "github-actions"
-#    directory: "/"
-#    schedule:
-#      interval: "weekly"
-#    target-branch: "dev"
-#    commit-message:
-#      prefix: "chore"
-#      include: "scope"
-#    labels:
-#      - "Type: Maintenance"
+ # Maintain dependencies for docker
+ - package-ecosystem: "docker"
+   directory: "/"
+   schedule:
+     interval: "weekly"
+   target-branch: "dev"
+   commit-message:
+     prefix: "chore"
+     include: "scope"
+   labels:
+     - "Type: Maintenance"
+
+ # Maintain dependencies for GitHub Actions
+ - package-ecosystem: "github-actions"
+   directory: "/"
+   schedule:
+     interval: "weekly"
+   target-branch: "dev"
+   commit-message:
+     prefix: "chore"
+     include: "scope"
+   labels:
+     - "Type: Maintenance"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Integration Tests
         env:
           GH_ACTION: true
-        run: sudo bash run.sh
+        run: bash run.sh
         working-directory: integration_tests/
 
       - name: Race Condition Tests - Standard User

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
         run: go test -race ./...
         working-directory: v2/
 
-      - name: Integration Tests - Standard User
+      - name: Integration Tests
         env:
           GH_ACTION: true
         run: bash run.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,12 +39,6 @@ jobs:
         run: bash run.sh
         working-directory: integration_tests/
 
-      - name: Integration Tests - Root User
-        env:
-          GH_ACTION: true
-        run: sudo bash run.sh
-        working-directory: integration_tests/
-
       - name: Race Condition Tests - Standard User
         run: |
           go run -race . -host scanme.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,15 +33,25 @@ jobs:
         run: go test -race ./...
         working-directory: v2/
 
-      - name: Integration Tests
+      - name: Integration Tests - Standard User
         env:
           GH_ACTION: true
         run: bash run.sh
         working-directory: integration_tests/
 
-      - name: Race Condition Tests
+      - name: Integration Tests - Root User
+        env:
+          GH_ACTION: true
+        run: sudo bash run.sh
+        working-directory: integration_tests/
+
+      - name: Race Condition Tests - Standard User
         run: |
           go run -race . -host scanme.sh
+        working-directory: v2/cmd/naabu/
+
+      - name: Race Condition Tests - Root User
+        run: |
           sudo go run -race . -host scanme.sh
         working-directory: v2/cmd/naabu/
 
@@ -70,15 +80,25 @@ jobs:
         run: go test -race ./...
         working-directory: v2/
 
-      - name: Integration Tests
+      - name: Integration Tests - Standard User
         env:
           GH_ACTION: true
         run: bash run.sh
         working-directory: integration_tests/
 
-      - name: Race Condition Tests
+      - name: Integration Tests - Root User
+        env:
+          GH_ACTION: true
+        run: sudo bash run.sh
+        working-directory: integration_tests/
+
+      - name: Race Condition Tests - Standard User
         run: |
           go run -race . -host scanme.sh
+        working-directory: v2/cmd/naabu/
+
+      - name: Race Condition Tests - Root User
+        run: |
           sudo go run -race . -host scanme.sh
         working-directory: v2/cmd/naabu/
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -90,28 +90,28 @@ jobs:
           sudo go run -race . -host scanme.sh
         working-directory: v2/cmd/naabu/
 
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
+  # build-windows:
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: 1.21.x
 
-      - name: Check out code
-        uses: actions/checkout@v3
+  #     - name: Check out code
+  #       uses: actions/checkout@v3
 
-      - name: Build
-        run: go build .
-        working-directory: v2/cmd/naabu/
+  #     - name: Build
+  #       run: go build .
+  #       working-directory: v2/cmd/naabu/
 
-      - name: Test
-        run: go test -race ./...
-        working-directory: v2/
+  #     - name: Test
+  #       run: go test -race ./...
+  #       working-directory: v2/
 
-      - name: Race Condition Tests
-        # Known issue: https://github.com/golang/go/issues/46099
-        run: |
-          # go run -race . -host scanme.sh
-          # sudo go run -race . -host scanme.sh
-        working-directory: v2/cmd/naabu/
+  #     - name: Race Condition Tests
+  #       # Known issue: https://github.com/golang/go/issues/46099
+  #       run: |
+  #         # go run -race . -host scanme.sh
+  #         # sudo go run -race . -host scanme.sh
+  #       working-directory: v2/cmd/naabu/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Race Condition Tests - Root User
         run: |
-          sudo go run -race . -host scanme.sh
+          sudo go run -race . -host scanme.sh -Pn
         working-directory: v2/cmd/naabu/
 
   build-mac:
@@ -87,7 +87,7 @@ jobs:
 
       - name: Race Condition Tests - Root User
         run: |
-          sudo go run -race . -host scanme.sh
+          sudo go run -race . -host scanme.sh -Pn
         working-directory: v2/cmd/naabu/
 
   # build-windows:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,13 +11,13 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
-
-      - name: Check out code
-        uses: actions/checkout@v3
 
       - name: Install libpcap-dev
         run: sudo apt install libpcap-dev

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -80,13 +80,7 @@ jobs:
         run: go test -race ./...
         working-directory: v2/
 
-      - name: Integration Tests - Standard User
-        env:
-          GH_ACTION: true
-        run: bash run.sh
-        working-directory: integration_tests/
-
-      - name: Integration Tests - Root User
+      - name: Integration Tests
         env:
           GH_ACTION: true
         run: sudo bash run.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -90,28 +90,28 @@ jobs:
           sudo go run -race . -host scanme.sh -Pn
         working-directory: v2/cmd/naabu/
 
-  # build-windows:
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: 1.21.x
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v3
 
-  #     - name: Build
-  #       run: go build .
-  #       working-directory: v2/cmd/naabu/
+      - name: Build
+        run: go build .
+        working-directory: v2/cmd/naabu/
 
-  #     - name: Test
-  #       run: go test -race ./...
-  #       working-directory: v2/
+      - name: Test
+        run: go test -race ./...
+        working-directory: v2/
 
-  #     - name: Race Condition Tests
-  #       # Known issue: https://github.com/golang/go/issues/46099
-  #       run: |
-  #         # go run -race . -host scanme.sh
-  #         # sudo go run -race . -host scanme.sh
-  #       working-directory: v2/cmd/naabu/
+      - name: Race Condition Tests
+        # Known issue: https://github.com/golang/go/issues/46099
+        run: |
+          # go run -race . -host scanme.sh
+          # sudo go run -race . -host scanme.sh
+        working-directory: v2/cmd/naabu/

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -55,22 +55,22 @@ jobs:
           version: latest
           workdir: v2
 
-  # release-test-windows:
-  #   runs-on: windows-latest-8-cores
-  #   steps:
-  #     - name: "Check out code"
-  #       uses: actions/checkout@v3
-  #       with: 
-  #         fetch-depth: 0
+  release-test-windows:
+    runs-on: windows-latest-8-cores
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
 
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: 1.21.x
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
       
-  #     - name: release test
-  #       uses: goreleaser/goreleaser-action@v4
-  #       with:
-  #         args: "release --clean --snapshot -f .goreleaser/windows.yml"
-  #         version: latest
-  #         workdir: v2
+      - name: release test
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          args: "release --clean --snapshot -f .goreleaser/windows.yml"
+          version: latest
+          workdir: v2

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -55,22 +55,22 @@ jobs:
           version: latest
           workdir: v2
 
-  release-test-windows:
-    runs-on: windows-latest-8-cores
-    steps:
-      - name: "Check out code"
-        uses: actions/checkout@v3
-        with: 
-          fetch-depth: 0
+  # release-test-windows:
+  #   runs-on: windows-latest-8-cores
+  #   steps:
+  #     - name: "Check out code"
+  #       uses: actions/checkout@v3
+  #       with: 
+  #         fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: 1.21.x
       
-      - name: release test
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          args: "release --clean --snapshot -f .goreleaser/windows.yml"
-          version: latest
-          workdir: v2
+  #     - name: release test
+  #       uses: goreleaser/goreleaser-action@v4
+  #       with:
+  #         args: "release --clean --snapshot -f .goreleaser/windows.yml"
+  #         version: latest
+  #         workdir: v2

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Naabu also supports excluding CDN/WAF IPs being port scanned. If used, only `80`
 Currently `cloudflare`, `akamai`, `incapsula` and `sucuri` IPs are supported for exclusions.
 
 # Scan Status
-Naabu exposes json scan info on a local port bound to localhost at `http://localhost:63636` (the port can be changed via the `-metrics-port` flag)
+Naabu exposes json scan info on a local port bound to localhost at `http://localhost:63636/metrics` (the port can be changed via the `-metrics-port` flag)
 
 # Using naabu as library
 The following sample program scan the port `80` of `scanme.sh`. The results are returned via the `OnResult` callback:

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -14,7 +14,7 @@ mv integration-test ../../../integration_tests/integration-test
 cd ../../../integration_tests
 echo "::endgroup::"
 
-./integration-test
+sudo ./integration-test
 if [ $? -eq 0 ]
 then
   exit 0

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -10,8 +10,36 @@ import (
 )
 
 var libraryTestcases = map[string]testutils.TestCase{
-	"sdk - one execution":       &naabuSingleLibrary{},
-	"sdk - multiple executions": &naabuMultipleExecLibrary{},
+	"sdk - one passive execution": &naabuPassiveSingleLibrary{},
+	"sdk - one execution":         &naabuSingleLibrary{},
+	"sdk - multiple executions":   &naabuMultipleExecLibrary{},
+}
+
+type naabuPassiveSingleLibrary struct {
+}
+
+func (h *naabuPassiveSingleLibrary) Execute() error {
+	testFile := "test.txt"
+	err := os.WriteFile(testFile, []byte("scanme.sh"), 0644)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(testFile)
+
+	options := runner.Options{
+		HostsFile: testFile,
+		Ports:     "80",
+		Passive:   true,
+		OnResult:  func(hr *result.HostResult) {},
+	}
+
+	naabuRunner, err := runner.NewRunner(&options)
+	if err != nil {
+		return err
+	}
+	defer naabuRunner.Close()
+
+	return naabuRunner.RunEnumeration()
 }
 
 type naabuSingleLibrary struct {
@@ -28,7 +56,6 @@ func (h *naabuSingleLibrary) Execute() error {
 	options := runner.Options{
 		HostsFile: testFile,
 		Ports:     "80",
-		Passive:   true,
 		OnResult:  func(hr *result.HostResult) {},
 	}
 

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -122,7 +122,7 @@ func (h *naabuMultipleExecLibrary) Execute() error {
 		},
 	}
 
-	for i := 0; i < 25; i++ {
+	for i := 0; i < 3; i++ {
 		naabuRunner, err := runner.NewRunner(&options)
 		if err != nil {
 			return err

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -75,6 +75,7 @@ func (h *naabuSingleLibrary) Execute() error {
 		OnResult: func(hr *result.HostResult) {
 			got = true
 		},
+		WarmUpTime: 2,
 	}
 
 	naabuRunner, err := runner.NewRunner(&options)
@@ -120,6 +121,7 @@ func (h *naabuMultipleExecLibrary) Execute() error {
 		OnResult: func(hr *result.HostResult) {
 			got = true
 		},
+		WarmUpTime: 2,
 	}
 
 	for i := 0; i < 3; i++ {

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -77,4 +77,5 @@ func (h *naabuMultipleExecLibrary) Execute() error {
 			return errors.New("no results found")
 		}
 	}
+	return nil
 }

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -53,10 +53,14 @@ func (h *naabuSingleLibrary) Execute() error {
 	}
 	defer os.RemoveAll(testFile)
 
+	var got bool
+
 	options := runner.Options{
 		HostsFile: testFile,
 		Ports:     "80",
-		OnResult:  func(hr *result.HostResult) {},
+		OnResult: func(hr *result.HostResult) {
+			got = true
+		},
 	}
 
 	naabuRunner, err := runner.NewRunner(&options)
@@ -65,7 +69,14 @@ func (h *naabuSingleLibrary) Execute() error {
 	}
 	defer naabuRunner.Close()
 
-	return naabuRunner.RunEnumeration()
+	if err = naabuRunner.RunEnumeration(); err != nil {
+		return err
+	}
+	if !got {
+		return errors.New("no results found")
+	}
+
+	return nil
 }
 
 type naabuMultipleExecLibrary struct {

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -95,7 +95,6 @@ func (h *naabuMultipleExecLibrary) Execute() error {
 	options := runner.Options{
 		HostsFile: testFile,
 		Ports:     "80",
-		Passive:   true,
 		OnResult: func(hr *result.HostResult) {
 			got = true
 		},

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 
@@ -39,7 +40,7 @@ func (h *naabuPassiveSingleLibrary) Execute() error {
 	}
 	defer naabuRunner.Close()
 
-	return naabuRunner.RunEnumeration()
+	return naabuRunner.RunEnumeration(context.TODO())
 }
 
 type naabuSingleLibrary struct {
@@ -69,7 +70,7 @@ func (h *naabuSingleLibrary) Execute() error {
 	}
 	defer naabuRunner.Close()
 
-	if err = naabuRunner.RunEnumeration(); err != nil {
+	if err = naabuRunner.RunEnumeration(context.TODO()); err != nil {
 		return err
 	}
 	if !got {
@@ -105,14 +106,14 @@ func (h *naabuMultipleExecLibrary) Execute() error {
 		if err != nil {
 			return err
 		}
-		defer naabuRunner.Close()
 
-		if err = naabuRunner.RunEnumeration(); err != nil {
+		if err = naabuRunner.RunEnumeration(context.TODO()); err != nil {
 			return err
 		}
 		if !got {
 			return errors.New("no results found")
 		}
+		naabuRunner.Close()
 	}
 	return nil
 }

--- a/v2/cmd/integration-test/library.go
+++ b/v2/cmd/integration-test/library.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/user"
 
 	"github.com/projectdiscovery/naabu/v2/internal/testutils"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
@@ -52,9 +53,9 @@ type naabuSingleLibrary struct {
 }
 
 func (h *naabuSingleLibrary) Execute() error {
-	// ignore syn scan without privileges
 	if h.scanType == "s" && !privileges.IsPrivileged {
-		return nil
+		usr, _ := user.Current()
+		return errors.New("invalid user" + usr.Name)
 	}
 
 	testFile := "test.txt"
@@ -97,9 +98,9 @@ type naabuMultipleExecLibrary struct {
 }
 
 func (h *naabuMultipleExecLibrary) Execute() error {
-	// ignore syn scan without privileges
 	if h.scanType == "s" && !privileges.IsPrivileged {
-		return nil
+		usr, _ := user.Current()
+		return errors.New("invalid user" + usr.Name)
 	}
 
 	testFile := "test.txt"

--- a/v2/cmd/naabu/main.go
+++ b/v2/cmd/naabu/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
+	"os"
+	"os/signal"
+
 	_ "github.com/projectdiscovery/fdmax/autofdmax"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/naabu/v2/pkg/runner"
-	"os"
-	"os/signal"
 )
 
 func main() {
@@ -35,7 +37,7 @@ func main() {
 		}
 	}()
 
-	err = naabuRunner.RunEnumeration()
+	err = naabuRunner.RunEnumeration(context.TODO())
 	if err != nil {
 		gologger.Fatal().Msgf("Could not run enumeration: %s\n", err)
 	}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,6 +3,7 @@ module github.com/projectdiscovery/naabu/v2
 go 1.21
 
 require (
+	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/google/gopacket v1.1.19
 	github.com/logrusorgru/aurora v2.0.3+incompatible
@@ -34,7 +35,6 @@ require (
 require (
 	aead.dev/minisign v0.2.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
-	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057 // indirect
 	github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/akrylysov/pogreb v0.10.1 // indirect

--- a/v2/pkg/result/results.go
+++ b/v2/pkg/result/results.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+type ResultFn func(*HostResult)
+
 type HostResult struct {
 	Host  string
 	IP    string

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -210,8 +210,6 @@ func ParseOptions() *Options {
 	// Check if stdin pipe was given
 	options.Stdin = !options.DisableStdin && fileutil.HasStdin()
 
-	// Read the inputs and configure the logging
-	options.configureOutput()
 	options.ResumeCfg = NewResumeCfg()
 	if options.ShouldLoadResume() {
 		if err := options.ResumeCfg.ConfigureResume(); err != nil {

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 	"github.com/projectdiscovery/naabu/v2/pkg/result"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 	fileutil "github.com/projectdiscovery/utils/file"
 
 	"github.com/projectdiscovery/goflags"
@@ -139,7 +140,7 @@ func ParseOptions() *Options {
 
 	flagSet.CreateGroup("config", "Configuration",
 		flagSet.BoolVarP(&options.ScanAllIPS, "sa", "scan-all-ips", false, "scan all the IP's associated with DNS record"),
-		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{"4"}, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{scan.IPV4}, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
 		flagSet.StringVarP(&options.ScanType, "s", "scan-type", SynScan, "type of port scan (SYN/CONNECT)"),
 		flagSet.StringVar(&options.SourceIP, "source-ip", "", "source ip and port (x.x.x.x:yyy)"),
 		flagSet.BoolVarP(&options.InterfacesList, "il", "interface-list", false, "list available interfaces and public ip"),

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -230,9 +230,7 @@ func ParseOptions() *Options {
 	if !options.DisableUpdateCheck {
 		latestVersion, err := updateutils.GetToolVersionCallback("naabu", version)()
 		if err != nil {
-			if options.Verbose {
-				gologger.Error().Msgf("naabu version check failed: %v", err.Error())
-			}
+			gologger.Verbose().Msgf("naabu version check failed: %v", err.Error())
 		} else {
 			gologger.Info().Msgf("Current naabu version %v %v", version, updateutils.GetVersionDescription(version, latestVersion))
 		}

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -61,7 +61,8 @@ type Options struct {
 	ProxyAuth         string              // Socks5 proxy authentication (username:password)
 	Resolvers         string              // Resolvers (comma separated or file)
 	baseResolvers     []string
-	OnResult          OnResultCallback // OnResult callback
+	OnResult          result.ResultFn // callback on final host result
+	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
 	Resume            bool
 	ResumeCfg         *ResumeCfg
@@ -95,9 +96,6 @@ type Options struct {
 	// MetricsPort with statistics
 	MetricsPort int
 }
-
-// OnResultCallback (hostResult)
-type OnResultCallback func(*result.HostResult)
 
 // ParseOptions parses the command line flags provided by a user
 func ParseOptions() *Options {

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -198,7 +198,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.Version, "version", false, "display version of naabu"),
 		flagSet.BoolVar(&options.EnableProgressBar, "stats", false, "display stats of the running scan (deprecated)"),
 		flagSet.IntVarP(&options.StatsInterval, "stats-interval", "si", DefautStatsInterval, "number of seconds to wait between showing a statistics update (deprecated)"),
-		flagSet.IntVarP(&options.MetricsPort, "metrics-port", "mp", 63636, "port to expose nuclei metrics on"),
+		flagSet.IntVarP(&options.MetricsPort, "metrics-port", "mp", 63636, "port to expose naabu metrics on"),
 	)
 
 	_ = flagSet.Parse()

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -140,7 +140,7 @@ func ParseOptions() *Options {
 
 	flagSet.CreateGroup("config", "Configuration",
 		flagSet.BoolVarP(&options.ScanAllIPS, "sa", "scan-all-ips", false, "scan all the IP's associated with DNS record"),
-		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{scan.IPV4}, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{scan.IPv4}, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
 		flagSet.StringVarP(&options.ScanType, "s", "scan-type", SynScan, "type of port scan (SYN/CONNECT)"),
 		flagSet.StringVar(&options.SourceIP, "source-ip", "", "source ip and port (x.x.x.x:yyy)"),
 		flagSet.BoolVarP(&options.InterfacesList, "il", "interface-list", false, "list available interfaces and public ip"),

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -139,7 +139,7 @@ func ParseOptions() *Options {
 
 	flagSet.CreateGroup("config", "Configuration",
 		flagSet.BoolVarP(&options.ScanAllIPS, "sa", "scan-all-ips", false, "scan all the IP's associated with DNS record"),
-		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", nil, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{"4"}, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
 		flagSet.StringVarP(&options.ScanType, "s", "scan-type", SynScan, "type of port scan (SYN/CONNECT)"),
 		flagSet.StringVar(&options.SourceIP, "source-ip", "", "source ip and port (x.x.x.x:yyy)"),
 		flagSet.BoolVarP(&options.InterfacesList, "il", "interface-list", false, "list available interfaces and public ip"),

--- a/v2/pkg/runner/resume.go
+++ b/v2/pkg/runner/resume.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	fileutil "github.com/projectdiscovery/utils/file"
+	permissionutil "github.com/projectdiscovery/utils/permission"
 )
 
 // Default resume file
@@ -51,10 +52,10 @@ func (resumeCfg *ResumeCfg) SaveResumeConfig() error {
 	}
 	resumeFolderPath := DefaultResumeFolderPath()
 	if !fileutil.FolderExists(resumeFolderPath) {
-		_ = os.MkdirAll(DefaultResumeFolderPath(), 0644)
+		fileutil.CreateFolder(DefaultResumeFolderPath())
 	}
 
-	return os.WriteFile(DefaultResumeFilePath(), data, 0644)
+	return os.WriteFile(DefaultResumeFilePath(), data, permissionutil.ConfigFilePermission)
 }
 
 // ConfigureResume read the resume config file

--- a/v2/pkg/runner/resume.go
+++ b/v2/pkg/runner/resume.go
@@ -52,7 +52,7 @@ func (resumeCfg *ResumeCfg) SaveResumeConfig() error {
 	}
 	resumeFolderPath := DefaultResumeFolderPath()
 	if !fileutil.FolderExists(resumeFolderPath) {
-		fileutil.CreateFolder(DefaultResumeFolderPath())
+		_ = fileutil.CreateFolder(DefaultResumeFolderPath())
 	}
 
 	return os.WriteFile(DefaultResumeFilePath(), data, permissionutil.ConfigFilePermission)

--- a/v2/pkg/runner/resume.go
+++ b/v2/pkg/runner/resume.go
@@ -42,6 +42,9 @@ func NewResumeCfg() *ResumeCfg {
 
 // SaveResumeConfig to file
 func (resumeCfg *ResumeCfg) SaveResumeConfig() error {
+	resumeCfg.RLock()
+	defer resumeCfg.RUnlock()
+
 	data, err := json.MarshalIndent(resumeCfg, "", "\t")
 	if err != nil {
 		return err
@@ -56,6 +59,9 @@ func (resumeCfg *ResumeCfg) SaveResumeConfig() error {
 
 // ConfigureResume read the resume config file
 func (resumeCfg *ResumeCfg) ConfigureResume() error {
+	resumeCfg.RLock()
+	defer resumeCfg.RUnlock()
+
 	gologger.Info().Msg("Resuming from save checkpoint")
 	file, err := os.ReadFile(DefaultResumeFilePath())
 	if err != nil {

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -403,7 +403,11 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					}
 
 					for _, p := range data.Ports {
-						r.scanner.ScanResults.AddPort(ip, &port.Port{Port: p, Protocol: protocol.TCP})
+						pp := &port.Port{Port: p, Protocol: protocol.TCP}
+						if r.scanner.OnReceive != nil {
+							r.scanner.OnReceive(&result.HostResult{IP: ip, Ports: []*port.Port{pp}})
+						}
+						r.scanner.ScanResults.AddPort(ip, pp)
 					}
 				}(ip)
 			}

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -646,8 +646,12 @@ func (r *Runner) Close() {
 	if r.options.EnableProgressBar {
 		_ = r.stats.Stop()
 	}
-	r.scanner.Close()
-	r.limiter.Stop()
+	if r.scanner != nil {
+		r.scanner.Close()
+	}
+	if r.limiter != nil {
+		r.limiter.Stop()
+	}
 }
 
 // PickIP randomly

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -763,6 +763,9 @@ func (r *Runner) handleHostPort(ctx context.Context, host string, p *port.Port) 
 		open, err := r.scanner.ConnectPort(host, p, time.Duration(r.options.Timeout)*time.Millisecond)
 		if open && err == nil {
 			r.scanner.ScanResults.AddPort(host, p)
+			if r.scanner.OnReceive != nil {
+				r.scanner.OnReceive(&result.HostResult{IP: host, Ports: []*port.Port{p}})
+			}
 		}
 	}
 }

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -133,17 +133,10 @@ func NewRunner(options *Options) (*Runner, error) {
 
 // RunEnumeration runs the ports enumeration flow on the targets specified
 func (r *Runner) RunEnumeration(pctx context.Context) error {
-	defer r.Close()
-
 	ctx, cancel := context.WithCancel(pctx)
 	defer cancel()
 
 	if privileges.IsPrivileged && r.options.ScanType == SynScan {
-		if !scan.Busy.TryLock() {
-			return errors.New("existing scan already in progress")
-		}
-		defer scan.Busy.Unlock()
-
 		// Set values if those were specified via cli, errors are fatal
 		if r.options.SourceIP != "" {
 			err := r.SetSourceIP(r.options.SourceIP)
@@ -163,7 +156,6 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 				return err
 			}
 		}
-
 		r.BackgroundWorkers(ctx)
 	}
 
@@ -742,7 +734,7 @@ func (r *Runner) SetSourcePort(sourcePort string) error {
 		return err
 	}
 
-	scan.ListenPort = port
+	r.scanner.ListenHandler.Port = port
 
 	return nil
 }

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -181,7 +181,7 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 				}
 			}
 		}
-		r.unique.Set(ipPort, struct{}{})
+		_ = r.unique.Set(ipPort, struct{}{})
 	}
 
 	csvHeaderEnabled := true

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -789,6 +789,10 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 				continue
 			}
 
+			if !ipMatchesIpVersions(hostResult.IP, r.options.IPVersion...) {
+				continue
+			}
+
 			// recover hostnames from ip:port combination
 			for _, p := range hostResult.Ports {
 				ipPort := net.JoinHostPort(hostResult.IP, fmt.Sprint(p.Port))
@@ -882,6 +886,10 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 			if err != nil {
 				continue
 			}
+			if !ipMatchesIpVersions(hostIP, r.options.IPVersion...) {
+				continue
+			}
+
 			buffer := bytes.Buffer{}
 			writer := csv.NewWriter(&buffer)
 			for _, host := range dt {
@@ -935,5 +943,16 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 			csvFileHeaderEnabled = false
 		}
 	}
+}
 
+func ipMatchesIpVersions(ip string, ipVersions ...string) bool {
+	for _, ipVersion := range ipVersions {
+		if ipVersion == "4" && iputil.IsIPv4(ip) {
+			return true
+		}
+		if ipVersion == "6" && iputil.IsIPv6(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -62,6 +62,11 @@ type Target struct {
 func NewRunner(options *Options) (*Runner, error) {
 	options.configureHostDiscovery()
 
+	// default to ipv4 if no ipversion was specified
+	if len(options.IPVersion) == 0 {
+		options.IPVersion = []string{scan.IPv4}
+	}
+
 	if options.Retries == 0 {
 		options.Retries = DefaultRetriesSynScan
 	}
@@ -947,7 +952,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 
 func ipMatchesIpVersions(ip string, ipVersions ...string) bool {
 	for _, ipVersion := range ipVersions {
-		if ipVersion == scan.IPV4 && iputil.IsIPv4(ip) {
+		if ipVersion == scan.IPv4 && iputil.IsIPv4(ip) {
 			return true
 		}
 		if ipVersion == scan.IPv6 && iputil.IsIPv6(ip) {

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -947,10 +947,10 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 
 func ipMatchesIpVersions(ip string, ipVersions ...string) bool {
 	for _, ipVersion := range ipVersions {
-		if ipVersion == "4" && iputil.IsIPv4(ip) {
+		if ipVersion == scan.IPV4 && iputil.IsIPv4(ip) {
 			return true
 		}
-		if ipVersion == "6" && iputil.IsIPv6(ip) {
+		if ipVersion == scan.IPv6 && iputil.IsIPv6(ip) {
 			return true
 		}
 	}

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -132,8 +132,11 @@ func NewRunner(options *Options) (*Runner, error) {
 }
 
 // RunEnumeration runs the ports enumeration flow on the targets specified
-func (r *Runner) RunEnumeration() error {
+func (r *Runner) RunEnumeration(pctx context.Context) error {
 	defer r.Close()
+
+	ctx, cancel := context.WithCancel(pctx)
+	defer cancel()
 
 	if privileges.IsPrivileged && r.options.ScanType == SynScan {
 		// Set values if those were specified via cli, errors are fatal
@@ -156,7 +159,7 @@ func (r *Runner) RunEnumeration() error {
 			}
 		}
 
-		r.BackgroundWorkers()
+		r.BackgroundWorkers(ctx)
 	}
 
 	if r.options.Stream {
@@ -601,8 +604,8 @@ func (r *Runner) ConnectVerification() {
 	swg.Wait()
 }
 
-func (r *Runner) BackgroundWorkers() {
-	r.scanner.StartWorkers()
+func (r *Runner) BackgroundWorkers(ctx context.Context) {
+	r.scanner.StartWorkers(ctx)
 }
 
 func (r *Runner) RawSocketHostDiscovery(ip string) {

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -105,6 +105,7 @@ func NewRunner(options *Options) (*Runner, error) {
 		Proxy:         options.Proxy,
 		ProxyAuth:     options.ProxyAuth,
 		Stream:        options.Stream,
+		OnReceive:     options.OnReceive,
 	})
 	if err != nil {
 		return nil, err

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -99,7 +99,6 @@ func NewRunner(options *Options) (*Runner, error) {
 		Retries:       options.Retries,
 		Rate:          options.Rate,
 		PortThreshold: options.PortThreshold,
-		Debug:         options.Debug,
 		ExcludeCdn:    options.ExcludeCDN,
 		OutputCdn:     options.OutputCDN,
 		ExcludedIps:   excludedIps,

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -156,10 +156,6 @@ func (r *Runner) RunEnumeration() error {
 			}
 		}
 
-		err := r.scanner.SetupHandlers()
-		if err != nil {
-			return err
-		}
 		r.BackgroundWorkers()
 	}
 
@@ -728,7 +724,7 @@ func (r *Runner) SetSourcePort(sourcePort string) error {
 		return err
 	}
 
-	r.scanner.SourcePort = port
+	scan.ListenPort = port
 
 	return nil
 }

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -139,6 +139,11 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 	defer cancel()
 
 	if privileges.IsPrivileged && r.options.ScanType == SynScan {
+		if !scan.Busy.TryLock() {
+			return errors.New("existing scan already in progress")
+		}
+		defer scan.Busy.Unlock()
+
 		// Set values if those were specified via cli, errors are fatal
 		if r.options.SourceIP != "" {
 			err := r.SetSourceIP(r.options.SourceIP)

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -60,6 +60,8 @@ type Target struct {
 // NewRunner creates a new runner struct instance by parsing
 // the configuration options, configuring sources, reading lists, etc
 func NewRunner(options *Options) (*Runner, error) {
+	options.configureOutput()
+
 	options.configureHostDiscovery()
 
 	// default to ipv4 if no ipversion was specified

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -178,7 +178,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 	if shouldDiscoverHosts && shouldUseRawPackets {
 		// perform host discovery
 		showHostDiscoveryInfo()
-		r.scanner.Phase.Set(scan.HostDiscovery)
+		r.scanner.ListenHandler.Phase.Set(scan.HostDiscovery)
 		// shrinks the ips to the minimum amount of cidr
 		_, targetsV4, targetsv6, _, err := r.GetTargetIps(r.getPreprocessedIps)
 		if err != nil {
@@ -228,7 +228,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 	switch {
 	case r.options.Stream && !r.options.Passive: // stream active
 		showNetworkCapabilities(r.options)
-		r.scanner.Phase.Set(scan.Scan)
+		r.scanner.ListenHandler.Phase.Set(scan.Scan)
 
 		handleStreamIp := func(target string, port *port.Port) bool {
 			if r.scanner.ScanResults.HasSkipped(target) {
@@ -273,7 +273,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 		showNetworkCapabilities(r.options)
 		// create retryablehttp instance
 		httpClient := retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)
-		r.scanner.Phase.Set(scan.Scan)
+		r.scanner.ListenHandler.Phase.Set(scan.Scan)
 		for target := range r.streamChannel {
 			if err := r.scanner.IPRanger.Add(target.Cidr); err != nil {
 				gologger.Warning().Msgf("Couldn't track %s in scan results: %s\n", target, err)
@@ -349,7 +349,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 		portsCount = uint64(len(r.scanner.Ports))
 		targetsWithPortCount = uint64(len(targetsWithPort))
 
-		r.scanner.Phase.Set(scan.Scan)
+		r.scanner.ListenHandler.Phase.Set(scan.Scan)
 		Range := targetsCount * portsCount
 		if r.options.EnableProgressBar {
 			r.stats.AddStatic("ports", portsCount)
@@ -478,7 +478,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 			time.Sleep(time.Duration(r.options.WarmUpTime) * time.Second)
 		}
 
-		r.scanner.Phase.Set(scan.Done)
+		r.scanner.ListenHandler.Phase.Set(scan.Done)
 
 		// Validate the hosts if the user has asked for second step validation
 		if r.options.Verify {
@@ -580,7 +580,7 @@ func (r *Runner) PickPort(index int) *port.Port {
 }
 
 func (r *Runner) ConnectVerification() {
-	r.scanner.Phase.Set(scan.Scan)
+	r.scanner.ListenHandler.Phase.Set(scan.Scan)
 	var swg sync.WaitGroup
 	limiter := ratelimit.New(context.Background(), uint(r.options.Rate), time.Second)
 

--- a/v2/pkg/runner/targets.go
+++ b/v2/pkg/runner/targets.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (r *Runner) Load() error {
-	r.scanner.Phase.Set(scan.Init)
+	r.scanner.ListenHandler.Phase.Set(scan.Init)
 
 	// merge all target sources into a file
 	targetfile, err := r.mergeToFile()

--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -21,7 +21,7 @@ func (r *Runner) host2ips(target string) (targetIPsV4 []string, targetIPsV6 []st
 			return nil, nil, err
 		}
 		if len(r.options.IPVersion) > 0 {
-			if sliceutil.Contains(r.options.IPVersion, scan.IPV4) {
+			if sliceutil.Contains(r.options.IPVersion, scan.IPv4) {
 				targetIPsV4 = append(targetIPsV4, dnsData.A...)
 			}
 			if sliceutil.Contains(r.options.IPVersion, scan.IPv6) {

--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 	iputil "github.com/projectdiscovery/utils/ip"
 	osutil "github.com/projectdiscovery/utils/os"
 	sliceutil "github.com/projectdiscovery/utils/slice"
@@ -20,10 +21,10 @@ func (r *Runner) host2ips(target string) (targetIPsV4 []string, targetIPsV6 []st
 			return nil, nil, err
 		}
 		if len(r.options.IPVersion) > 0 {
-			if sliceutil.Contains(r.options.IPVersion, "4") {
+			if sliceutil.Contains(r.options.IPVersion, scan.IPV4) {
 				targetIPsV4 = append(targetIPsV4, dnsData.A...)
 			}
-			if sliceutil.Contains(r.options.IPVersion, "6") {
+			if sliceutil.Contains(r.options.IPVersion, scan.IPv6) {
 				targetIPsV6 = append(targetIPsV6, dnsData.AAAA...)
 			}
 		} else {

--- a/v2/pkg/runner/util_test.go
+++ b/v2/pkg/runner/util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +21,7 @@ func Test_host2ips(t *testing.T) {
 		{"10.10.10.0/24", nil, nil, true},
 	}
 
-	r, err := NewRunner(&Options{IPVersion: []string{"4", "6"}, Retries: 1})
+	r, err := NewRunner(&Options{IPVersion: []string{scan.IPV4, scan.IPv6}, Retries: 1})
 	assert.Nil(t, err)
 	if dnsclient, err := dnsx.New(dnsx.DefaultOptions); err != nil {
 		assert.Error(t, err)

--- a/v2/pkg/runner/util_test.go
+++ b/v2/pkg/runner/util_test.go
@@ -21,7 +21,7 @@ func Test_host2ips(t *testing.T) {
 		{"10.10.10.0/24", nil, nil, true},
 	}
 
-	r, err := NewRunner(&Options{IPVersion: []string{scan.IPV4, scan.IPv6}, Retries: 1})
+	r, err := NewRunner(&Options{IPVersion: []string{scan.IPv4, scan.IPv6}, Retries: 1})
 	assert.Nil(t, err)
 	if dnsclient, err := dnsx.New(dnsx.DefaultOptions); err != nil {
 		assert.Error(t, err)

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -143,9 +143,11 @@ func (options *Options) ValidateOptions() error {
 
 // configureOutput configures the output on the screen
 func (options *Options) configureOutput() {
-	// If the user desires verbose output, show verbose output
 	if options.Verbose {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelVerbose)
+	}
+	if options.Debug {
+		gologger.DefaultLogger.SetMaxLevel(levels.LevelDebug)
 	}
 	if options.NoColor {
 		gologger.DefaultLogger.SetFormatter(formatter.NewCLI(true))

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 	fileutil "github.com/projectdiscovery/utils/file"
 	iputil "github.com/projectdiscovery/utils/ip"
 	osutil "github.com/projectdiscovery/utils/os"
@@ -113,7 +114,7 @@ func (options *Options) ValidateOptions() error {
 		options.SourcePort = port
 	}
 
-	if len(options.IPVersion) > 0 && !sliceutil.ContainsItems([]string{"4", "6"}, options.IPVersion) {
+	if len(options.IPVersion) > 0 && !sliceutil.ContainsItems([]string{scan.IPV4, scan.IPv6}, options.IPVersion) {
 		return errors.New("IP Version must be 4 and/or 6")
 	}
 	// Return error if any host discovery releated option is provided but host discovery is disabled

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -114,7 +114,7 @@ func (options *Options) ValidateOptions() error {
 		options.SourcePort = port
 	}
 
-	if len(options.IPVersion) > 0 && !sliceutil.ContainsItems([]string{scan.IPV4, scan.IPv6}, options.IPVersion) {
+	if len(options.IPVersion) > 0 && !sliceutil.ContainsItems([]string{scan.IPv4, scan.IPv6}, options.IPVersion) {
 		return errors.New("IP Version must be 4 and/or 6")
 	}
 	// Return error if any host discovery releated option is provided but host discovery is disabled

--- a/v2/pkg/scan/arp.go
+++ b/v2/pkg/scan/arp.go
@@ -56,7 +56,7 @@ func ArpRequestAsync(s *Scanner, ip string) {
 		return
 	}
 	// send the packet out on every interface
-	if handlers, ok := s.handlers.(Handlers); ok {
+	if handlers, ok := handlers.(Handlers); ok {
 		for _, handler := range handlers.EthernetActive {
 			err := handler.WritePacketData(buf.Bytes())
 			if err != nil {

--- a/v2/pkg/scan/arp.go
+++ b/v2/pkg/scan/arp.go
@@ -17,7 +17,7 @@ func init() {
 
 // ArpRequestAsync asynchronous to the target ip address
 func ArpRequestAsync(s *Scanner, ip string) {
-	networkInterface, _, sourceIP, err := s.Router.Route(net.ParseIP(ip))
+	networkInterface, _, sourceIP, err := router.Route(net.ParseIP(ip))
 	if networkInterface == nil {
 		err = errors.New("Could not send ARP Request packet to " + ip + ": no interface with outbound source found")
 	}
@@ -56,12 +56,10 @@ func ArpRequestAsync(s *Scanner, ip string) {
 		return
 	}
 	// send the packet out on every interface
-	if handlers, ok := handlers.(Handlers); ok {
-		for _, handler := range handlers.EthernetActive {
-			err := handler.WritePacketData(buf.Bytes())
-			if err != nil {
-				gologger.Warning().Msgf("%s\n", err)
-			}
+	for _, handler := range handlers.EthernetActive {
+		err := handler.WritePacketData(buf.Bytes())
+		if err != nil {
+			gologger.Warning().Msgf("%s\n", err)
 		}
 	}
 }

--- a/v2/pkg/scan/arp_unix.go
+++ b/v2/pkg/scan/arp_unix.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 // ArpRequestAsync asynchronous to the target ip address
-func arpRequestAsync(s *Scanner, ip string) {
+func arpRequestAsync(ip string) {
 	networkInterface, _, sourceIP, err := pkgRouter.Route(net.ParseIP(ip))
 	if networkInterface == nil {
 		err = errors.New("Could not send ARP Request packet to " + ip + ": no interface with outbound source found")

--- a/v2/pkg/scan/arp_unix.go
+++ b/v2/pkg/scan/arp_unix.go
@@ -12,12 +12,12 @@ import (
 )
 
 func init() {
-	arpRequestAsyncCallback = ArpRequestAsync
+	ArpRequestAsync = arpRequestAsync
 }
 
 // ArpRequestAsync asynchronous to the target ip address
-func ArpRequestAsync(s *Scanner, ip string) {
-	networkInterface, _, sourceIP, err := router.Route(net.ParseIP(ip))
+func arpRequestAsync(s *Scanner, ip string) {
+	networkInterface, _, sourceIP, err := pkgRouter.Route(net.ParseIP(ip))
 	if networkInterface == nil {
 		err = errors.New("Could not send ARP Request packet to " + ip + ": no interface with outbound source found")
 	}

--- a/v2/pkg/scan/arp_win.go
+++ b/v2/pkg/scan/arp_win.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package scan
+
+func init() {
+	ArpRequestAsync = func(s *Scanner, ip string) {}
+}

--- a/v2/pkg/scan/arp_win.go
+++ b/v2/pkg/scan/arp_win.go
@@ -3,5 +3,5 @@
 package scan
 
 func init() {
-	ArpRequestAsync = func(s *Scanner, ip string) {}
+	ArpRequestAsync = func(ip string) {}
 }

--- a/v2/pkg/scan/icmp.go
+++ b/v2/pkg/scan/icmp.go
@@ -24,11 +24,7 @@ const (
 
 func init() {
 	pingIcmpEchoRequestCallback = PingIcmpEchoRequest
-	pingIcmpEchoRequestAsyncCallback = PingIcmpEchoRequestAsync
 	pingIcmpTimestampRequestCallback = PingIcmpTimestampRequest
-	pingIcmpTimestampRequestAsyncCallback = PingIcmpTimestampRequestAsync
-	pingIcmpAddressMaskRequestAsyncCallback = PingIcmpAddressMaskRequestAsync
-	pingNdpRequestAsyncCallback = PingNdpRequestAsync
 }
 
 // PingIcmpEchoRequest synchronous to the target ip address
@@ -78,7 +74,7 @@ func PingIcmpEchoRequest(ip string, timeout time.Duration) bool {
 }
 
 // PingIcmpEchoRequestAsync asynchronous to the target ip address
-func PingIcmpEchoRequestAsync(s *Scanner, ip string) {
+func PingIcmpEchoRequestAsync(ip string) {
 	destinationIP := net.ParseIP(ip)
 	var destAddr net.Addr
 	m := icmp.Message{
@@ -177,7 +173,7 @@ func PingIcmpTimestampRequest(ip string, timeout time.Duration) bool {
 }
 
 // PingIcmpTimestampRequestAsync synchronous to the target ip address - ipv4 only
-func PingIcmpTimestampRequestAsync(s *Scanner, ip string) {
+func PingIcmpTimestampRequestAsync(ip string) {
 	if !iputil.IsIPv4(ip) {
 		return
 	}
@@ -264,7 +260,7 @@ func ParseTimestamp(_ int, b []byte) (icmp.MessageBody, error) {
 }
 
 // PingIcmpAddressMaskRequestAsync asynchronous to the target ip address - ipv4 only
-func PingIcmpAddressMaskRequestAsync(s *Scanner, ip string) {
+func PingIcmpAddressMaskRequestAsync(ip string) {
 	if !iputil.IsIPv4(ip) {
 		return
 	}

--- a/v2/pkg/scan/icmp.go
+++ b/v2/pkg/scan/icmp.go
@@ -94,12 +94,12 @@ func PingIcmpEchoRequestAsync(s *Scanner, ip string) {
 	switch {
 	case iputil.IsIPv4(ip):
 		m.Type = ipv4.ICMPTypeEcho
-		packetListener = s.icmpPacketListener4
+		packetListener = icmpConn4
 		destAddr = &net.IPAddr{IP: destinationIP}
 	case iputil.IsIPv6(ip):
 		m.Type = ipv6.ICMPTypeEchoRequest
-		packetListener = s.icmpPacketListener6
-		networkInterface, _, _, err := s.Router.Route(destinationIP)
+		packetListener = icmpConn6
+		networkInterface, _, _, err := router.Route(destinationIP)
 		if networkInterface == nil {
 			err = fmt.Errorf("could not send ICMP Echo Request packet to %s: no interface with outbout source ipv6 found", destinationIP)
 		}
@@ -197,7 +197,7 @@ func PingIcmpTimestampRequestAsync(s *Scanner, ip string) {
 		return
 	}
 
-	_, err = s.icmpPacketListener4.WriteTo(data, destAddr)
+	_, err = icmpConn4.WriteTo(data, destAddr)
 	if err != nil {
 		return
 	}
@@ -288,7 +288,7 @@ send:
 	if retries >= maxRetries {
 		return
 	}
-	_, err = s.icmpPacketListener4.WriteTo(data, destAddr)
+	_, err = icmpConn4.WriteTo(data, destAddr)
 	if err != nil {
 		retries++
 		// introduce a small delay to allow the network interface to flush the queue

--- a/v2/pkg/scan/icmp.go
+++ b/v2/pkg/scan/icmp.go
@@ -99,7 +99,7 @@ func PingIcmpEchoRequestAsync(s *Scanner, ip string) {
 	case iputil.IsIPv6(ip):
 		m.Type = ipv6.ICMPTypeEchoRequest
 		packetListener = icmpConn6
-		networkInterface, _, _, err := router.Route(destinationIP)
+		networkInterface, _, _, err := pkgRouter.Route(destinationIP)
 		if networkInterface == nil {
 			err = fmt.Errorf("could not send ICMP Echo Request packet to %s: no interface with outbout source ipv6 found", destinationIP)
 		}

--- a/v2/pkg/scan/ndp.go
+++ b/v2/pkg/scan/ndp.go
@@ -19,7 +19,7 @@ func init() {
 
 // PingNdpRequestAsync asynchronous to the target ip address
 func PingNdpRequestAsync(s *Scanner, ip string) {
-	networkInterface, _, _, err := router.Route(net.ParseIP(ip))
+	networkInterface, _, _, err := pkgRouter.Route(net.ParseIP(ip))
 	if networkInterface == nil {
 		err = errors.New("Could not send PingNdp Request packet to " + ip + ": no interface with outbound source found")
 	}

--- a/v2/pkg/scan/ndp.go
+++ b/v2/pkg/scan/ndp.go
@@ -19,7 +19,7 @@ func init() {
 
 // PingNdpRequestAsync asynchronous to the target ip address
 func PingNdpRequestAsync(s *Scanner, ip string) {
-	networkInterface, _, _, err := s.Router.Route(net.ParseIP(ip))
+	networkInterface, _, _, err := router.Route(net.ParseIP(ip))
 	if networkInterface == nil {
 		err = errors.New("Could not send PingNdp Request packet to " + ip + ": no interface with outbound source found")
 	}
@@ -47,7 +47,7 @@ send:
 	if retries >= maxRetries {
 		return
 	}
-	_, err = s.icmpPacketListener6.WriteTo(data, destAddr)
+	_, err = icmpConn6.WriteTo(data, destAddr)
 	if err != nil {
 		retries++
 		// introduce a small delay to allow the network interface to flush the queue

--- a/v2/pkg/scan/ndp.go
+++ b/v2/pkg/scan/ndp.go
@@ -13,12 +13,8 @@ import (
 	"golang.org/x/net/ipv6"
 )
 
-func init() {
-	pingNdpRequestAsyncCallback = PingNdpRequestAsync
-}
-
 // PingNdpRequestAsync asynchronous to the target ip address
-func PingNdpRequestAsync(s *Scanner, ip string) {
+func PingNdpRequestAsync(ip string) {
 	networkInterface, _, _, err := pkgRouter.Route(net.ParseIP(ip))
 	if networkInterface == nil {
 		err = errors.New("Could not send PingNdp Request packet to " + ip + ": no interface with outbound source found")

--- a/v2/pkg/scan/option.go
+++ b/v2/pkg/scan/option.go
@@ -10,7 +10,6 @@ type Options struct {
 	Retries       int
 	Rate          int
 	PortThreshold int
-	Debug         bool
 	ExcludeCdn    bool
 	OutputCdn     bool
 	ExcludedIps   []string

--- a/v2/pkg/scan/option.go
+++ b/v2/pkg/scan/option.go
@@ -2,6 +2,8 @@ package scan
 
 import (
 	"time"
+
+	"github.com/projectdiscovery/naabu/v2/pkg/result"
 )
 
 // Options of the scan
@@ -16,4 +18,5 @@ type Options struct {
 	Proxy         string
 	ProxyAuth     string
 	Stream        bool
+	OnReceive     result.ResultFn
 }

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -90,7 +90,6 @@ type Scanner struct {
 	NetworkInterface     *net.Interface
 	cdn                  *cdncheck.Client
 	tcpsequencer         *TCPSequencer
-	debug                bool
 	stream               bool
 	ListenHandler        *ListenHandler
 }
@@ -136,7 +135,6 @@ func NewScanner(options *Options) (*Scanner, error) {
 		retries:       options.Retries,
 		rate:          options.Rate,
 		portThreshold: options.PortThreshold,
-		debug:         options.Debug,
 		tcpsequencer:  NewTCPSequencer(),
 		IPRanger:      iprang,
 	}

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -259,6 +259,13 @@ func (s *Scanner) TCPResultWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case ip := <-s.ListenHandler.TcpChan:
+			srcIP4WithPort := net.JoinHostPort(ip.ipv4, ip.port.String())
+			srcIP6WithPort := net.JoinHostPort(ip.ipv6, ip.port.String())
+			isIPInRange := s.IPRanger.ContainsAny(srcIP4WithPort, srcIP6WithPort, ip.ipv4, ip.ipv6)
+			if !isIPInRange {
+				gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s\n", ip.ipv4, ip.ipv6)
+			}
+
 			if s.OnReceive != nil {
 				singlePort := []*port.Port{ip.port}
 				if ip.ipv4 != "" {

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -273,7 +273,7 @@ func (s *Scanner) UDPReadWorker6() {
 
 // TCPReadWorkerPCAP reads and parse incoming TCP packets with pcap
 func (s *Scanner) TCPReadWorkerPCAP() {
-	TransportReadWorkerPCAPUnix(s)
+	TransportReadWorkerPCAP(s)
 }
 
 // EnqueueICMP outgoing ICMP packets
@@ -588,8 +588,8 @@ func (s *Scanner) ACKPort(dstIP string, port int, timeout time.Duration) (bool, 
 
 	if s.SourceIP4 != nil {
 		ip4.SrcIP = s.SourceIP4
-	} else if router != nil {
-		_, _, sourceIP, err := router.Route(ip4.DstIP)
+	} else if pkgRouter != nil {
+		_, _, sourceIP, err := pkgRouter.Route(ip4.DstIP)
 		if err != nil {
 			return false, err
 		}
@@ -691,7 +691,7 @@ func (s *Scanner) sendAsyncTCP4(ip string, p *port.Port, pkgFlag PkgFlag) {
 	if s.SourceIP4 != nil {
 		ip4.SrcIP = s.SourceIP4
 	} else {
-		_, _, sourceIP, err := router.Route(ip4.DstIP)
+		_, _, sourceIP, err := pkgRouter.Route(ip4.DstIP)
 		if err != nil {
 			gologger.Debug().Msgf("could not find route to host %s:%d: %s\n", ip, p.Port, err)
 			return
@@ -748,7 +748,7 @@ func (s *Scanner) sendAsyncUDP4(ip string, p *port.Port, pkgFlag PkgFlag) {
 	if s.SourceIP4 != nil {
 		ip4.SrcIP = s.SourceIP4
 	} else {
-		_, _, sourceIP, err := router.Route(ip4.DstIP)
+		_, _, sourceIP, err := pkgRouter.Route(ip4.DstIP)
 		if err != nil {
 			gologger.Debug().Msgf("could not find route to host %s:%d: %s\n", ip, p.Port, err)
 			return
@@ -791,7 +791,7 @@ func (s *Scanner) sendAsyncTCP6(ip string, p *port.Port, pkgFlag PkgFlag) {
 	if s.SourceIP6 != nil {
 		ip6.SrcIP = s.SourceIP6
 	} else {
-		_, _, sourceIP, err := router.Route(ip6.DstIP)
+		_, _, sourceIP, err := pkgRouter.Route(ip6.DstIP)
 		if err != nil {
 			gologger.Debug().Msgf("could not find route to host %s:%d: %s\n", ip, p.Port, err)
 			return
@@ -849,7 +849,7 @@ func (s *Scanner) sendAsyncUDP6(ip string, p *port.Port, pkgFlag PkgFlag) {
 	if s.SourceIP6 != nil {
 		ip6.SrcIP = s.SourceIP6
 	} else {
-		_, _, sourceIP, err := router.Route(ip6.DstIP)
+		_, _, sourceIP, err := pkgRouter.Route(ip6.DstIP)
 		if err != nil {
 			gologger.Debug().Msgf("could not find route to host %s:%d: %s\n", ip, p.Port, err)
 			return

--- a/v2/pkg/scan/scan_common.go
+++ b/v2/pkg/scan/scan_common.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	IPV4 = "4"
+	IPv4 = "4"
 	IPv6 = "6"
 )
 

--- a/v2/pkg/scan/scan_common.go
+++ b/v2/pkg/scan/scan_common.go
@@ -9,6 +9,11 @@ import (
 	"golang.org/x/net/icmp"
 )
 
+const (
+	IPV4 = "4"
+	IPv6 = "6"
+)
+
 var (
 	ListenHandlers                                          []*ListenHandler
 	NetworkInterface                                        string

--- a/v2/pkg/scan/scan_common.go
+++ b/v2/pkg/scan/scan_common.go
@@ -2,12 +2,14 @@ package scan
 
 import (
 	"net"
+	"sync"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/routing"
 	"golang.org/x/net/icmp"
 )
 
 var (
+	Busy                                                    sync.Mutex
 	NetworkInterface                                        string
 	tcpChan, udpChan, hostDiscoveryChan                     chan *PkgResult
 	tcpConn4, udpConn4, tcpConn6, udpConn6                  *net.IPConn

--- a/v2/pkg/scan/scan_common.go
+++ b/v2/pkg/scan/scan_common.go
@@ -2,26 +2,33 @@ package scan
 
 import (
 	"net"
-	"sync"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/routing"
 	"golang.org/x/net/icmp"
 )
 
 var (
-	Busy                                                    sync.Mutex
+	ListenHandlers                                          []*ListenHandler
 	NetworkInterface                                        string
-	tcpChan, udpChan, hostDiscoveryChan                     chan *PkgResult
-	tcpConn4, udpConn4, tcpConn6, udpConn6                  *net.IPConn
+	networkInterface                                        *net.Interface
 	transportPacketSend, icmpPacketSend, ethernetPacketSend chan *PkgSend
 	icmpConn4, icmpConn6                                    *icmp.PacketConn
 
-	pkgRouter  routing.Router
-	ListenPort int
+	pkgRouter routing.Router
 
-	TransportReadWorkerPCAP func(s *Scanner)
-	ArpRequestAsync         func(s *Scanner, ip string)
+	ArpRequestAsync  func(ip string)
+	InitScanner      func(s *Scanner) error
+	NumberOfHandlers = 1
+	tcpsequencer     = NewTCPSequencer()
 )
+
+type ListenHandler struct {
+	Busy                                   bool
+	Phase                                  Phase
+	Port                                   int
+	TcpConn4, UdpConn4, TcpConn6, UdpConn6 *net.IPConn
+	TcpChan, UdpChan, HostDiscoveryChan    chan *PkgResult
+}
 
 func init() {
 	if r, err := routing.New(); err != nil {

--- a/v2/pkg/scan/scan_common.go
+++ b/v2/pkg/scan/scan_common.go
@@ -1,0 +1,30 @@
+package scan
+
+import (
+	"net"
+
+	"github.com/projectdiscovery/naabu/v2/pkg/routing"
+	"golang.org/x/net/icmp"
+)
+
+var (
+	NetworkInterface                                        string
+	tcpChan, udpChan, hostDiscoveryChan                     chan *PkgResult
+	tcpConn4, udpConn4, tcpConn6, udpConn6                  *net.IPConn
+	transportPacketSend, icmpPacketSend, ethernetPacketSend chan *PkgSend
+	icmpConn4, icmpConn6                                    *icmp.PacketConn
+
+	pkgRouter  routing.Router
+	ListenPort int
+
+	TransportReadWorkerPCAP func(s *Scanner)
+	ArpRequestAsync         func(s *Scanner, ip string)
+)
+
+func init() {
+	if r, err := routing.New(); err != nil {
+		panic(err)
+	} else {
+		pkgRouter = r
+	}
+}

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -212,7 +212,7 @@ func sendAsyncTCP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		err = send(ip, listenHandler.TcpConn4, &tcp)
 		if err != nil {
 			// if s.debug {
-			// 	gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
+			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 			// }
 		}
 	}
@@ -250,7 +250,7 @@ func sendAsyncUDP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		err = send(ip, listenHandler.UdpConn4, &udp)
 		if err != nil {
 			// if s.debug {
-			// 	gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
+			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 			// }
 		}
 	}
@@ -304,7 +304,7 @@ func sendAsyncTCP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		err = send(ip, listenHandler.TcpConn6, &tcp)
 		if err != nil {
 			// if s.debug {
-			// 	gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
+			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 			// }
 		}
 	}
@@ -343,7 +343,7 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		err = send(ip, listenHandler.UdpConn6, &udp)
 		if err != nil {
 			// if s.debug {
-			// 	gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
+			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 			// }
 		}
 	}
@@ -434,27 +434,27 @@ send:
 func (l *ListenHandler) TcpReadWorker4() {
 	data := make([]byte, 4096)
 	for {
-		l.TcpConn4.ReadFrom(data)
+		_, _, _ = l.TcpConn4.ReadFrom(data)
 	}
 }
 
 func (l *ListenHandler) TcpReadWorker6() {
 	data := make([]byte, 4096)
 	for {
-		l.TcpConn6.ReadFrom(data)
+		_, _, _ = l.TcpConn6.ReadFrom(data)
 	}
 }
 
 func (l *ListenHandler) UdpReadWorker4() {
 	data := make([]byte, 4096)
 	for {
-		l.UdpConn4.ReadFrom(data)
+		_, _, _ = l.UdpConn4.ReadFrom(data)
 	}
 }
 func (l *ListenHandler) UdpReadWorker6() {
 	data := make([]byte, 4096)
 	for {
-		l.UdpConn6.ReadFrom(data)
+		_, _, _ = l.UdpConn6.ReadFrom(data)
 	}
 }
 
@@ -869,8 +869,8 @@ func ACKPort(listenHandler *ListenHandler, dstIP string, port int, timeout time.
 				continue
 			} else if tcp.RST {
 				// if s.debug {
-				// 	gologger.Debug().Msgf("Accepting RST packet from %s:%d\n", addr.String(), tcp.DstPort)
-				// 	return true, nil
+				gologger.Debug().Msgf("Accepting RST packet from %s:%d\n", addr.String(), tcp.DstPort)
+				return true, nil
 				// }
 			}
 		}

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -186,7 +186,7 @@ func SetupHandlerUnix(interfaceName, bpfFilter string, protocols ...protocol.Pro
 		default:
 			panic("protocol not supported")
 		}
-		initilizedHandlers.Set(hash, struct{}{})
+		_ = initilizedHandlers.Set(hash, struct{}{})
 	}
 
 	return nil

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -53,7 +53,7 @@ func init() {
 
 	icmpConn6, err = icmp.ListenPacket("ip6:icmp", "::")
 	if err != nil {
-		panic(err)
+		gologger.Error().Msgf("could not setup ip6:icmp: %s", err)
 	}
 
 	icmpPacketSend = make(chan *PkgSend, packetSendSize)
@@ -84,12 +84,12 @@ func init() {
 
 		listenHandler.TcpConn6, err = net.ListenIP("ip6:tcp", &net.IPAddr{IP: net.ParseIP(fmt.Sprintf(":::%d", listenHandler.Port))})
 		if err != nil {
-			panic(err)
+			gologger.Error().Msgf("could not setup ip6:tcp: %s\n", err)
 		}
 
 		listenHandler.UdpConn6, err = net.ListenIP("ip6:udp", &net.IPAddr{IP: net.ParseIP(fmt.Sprintf(":::%d", listenHandler.Port))})
 		if err != nil {
-			panic(err)
+			gologger.Error().Msgf("could not setup ip6:udp: %s\n", err)
 		}
 
 		go listenHandler.ICMPReadWorker4()
@@ -353,6 +353,9 @@ func (l *ListenHandler) ICMPReadWorker4() {
 
 // ICMPReadWorker6 reads packets from the network layer
 func (l *ListenHandler) ICMPReadWorker6() {
+	if icmpConn6 == nil {
+		return
+	}
 	data := make([]byte, 1500)
 	for {
 		n, addr, err := icmpConn6.ReadFrom(data)
@@ -420,6 +423,9 @@ func (l *ListenHandler) TcpReadWorker4() {
 }
 
 func (l *ListenHandler) TcpReadWorker6() {
+	if l.TcpConn6 == nil {
+		return
+	}
 	data := make([]byte, 4096)
 	for {
 		_, _, _ = l.TcpConn6.ReadFrom(data)
@@ -433,6 +439,9 @@ func (l *ListenHandler) UdpReadWorker4() {
 	}
 }
 func (l *ListenHandler) UdpReadWorker6() {
+	if l.UdpConn6 == nil {
+		return
+	}
 	data := make([]byte, 4096)
 	for {
 		_, _, _ = l.UdpConn6.ReadFrom(data)

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -19,7 +19,13 @@ import (
 	"github.com/projectdiscovery/naabu/v2/pkg/port"
 	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
 	"github.com/projectdiscovery/naabu/v2/pkg/routing"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	"golang.org/x/net/icmp"
+)
+
+var (
+	initilizedHandlers = mapsutil.NewSyncLockMap[string, struct{}]()
+	onceReadWorker     = sync.Once{}
 )
 
 func init() {
@@ -27,6 +33,8 @@ func init() {
 	setupHandlerCallback = SetupHandlerUnix
 	tcpReadWorkerPCAPCallback = TransportReadWorkerPCAPUnix
 	cleanupHandlersCallback = CleanupHandlersUnix
+
+	handlers = &Handlers{}
 }
 
 // Handlers contains the list of pcap handlers
@@ -80,9 +88,6 @@ func NewScannerUnix(scanner *Scanner) error {
 	}
 	scanner.udpPacketListener6 = udpConn6
 
-	var handlers Handlers
-	scanner.handlers = handlers
-
 	scanner.tcpChan = make(chan *PkgResult, chanSize)
 	scanner.udpChan = make(chan *PkgResult, chanSize)
 	scanner.transportPacketSend = make(chan *PkgSend, packetSendSize)
@@ -108,9 +113,17 @@ func NewScannerUnix(scanner *Scanner) error {
 	return err
 }
 
+func InterfaceProtoHash(interfaceName string, proto protocol.Protocol) string {
+	return fmt.Sprintf("%s-%s", interfaceName, proto.String())
+}
+
 // SetupHandlerUnix on unix OS
-func SetupHandlerUnix(s *Scanner, interfaceName, bpfFilter string, protocols ...protocol.Protocol) error {
+func SetupHandlerUnix(interfaceName, bpfFilter string, protocols ...protocol.Protocol) error {
 	for _, proto := range protocols {
+		hash := InterfaceProtoHash(interfaceName, proto)
+		if initilizedHandlers.Has(hash) {
+			continue
+		}
 		inactive, err := pcap.NewInactiveHandle(interfaceName)
 		if err != nil {
 			return err
@@ -123,7 +136,7 @@ func SetupHandlerUnix(s *Scanner, interfaceName, bpfFilter string, protocols ...
 
 		readTimeout := time.Duration(readtimeout) * time.Millisecond
 		if err = inactive.SetTimeout(readTimeout); err != nil {
-			s.CleanupHandlers()
+			CleanupHandlersUnix()
 			return err
 		}
 		err = inactive.SetImmediateMode(true)
@@ -131,7 +144,7 @@ func SetupHandlerUnix(s *Scanner, interfaceName, bpfFilter string, protocols ...
 			return err
 		}
 
-		handlers, ok := s.handlers.(Handlers)
+		handlers, ok := handlers.(*Handlers)
 		if !ok {
 			return errors.New("couldn't create handlers")
 		}
@@ -147,7 +160,7 @@ func SetupHandlerUnix(s *Scanner, interfaceName, bpfFilter string, protocols ...
 
 		handle, err := inactive.Activate()
 		if err != nil {
-			s.CleanupHandlers()
+			CleanupHandlersUnix()
 			return err
 		}
 
@@ -173,7 +186,7 @@ func SetupHandlerUnix(s *Scanner, interfaceName, bpfFilter string, protocols ...
 		default:
 			panic("protocol not supported")
 		}
-		s.handlers = handlers
+		initilizedHandlers.Set(hash, struct{}{})
 	}
 
 	return nil
@@ -181,241 +194,241 @@ func SetupHandlerUnix(s *Scanner, interfaceName, bpfFilter string, protocols ...
 
 // TransportReadWorkerPCAPUnix for TCP and UDP
 func TransportReadWorkerPCAPUnix(s *Scanner) {
-	defer s.CleanupHandlers()
+	onceReadWorker.Do(func() {
+		var wgread sync.WaitGroup
 
-	var wgread sync.WaitGroup
-
-	handlers, ok := s.handlers.(Handlers)
-	if !ok {
-		return
-	}
-
-	transportReaderCallback := func(tcp layers.TCP, udp layers.UDP, ip, srcIP4, srcIP6 string) {
-		// We consider only incoming packets
-		tcpPortMatches := tcp.DstPort == layers.TCPPort(s.SourcePort)
-		udpPortMatches := udp.DstPort == layers.UDPPort(s.SourcePort)
-		sourcePortMatches := tcpPortMatches || udpPortMatches
-		switch {
-		case !sourcePortMatches:
-			gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s tcp_dport=%d udp_dport=%d\n", srcIP4, srcIP6, tcp.DstPort, udp.DstPort)
-
-		case s.Phase.Is(HostDiscovery):
-			proto := protocol.TCP
-			if udpPortMatches {
-				proto = protocol.UDP
-			}
-			s.hostDiscoveryChan <- &PkgResult{ip: ip, port: &port.Port{Port: int(tcp.SrcPort), Protocol: proto}}
-		case tcpPortMatches && tcp.SYN && tcp.ACK:
-			s.tcpChan <- &PkgResult{ip: ip, port: &port.Port{Port: int(tcp.SrcPort), Protocol: protocol.TCP}}
-		case udpPortMatches && udp.Length > 0: // needs a better matching of udp payloads
-			s.udpChan <- &PkgResult{ip: ip, port: &port.Port{Port: int(udp.SrcPort), Protocol: protocol.UDP}}
+		handlers, ok := handlers.(*Handlers)
+		if !ok {
+			return
 		}
-	}
 
-	// In case of OSX, when we decode the data from 'loO' interface
-	// always get [Ethernet] layer only.
-	// with the help of data received from packetSource.Packets() we can
-	// extract the high level layers like [IPv4, IPv6, TCP, UDP]
-	loopBackScanCaseCallback := func(handler *pcap.Handle, wg *sync.WaitGroup) {
-		defer wg.Done()
-		packetSource := gopacket.NewPacketSource(handler, handler.LinkType())
-		for packet := range packetSource.Packets() {
-			tcp := &layers.TCP{}
-			udp := &layers.UDP{}
-			for _, layerType := range packet.Layers() {
-				ipLayer := packet.Layer(layers.LayerTypeIPv4)
-				if ipLayer == nil {
-					ipLayer = packet.Layer(layers.LayerTypeIPv6)
+		transportReaderCallback := func(tcp layers.TCP, udp layers.UDP, ip, srcIP4, srcIP6 string) {
+			// We consider only incoming packets
+			tcpPortMatches := tcp.DstPort == layers.TCPPort(s.SourcePort)
+			udpPortMatches := udp.DstPort == layers.UDPPort(s.SourcePort)
+			sourcePortMatches := tcpPortMatches || udpPortMatches
+			switch {
+			case !sourcePortMatches:
+				gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s tcp_dport=%d udp_dport=%d\n", srcIP4, srcIP6, tcp.DstPort, udp.DstPort)
+
+			case s.Phase.Is(HostDiscovery):
+				proto := protocol.TCP
+				if udpPortMatches {
+					proto = protocol.UDP
+				}
+				s.hostDiscoveryChan <- &PkgResult{ip: ip, port: &port.Port{Port: int(tcp.SrcPort), Protocol: proto}}
+			case tcpPortMatches && tcp.SYN && tcp.ACK:
+				s.tcpChan <- &PkgResult{ip: ip, port: &port.Port{Port: int(tcp.SrcPort), Protocol: protocol.TCP}}
+			case udpPortMatches && udp.Length > 0: // needs a better matching of udp payloads
+				s.udpChan <- &PkgResult{ip: ip, port: &port.Port{Port: int(udp.SrcPort), Protocol: protocol.UDP}}
+			}
+		}
+
+		// In case of OSX, when we decode the data from 'loO' interface
+		// always get [Ethernet] layer only.
+		// with the help of data received from packetSource.Packets() we can
+		// extract the high level layers like [IPv4, IPv6, TCP, UDP]
+		loopBackScanCaseCallback := func(handler *pcap.Handle, wg *sync.WaitGroup) {
+			defer wg.Done()
+			packetSource := gopacket.NewPacketSource(handler, handler.LinkType())
+			for packet := range packetSource.Packets() {
+				tcp := &layers.TCP{}
+				udp := &layers.UDP{}
+				for _, layerType := range packet.Layers() {
+					ipLayer := packet.Layer(layers.LayerTypeIPv4)
 					if ipLayer == nil {
-						continue
+						ipLayer = packet.Layer(layers.LayerTypeIPv6)
+						if ipLayer == nil {
+							continue
+						}
 					}
-				}
-				var srcIP4, srcIP6 string
-				if ipv4, ok := ipLayer.(*layers.IPv4); ok {
-					srcIP4 = ipv4.SrcIP.String()
-				} else if ipv6, ok := ipLayer.(*layers.IPv6); ok {
-					srcIP6 = ipv6.SrcIP.String()
-				}
+					var srcIP4, srcIP6 string
+					if ipv4, ok := ipLayer.(*layers.IPv4); ok {
+						srcIP4 = ipv4.SrcIP.String()
+					} else if ipv6, ok := ipLayer.(*layers.IPv6); ok {
+						srcIP6 = ipv6.SrcIP.String()
+					}
 
-				tcpLayer := packet.Layer(layers.LayerTypeTCP)
-				if tcpLayer != nil {
-					tcp, ok = tcpLayer.(*layers.TCP)
-					if !ok {
-						continue
+					tcpLayer := packet.Layer(layers.LayerTypeTCP)
+					if tcpLayer != nil {
+						tcp, ok = tcpLayer.(*layers.TCP)
+						if !ok {
+							continue
+						}
 					}
-				}
-				udpLayer := packet.Layer(layers.LayerTypeUDP)
-				if udpLayer != nil {
-					udp, ok = udpLayer.(*layers.UDP)
-					if !ok {
-						continue
+					udpLayer := packet.Layer(layers.LayerTypeUDP)
+					if udpLayer != nil {
+						udp, ok = udpLayer.(*layers.UDP)
+						if !ok {
+							continue
+						}
 					}
-				}
 
-				if layerType.LayerType() == layers.LayerTypeTCP || layerType.LayerType() == layers.LayerTypeUDP {
-					srcPort := fmt.Sprint(int(tcp.SrcPort))
-					srcIP4WithPort := net.JoinHostPort(srcIP4, srcPort)
-					isIP4InRange := s.IPRanger.ContainsAny(srcIP4, srcIP4WithPort)
-					srcIP6WithPort := net.JoinHostPort(srcIP6, srcPort)
-					isIP6InRange := s.IPRanger.ContainsAny(srcIP6, srcIP6WithPort)
-					var ip string
-					if isIP4InRange {
-						ip = srcIP4
-					} else if isIP6InRange {
-						ip = srcIP6
-					} else {
-						gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s\n", srcIP4, srcIP6)
+					if layerType.LayerType() == layers.LayerTypeTCP || layerType.LayerType() == layers.LayerTypeUDP {
+						srcPort := fmt.Sprint(int(tcp.SrcPort))
+						srcIP4WithPort := net.JoinHostPort(srcIP4, srcPort)
+						isIP4InRange := s.IPRanger.ContainsAny(srcIP4, srcIP4WithPort)
+						srcIP6WithPort := net.JoinHostPort(srcIP6, srcPort)
+						isIP6InRange := s.IPRanger.ContainsAny(srcIP6, srcIP6WithPort)
+						var ip string
+						if isIP4InRange {
+							ip = srcIP4
+						} else if isIP6InRange {
+							ip = srcIP6
+						} else {
+							gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s\n", srcIP4, srcIP6)
+						}
+						transportReaderCallback(*tcp, *udp, ip, srcIP4, srcIP6)
 					}
-					transportReaderCallback(*tcp, *udp, ip, srcIP4, srcIP6)
 				}
 			}
 		}
-	}
 
-	// Loopback Readers
-	for _, handler := range handlers.LoopbackHandlers {
-		wgread.Add(1)
-		go loopBackScanCaseCallback(handler, &wgread)
-	}
+		// Loopback Readers
+		for _, handler := range handlers.LoopbackHandlers {
+			wgread.Add(1)
+			go loopBackScanCaseCallback(handler, &wgread)
+		}
 
-	// Transport Readers (TCP|UDP)
-	for _, handler := range handlers.TransportActive {
-		wgread.Add(1)
-		go func(handler *pcap.Handle) {
-			defer wgread.Done()
+		// Transport Readers (TCP|UDP)
+		for _, handler := range handlers.TransportActive {
+			wgread.Add(1)
+			go func(handler *pcap.Handle) {
+				defer wgread.Done()
 
-			var (
-				eth layers.Ethernet
-				ip4 layers.IPv4
-				ip6 layers.IPv6
-				tcp layers.TCP
-				udp layers.UDP
-			)
+				var (
+					eth layers.Ethernet
+					ip4 layers.IPv4
+					ip6 layers.IPv6
+					tcp layers.TCP
+					udp layers.UDP
+				)
 
-			// Interfaces with MAC (Physical + Virtualized)
-			parser4Mac := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &eth, &ip4, &tcp, &udp)
-			parser6Mac := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &eth, &ip6, &tcp, &udp)
-			// Interfaces without MAC (TUN/TAP)
-			parser4NoMac := gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &ip4, &tcp, &udp)
-			parser6NoMac := gopacket.NewDecodingLayerParser(layers.LayerTypeIPv6, &ip6, &tcp, &udp)
+				// Interfaces with MAC (Physical + Virtualized)
+				parser4Mac := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &eth, &ip4, &tcp, &udp)
+				parser6Mac := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &eth, &ip6, &tcp, &udp)
+				// Interfaces without MAC (TUN/TAP)
+				parser4NoMac := gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &ip4, &tcp, &udp)
+				parser6NoMac := gopacket.NewDecodingLayerParser(layers.LayerTypeIPv6, &ip6, &tcp, &udp)
 
-			var parsers []*gopacket.DecodingLayerParser
-			parsers = append(parsers,
-				parser4Mac, parser6Mac,
-				parser4NoMac, parser6NoMac,
-			)
+				var parsers []*gopacket.DecodingLayerParser
+				parsers = append(parsers,
+					parser4Mac, parser6Mac,
+					parser4NoMac, parser6NoMac,
+				)
 
-			decoded := []gopacket.LayerType{}
+				decoded := []gopacket.LayerType{}
 
-			for {
-				data, _, err := handler.ReadPacketData()
-				if err == io.EOF {
-					break
-				} else if err != nil {
-					continue
-				}
-
-				for _, parser := range parsers {
-					err := parser.DecodeLayers(data, &decoded)
-					if err != nil {
+				for {
+					data, _, err := handler.ReadPacketData()
+					if err == io.EOF {
+						break
+					} else if err != nil {
 						continue
 					}
-					for _, layerType := range decoded {
-						if layerType == layers.LayerTypeTCP || layerType == layers.LayerTypeUDP {
-							srcPort := fmt.Sprint(int(tcp.SrcPort))
-							srcIP4 := ip4.SrcIP.String()
-							srcIP4WithPort := net.JoinHostPort(srcIP4, srcPort)
-							isIP4InRange := s.IPRanger.ContainsAny(srcIP4, srcIP4WithPort)
-							srcIP6 := ip6.SrcIP.String()
-							srcIP6WithPort := net.JoinHostPort(srcIP6, srcPort)
-							isIP6InRange := s.IPRanger.ContainsAny(srcIP6, srcIP6WithPort)
-							var ip string
-							if isIP4InRange {
-								ip = srcIP4
-							} else if isIP6InRange {
-								ip = srcIP6
-							} else {
-								gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s\n", srcIP4, srcIP6)
-								continue
+
+					for _, parser := range parsers {
+						err := parser.DecodeLayers(data, &decoded)
+						if err != nil {
+							continue
+						}
+						for _, layerType := range decoded {
+							if layerType == layers.LayerTypeTCP || layerType == layers.LayerTypeUDP {
+								srcPort := fmt.Sprint(int(tcp.SrcPort))
+								srcIP4 := ip4.SrcIP.String()
+								srcIP4WithPort := net.JoinHostPort(srcIP4, srcPort)
+								isIP4InRange := s.IPRanger.ContainsAny(srcIP4, srcIP4WithPort)
+								srcIP6 := ip6.SrcIP.String()
+								srcIP6WithPort := net.JoinHostPort(srcIP6, srcPort)
+								isIP6InRange := s.IPRanger.ContainsAny(srcIP6, srcIP6WithPort)
+								var ip string
+								if isIP4InRange {
+									ip = srcIP4
+								} else if isIP6InRange {
+									ip = srcIP6
+								} else {
+									gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s\n", srcIP4, srcIP6)
+									continue
+								}
+								transportReaderCallback(tcp, udp, ip, srcIP4, srcIP6)
 							}
-							transportReaderCallback(tcp, udp, ip, srcIP4, srcIP6)
 						}
 					}
 				}
-			}
-		}(handler)
-	}
+			}(handler)
+		}
 
-	// Ethernet Readers
-	for _, handler := range handlers.EthernetActive {
-		wgread.Add(1)
-		go func(handler *pcap.Handle) {
-			defer wgread.Done()
+		// Ethernet Readers
+		for _, handler := range handlers.EthernetActive {
+			wgread.Add(1)
+			go func(handler *pcap.Handle) {
+				defer wgread.Done()
 
-			var (
-				eth layers.Ethernet
-				arp layers.ARP
-			)
+				var (
+					eth layers.Ethernet
+					arp layers.ARP
+				)
 
-			parser4 := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &eth, &arp)
-			parser4.IgnoreUnsupported = true
-			var parsers []*gopacket.DecodingLayerParser
-			parsers = append(parsers, parser4)
+				parser4 := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &eth, &arp)
+				parser4.IgnoreUnsupported = true
+				var parsers []*gopacket.DecodingLayerParser
+				parsers = append(parsers, parser4)
 
-			decoded := []gopacket.LayerType{}
+				decoded := []gopacket.LayerType{}
 
-			for {
-				data, _, err := handler.ReadPacketData()
-				if err == io.EOF {
-					break
-				} else if err != nil {
-					continue
-				}
-
-				for _, parser := range parsers {
-					err := parser.DecodeLayers(data, &decoded)
-					if err != nil {
+				for {
+					data, _, err := handler.ReadPacketData()
+					if err == io.EOF {
+						break
+					} else if err != nil {
 						continue
 					}
-					for _, layerType := range decoded {
-						if layerType == layers.LayerTypeARP {
-							// check if the packet was sent out
-							isReply := arp.Operation == layers.ARPReply
-							var sourceMacIsInterfaceMac bool
-							if s.NetworkInterface != nil {
-								sourceMacIsInterfaceMac = bytes.Equal([]byte(s.NetworkInterface.HardwareAddr), arp.SourceHwAddress)
-							}
-							isOutgoingPacket := !isReply || sourceMacIsInterfaceMac
-							if isOutgoingPacket {
-								continue
-							}
-							srcIP4 := net.IP(arp.SourceProtAddress)
-							srcMac := net.HardwareAddr(arp.SourceHwAddress)
 
-							isIP4InRange := s.IPRanger.Contains(srcIP4.String())
+					for _, parser := range parsers {
+						err := parser.DecodeLayers(data, &decoded)
+						if err != nil {
+							continue
+						}
+						for _, layerType := range decoded {
+							if layerType == layers.LayerTypeARP {
+								// check if the packet was sent out
+								isReply := arp.Operation == layers.ARPReply
+								var sourceMacIsInterfaceMac bool
+								if s.NetworkInterface != nil {
+									sourceMacIsInterfaceMac = bytes.Equal([]byte(s.NetworkInterface.HardwareAddr), arp.SourceHwAddress)
+								}
+								isOutgoingPacket := !isReply || sourceMacIsInterfaceMac
+								if isOutgoingPacket {
+									continue
+								}
+								srcIP4 := net.IP(arp.SourceProtAddress)
+								srcMac := net.HardwareAddr(arp.SourceHwAddress)
 
-							var ip string
-							if isIP4InRange {
-								ip = srcIP4.String()
-							} else {
-								gologger.Debug().Msgf("Discarding ARP packet from non target ip: ip4=%s mac=%s\n", srcIP4, srcMac)
-								continue
+								isIP4InRange := s.IPRanger.Contains(srcIP4.String())
+
+								var ip string
+								if isIP4InRange {
+									ip = srcIP4.String()
+								} else {
+									gologger.Debug().Msgf("Discarding ARP packet from non target ip: ip4=%s mac=%s\n", srcIP4, srcMac)
+									continue
+								}
+
+								s.hostDiscoveryChan <- &PkgResult{ip: ip}
 							}
-
-							s.hostDiscoveryChan <- &PkgResult{ip: ip}
 						}
 					}
 				}
-			}
-		}(handler)
-	}
+			}(handler)
+		}
 
-	wgread.Wait()
+		wgread.Wait()
+	})
 }
 
 // CleanupHandlers for all interfaces
-func CleanupHandlersUnix(s *Scanner) {
-	if handlers, ok := s.handlers.(Handlers); ok {
+func CleanupHandlersUnix() {
+	if handlers, ok := handlers.(Handlers); ok {
 		allActive := append(handlers.TransportActive, handlers.EthernetActive...)
 		allActive = append(allActive, handlers.LoopbackHandlers...)
 		for _, handler := range allActive {

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -202,15 +202,11 @@ func sendAsyncTCP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 
 	err = tcp.SetNetworkLayerForChecksum(&ip4)
 	if err != nil {
-		// if s.debug {
-		// 	gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
-		// }
+		gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
 	} else {
 		err = send(ip, listenHandler.TcpConn4, &tcp)
 		if err != nil {
-			// if s.debug {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
-			// }
 		}
 	}
 }
@@ -240,15 +236,11 @@ func sendAsyncUDP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 
 	err = udp.SetNetworkLayerForChecksum(&ip4)
 	if err != nil {
-		// if s.debug {
-		// 	gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
-		// }
+		gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
 	} else {
 		err = send(ip, listenHandler.UdpConn4, &udp)
 		if err != nil {
-			// if s.debug {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
-			// }
 		}
 	}
 }
@@ -294,15 +286,11 @@ func sendAsyncTCP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 
 	err = tcp.SetNetworkLayerForChecksum(&ip6)
 	if err != nil {
-		// if s.debug {
-		// 	gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
-		// }
+		gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
 	} else {
 		err = send(ip, listenHandler.TcpConn6, &tcp)
 		if err != nil {
-			// if s.debug {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
-			// }
 		}
 	}
 }
@@ -333,15 +321,11 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 
 	err = udp.SetNetworkLayerForChecksum(&ip6)
 	if err != nil {
-		// if s.debug {
-		// 	gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
-		// }
+		gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
 	} else {
 		err = send(ip, listenHandler.UdpConn6, &udp)
 		if err != nil {
-			// if s.debug {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
-			// }
 		}
 	}
 }
@@ -832,9 +816,7 @@ func ACKPort(listenHandler *ListenHandler, dstIP string, port int, timeout time.
 
 		// not matching ip
 		if addr.String() != dstIP {
-			// if s.debug {
-			// 	gologger.Debug().Msgf("Discarding TCP packet from non target ip %s for %s\n", dstIP, addr.String())
-			// }
+			gologger.Debug().Msgf("Discarding TCP packet from non target ip %s for %s\n", dstIP, addr.String())
 			continue
 		}
 
@@ -846,15 +828,11 @@ func ACKPort(listenHandler *ListenHandler, dstIP string, port int, timeout time.
 			}
 			// We consider only incoming packets
 			if tcp.DstPort != layers.TCPPort(rawPort.Port) {
-				// if s.debug {
-				// 	gologger.Debug().Msgf("Discarding TCP packet from %s:%d not matching %s:%d port\n", addr.String(), tcp.DstPort, dstIP, rawPort.Port)
-				// }
+				gologger.Debug().Msgf("Discarding TCP packet from %s:%d not matching %s:%d port\n", addr.String(), tcp.DstPort, dstIP, rawPort.Port)
 				continue
 			} else if tcp.RST {
-				// if s.debug {
 				gologger.Debug().Msgf("Accepting RST packet from %s:%d\n", addr.String(), tcp.DstPort)
 				return true, nil
-				// }
 			}
 		}
 	}

--- a/v2/pkg/scan/scan_win.go
+++ b/v2/pkg/scan/scan_win.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package scan
+
+func init() {
+	TransportReadWorkerPCAP = func(s *Scanner) {}
+}

--- a/v2/pkg/scan/scan_win.go
+++ b/v2/pkg/scan/scan_win.go
@@ -3,5 +3,5 @@
 package scan
 
 func init() {
-	InitScanner = func(s *Scanner) error { return nil }
+
 }

--- a/v2/pkg/scan/scan_win.go
+++ b/v2/pkg/scan/scan_win.go
@@ -3,5 +3,5 @@
 package scan
 
 func init() {
-	TransportReadWorkerPCAP = func(s *Scanner) {}
+	InitScanner = func(s *Scanner) error { return nil }
 }

--- a/v2/pkg/scan/scan_win.go
+++ b/v2/pkg/scan/scan_win.go
@@ -1,7 +1,3 @@
-//go:build windows
+//go:build windowz
 
 package scan
-
-func init() {
-
-}


### PR DESCRIPTION
This PR implements the following changes:
- Global pcap handler with demultiplexed pre-allocated network worker pool via source port (closes #952 and #937)
- Scan Shutdown via `context` (closes #698 )
- Adding `OnReceive` callback on response from target (partially closes #666 )
- Ipv6 is now optional (closes #914)