### PR TITLE
fix `-exclude-ports` for `-passive`

### DIFF
--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -420,13 +419,13 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 						return
 					}
 
-					parsedPorts, err := parsePortsList(strings.Trim(strings.Join(strings.Fields(fmt.Sprint(data.Ports)), ","), "[]"))
-					if err != nil {
-						gologger.Warning().Msgf("Couldn't parse ports for %s: %s\n", ip, err)
-						return
+					var passivePorts []*port.Port
+					for _, p := range data.Ports {
+						pp := &port.Port{Port: p, Protocol: protocol.TCP}
+						passivePorts = append(passivePorts, pp)
 					}
 
-					filteredPorts, err := excludePorts(r.options, parsedPorts)
+					filteredPorts, err := excludePorts(r.options, passivePorts)
 					if err != nil {
 						gologger.Warning().Msgf("Couldn't exclude ports for %s: %s\n", ip, err)
 						return

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -12,7 +12,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -419,7 +421,12 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 						return
 					}
 
+					excludePorts := strings.Split(r.options.ExcludePorts, ",")
 					for _, p := range data.Ports {
+						if slices.Contains(excludePorts, strconv.Itoa(p)) {
+							continue
+						}
+
 						pp := &port.Port{Port: p, Protocol: protocol.TCP}
 						if r.scanner.OnReceive != nil {
 							r.scanner.OnReceive(&result.HostResult{IP: ip, Ports: []*port.Port{pp}})


### PR DESCRIPTION
Closes #998.

before:
```console
$ go run . -host hackerone.com -top-ports 1000 -exclude-ports 80,443 -passive -v

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.0 (latest)
[INF] Running PASSIVE scan
hackerone.com:80
hackerone.com:443
hackerone.com:2053
hackerone.com:2082
hackerone.com:2083
hackerone.com:2086
hackerone.com:2087
hackerone.com:2096
hackerone.com:8080
hackerone.com:8443
hackerone.com:8880
[INF] Found 11 ports on host hackerone.com (104.18.36.214)
```

after:
```console
$ go run . -host hackerone.com -top-ports 1000 -exclude-ports 80,443 -passive -v

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.0 (latest)
[INF] Running PASSIVE scan
hackerone.com:2053
hackerone.com:2082
hackerone.com:2083
hackerone.com:2086
hackerone.com:2087
hackerone.com:2096
hackerone.com:8080
hackerone.com:8443
hackerone.com:8880
[INF] Found 9 ports on host hackerone.com (104.18.36.214)
```