### PR TITLE
Upgrade alpine to 3.18.6 for security fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,26 +20,26 @@ updates:
     allow:
       - dependency-name: "github.com/projectdiscovery/*"
 
-#  # Maintain dependencies for docker
-#  - package-ecosystem: "docker"
-#    directory: "/"
-#    schedule:
-#      interval: "weekly"
-#    target-branch: "dev"
-#    commit-message:
-#      prefix: "chore"
-#      include: "scope"
-#    labels:
-#      - "Type: Maintenance"
-#
-#  # Maintain dependencies for GitHub Actions
-#  - package-ecosystem: "github-actions"
-#    directory: "/"
-#    schedule:
-#      interval: "weekly"
-#    target-branch: "dev"
-#    commit-message:
-#      prefix: "chore"
-#      include: "scope"
-#    labels:
-#      - "Type: Maintenance"
+  # Maintain dependencies for docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "Type: Maintenance"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "Type: Maintenance"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@
 version: 2
 updates:
 
-
   # Maintain dependencies for go modules
   - package-ecosystem: "gomod"
     directory: "v2/"
@@ -18,27 +17,29 @@ updates:
       include: "scope"
     labels:
       - "Type: Maintenance"
+    allow:
+      - dependency-name: "github.com/projectdiscovery/*"
 
- # Maintain dependencies for docker
- - package-ecosystem: "docker"
-   directory: "/"
-   schedule:
-     interval: "weekly"
-   target-branch: "dev"
-   commit-message:
-     prefix: "chore"
-     include: "scope"
-   labels:
-     - "Type: Maintenance"
-
- # Maintain dependencies for GitHub Actions
- - package-ecosystem: "github-actions"
-   directory: "/"
-   schedule:
-     interval: "weekly"
-   target-branch: "dev"
-   commit-message:
-     prefix: "chore"
-     include: "scope"
-   labels:
-     - "Type: Maintenance"
+#  # Maintain dependencies for docker
+#  - package-ecosystem: "docker"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#    target-branch: "dev"
+#    commit-message:
+#      prefix: "chore"
+#      include: "scope"
+#    labels:
+#      - "Type: Maintenance"
+#
+#  # Maintain dependencies for GitHub Actions
+#  - package-ecosystem: "github-actions"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#    target-branch: "dev"
+#    commit-message:
+#      prefix: "chore"
+#      include: "scope"
+#    labels:
+#      - "Type: Maintenance"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 RUN go build ./cmd/naabu
 
 # Release
-FROM alpine:3.18.3
+FROM alpine:3.18.6
 RUN apk add nmap libpcap-dev bind-tools ca-certificates nmap-scripts
 COPY --from=builder /app/v2/naabu /usr/local/bin/
 ENTRYPOINT ["naabu"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 RUN go build ./cmd/naabu
 
 # Release
-FROM alpine:3.18.6
+FROM alpine:3.18.3
 RUN apk add nmap libpcap-dev bind-tools ca-certificates nmap-scripts
 COPY --from=builder /app/v2/naabu /usr/local/bin/
 ENTRYPOINT ["naabu"]


### PR DESCRIPTION
The following vulnerabilities are fixed with alpine upgrade from 3.18.3 to 3.18.6:
- https://security.alpinelinux.org/vuln/CVE-2023-2975
- https://security.alpinelinux.org/vuln/CVE-2023-3446
- https://security.alpinelinux.org/vuln/CVE-2023-3817
- https://security.alpinelinux.org/vuln/CVE-2023-5678
- https://security.alpinelinux.org/vuln/CVE-2023-5363