### PR TITLE
making icmp non fatal

### DIFF
--- a/v2/pkg/scan/icmp.go
+++ b/v2/pkg/scan/icmp.go
@@ -177,6 +177,9 @@ func PingIcmpTimestampRequestAsync(ip string) {
 	if !iputil.IsIPv4(ip) {
 		return
 	}
+	if icmpConn4 == nil {
+		return
+	}
 	destAddr := &net.IPAddr{IP: net.ParseIP(ip)}
 	m := icmp.Message{
 		Type: ipv4.ICMPTypeTimestamp,
@@ -262,6 +265,9 @@ func ParseTimestamp(_ int, b []byte) (icmp.MessageBody, error) {
 // PingIcmpAddressMaskRequestAsync asynchronous to the target ip address - ipv4 only
 func PingIcmpAddressMaskRequestAsync(ip string) {
 	if !iputil.IsIPv4(ip) {
+		return
+	}
+	if icmpConn4 == nil {
 		return
 	}
 	destAddr := &net.IPAddr{IP: net.ParseIP(ip)}

--- a/v2/pkg/scan/scan_unix.go
+++ b/v2/pkg/scan/scan_unix.go
@@ -51,7 +51,7 @@ func init() {
 	var err error
 	icmpConn4, err = icmp.ListenPacket("ip4:icmp", "0.0.0.0")
 	if err != nil {
-		panic(err)
+		gologger.Error().Msgf("could not setup ip4:icmp: %s", err)
 	}
 
 	icmpConn6, err = icmp.ListenPacket("ip6:icmp", "::")
@@ -381,6 +381,9 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 func (l *ListenHandler) ICMPReadWorker4() {
 	data := make([]byte, 1500)
 	for {
+		if icmpConn4 == nil {
+			return
+		}
 		n, addr, err := icmpConn4.ReadFrom(data)
 		if err != nil {
 			continue


### PR DESCRIPTION
Allow naabu to run without requiring the `net.ipv4.ping_group_range` sysctl setting or `CAP_NET_RAW` network capabilities