### PR TITLE
Fix units (seconds -> milliseconds) in a description of Timeout field in Options struct

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -34,7 +34,7 @@ type Options struct {
 
 	Retries        int                 // Retries is the number of retries for the port
 	Rate           int                 // Rate is the rate of port scan requests
-	Timeout        int                 // Timeout is the seconds to wait for ports to respond
+	Timeout        int                 // Timeout is the milliseconds to wait for ports to respond
 	WarmUpTime     int                 // WarmUpTime between scan phases
 	Host           goflags.StringSlice // Host is the single host or comma-separated list of hosts to find ports for
 	HostsFile      string              // HostsFile is the file containing list of hosts to find port for


### PR DESCRIPTION
There was a typo saying Timeout field is in seconds. It's actually milliseconds. This confused me a lot. 

References that the value is actually interpreted as milliseconds:
* https://github.com/projectdiscovery/naabu/blob/dev/pkg/runner/options.go#L192
```go
flagSet.IntVar(&options.Timeout, "timeout", DefaultPortTimeoutSynScan, "millisecond to wait before timing out"),
```
* https://github.com/projectdiscovery/naabu/blob/dev/pkg/runner/runner.go#L117
```go
Timeout:       time.Duration(options.Timeout) * time.Millisecond,
```