### PR TITLE
Automatically skip redundant host discovery

### DIFF
--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -65,7 +65,13 @@ type Target struct {
 func NewRunner(options *Options) (*Runner, error) {
 	options.configureOutput()
 
-	options.configureHostDiscovery()
+	// automatically disable host discovery when less than two ports for scan are provided
+	ports, err := ParsePorts(options)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse ports: %s", err)
+	}
+
+	options.configureHostDiscovery(ports)
 
 	// default to ipv4 if no ipversion was specified
 	if len(options.IPVersion) == 0 {
@@ -131,10 +137,7 @@ func NewRunner(options *Options) (*Runner, error) {
 	}
 	runner.scanner = scanner
 
-	runner.scanner.Ports, err = ParsePorts(options)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse ports: %s", err)
-	}
+	runner.scanner.Ports = ports
 
 	if options.EnableProgressBar {
 		defaultOptions := &clistats.DefaultOptions

--- a/v2/pkg/runner/validate.go
+++ b/v2/pkg/runner/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/naabu/v2/pkg/port"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 	fileutil "github.com/projectdiscovery/utils/file"
@@ -165,7 +166,12 @@ func (options *Options) configureOutput() {
 
 // ConfigureHostDiscovery enables default probes if none is specified
 // but host discovery option was requested
-func (options *Options) configureHostDiscovery() {
+func (options *Options) configureHostDiscovery(ports []*port.Port) {
+	// if less than two ports are specified as input, reduce time and scan directly
+	if len(ports) <= 2 {
+		gologger.Info().Msgf("Host discovery disabled: less than two ports were specified")
+		options.SkipHostDiscovery = true
+	}
 	if options.shouldDiscoverHosts() && !options.hasProbes() {
 		// if no options were defined enable
 		// - ICMP Echo Request


### PR DESCRIPTION
Closes #727 

```console
$ sudo ./naabu -p 80 -host 192.168.5.150 -debug

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.0 (latest)
[INF] Host discovery disabled: less than two ports were specified
[INF] Running SYN scan with CAP_NET_RAW privileges
192.168.5.150:80
[DBG] Received Transport (TCP) scan response from ipv4:192.168.5.150 ipv6: port:80
[INF] Found 1 ports on host 192.168.5.150 (192.168.5.150)
```