### PR TITLE
ci(goreleaser): Fix the failure of release workflow

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -47,7 +47,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release -f .goreleaser/linux.yml --rm-dist
+          args: release -f .goreleaser/linux.yml --clean
           workdir: v2
         env: 
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -70,7 +70,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release -f .goreleaser/windows.yml --rm-dist
+          args: release -f .goreleaser/windows.yml --clean
           workdir: v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -24,7 +24,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release -f .goreleaser/mac.yml --rm-dist
+          args: release -f .goreleaser/mac.yml --clean
           workdir: v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/v2/.goreleaser/linux.yml
+++ b/v2/.goreleaser/linux.yml
@@ -1,3 +1,4 @@
+version: 2
 env:
   - GO111MODULE=on
 before:

--- a/v2/.goreleaser/mac.yml
+++ b/v2/.goreleaser/mac.yml
@@ -1,3 +1,4 @@
+version: 2
 env:
   - GO111MODULE=on
 before:

--- a/v2/.goreleaser/windows.yml
+++ b/v2/.goreleaser/windows.yml
@@ -1,3 +1,4 @@
+version: 2
 env:
   - GO111MODULE=on
 before:


### PR DESCRIPTION
`--rm-dist` was deprecated.

https://goreleaser.com/deprecations/?h=dep#-rm-dist

The release workflow failed.

https://github.com/projectdiscovery/naabu/actions/runs/11593776126/job/32278527815

```
/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser release -f .goreleaser/linux.yml --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser' failed with exit code 1
```
