### PR TITLE
Adding support for udp payload

### DIFF
--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -58,6 +58,7 @@ type Options struct {
 	ScanAllIPS        bool                // Scan all the ips
 	IPVersion         goflags.StringSlice // IP Version to use while resolving hostnames
 	ScanType          string              // Scan Type
+	ConnectPayload    string              // Payload to use with CONNECT scan types
 	Proxy             string              // Socks5 proxy
 	ProxyAuth         string              // Socks5 proxy authentication (username:password)
 	Resolvers         string              // Resolvers (comma separated or file)
@@ -144,6 +145,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ScanAllIPS, "sa", "scan-all-ips", false, "scan all the IP's associated with DNS record"),
 		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{scan.IPv4}, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
 		flagSet.StringVarP(&options.ScanType, "s", "scan-type", SynScan, "type of port scan (SYN/CONNECT)"),
+		flagSet.StringVarP(&options.ConnectPayload, "cp", "connect-payload", "", "payload to send in CONNECT scans (optional)"),
 		flagSet.StringVar(&options.SourceIP, "source-ip", "", "source ip and port (x.x.x.x:yyy)"),
 		flagSet.BoolVarP(&options.InterfacesList, "il", "interface-list", false, "list available interfaces and public ip"),
 		flagSet.StringVarP(&options.Interface, "i", "interface", "", "network Interface to use for port scan"),

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -334,7 +334,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 			return nil
 		}
 	}
-
+	payload := r.options.ConnectPayload
 	switch {
 	case r.options.Stream && !r.options.Passive: // stream active
 		showNetworkCapabilities(r.options)
@@ -354,7 +354,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 				r.RawSocketEnumeration(ctx, target, port)
 			} else {
 				r.wgscan.Add()
-				go r.handleHostPort(ctx, target, port)
+				go r.handleHostPort(ctx, target, payload, port)
 			}
 			return true
 		}
@@ -547,7 +547,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					r.RawSocketEnumeration(ctx, ip, port)
 				} else {
 					r.wgscan.Add()
-					go r.handleHostPort(ctx, ip, port)
+					go r.handleHostPort(ctx, ip, payload, port)
 				}
 				if r.options.EnableProgressBar {
 					r.stats.IncrementCounter("packets", 1)
@@ -578,7 +578,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					r.RawSocketEnumeration(ctx, ip, &portWithMetadata)
 				} else {
 					r.wgscan.Add()
-					go r.handleHostPort(ctx, ip, &portWithMetadata)
+					go r.handleHostPort(ctx, ip, payload, &portWithMetadata)
 				}
 				if r.options.EnableProgressBar {
 					r.stats.IncrementCounter("packets", 1)
@@ -778,7 +778,7 @@ func (r *Runner) canIScanIfCDN(host string, port *port.Port) bool {
 	return port.Port == 80 || port.Port == 443
 }
 
-func (r *Runner) handleHostPort(ctx context.Context, host string, p *port.Port) {
+func (r *Runner) handleHostPort(ctx context.Context, host, payload string, p *port.Port) {
 	defer r.wgscan.Done()
 
 	select {
@@ -796,7 +796,7 @@ func (r *Runner) handleHostPort(ctx context.Context, host string, p *port.Port) 
 		}
 
 		r.limiter.Take()
-		open, err := r.scanner.ConnectPort(host, p, time.Duration(r.options.Timeout)*time.Millisecond)
+		open, err := r.scanner.ConnectPort(host, payload, p, time.Duration(r.options.Timeout)*time.Millisecond)
 		if open && err == nil {
 			r.scanner.ScanResults.AddPort(host, p)
 			if r.scanner.OnReceive != nil {

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -139,6 +139,10 @@ func (options *Options) ValidateOptions() error {
 		options.ScanType = ConnectScan
 	}
 
+	if options.ConnectPayload != "" && options.ScanType != ConnectScan {
+		return errors.New("connect payload can only be used with connect scan")
+	}
+
 	return nil
 }
 

--- a/v2/pkg/runner/validate_test.go
+++ b/v2/pkg/runner/validate_test.go
@@ -19,4 +19,9 @@ func TestOptions(t *testing.T) {
 
 	options.Resolvers = "aaabbbccc"
 	assert.NotNil(t, options.ValidateOptions())
+
+	options.Rate = 2
+	options.ConnectPayload = "aabbcc"
+	options.ScanType = SynScan
+	assert.EqualError(t, options.ValidateOptions(), "connect payload can only be used with connect scan")
 }

--- a/v2/pkg/scan/scan.go
+++ b/v2/pkg/scan/scan.go
@@ -364,7 +364,7 @@ func GetInterfaceFromIP(ip net.IP) (*net.Interface, error) {
 }
 
 // ConnectPort a single host and port
-func (s *Scanner) ConnectPort(host string, p *port.Port, timeout time.Duration) (bool, error) {
+func (s *Scanner) ConnectPort(host, payload string, p *port.Port, timeout time.Duration) (bool, error) {
 	hostport := net.JoinHostPort(host, fmt.Sprint(p.Port))
 	var (
 		err  error
@@ -395,7 +395,7 @@ func (s *Scanner) ConnectPort(host string, p *port.Port, timeout time.Duration) 
 		if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
 			return false, err
 		}
-		if _, err := conn.Write(nil); err != nil {
+		if _, err := conn.Write([]byte(payload)); err != nil {
 			return false, err
 		}
 		if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {


### PR DESCRIPTION
Most UDP services do not reply to empty requests. This PR adds a flag to include the data to write to the connection.

Partial solution to this issue: https://github.com/projectdiscovery/naabu/issues/462