### PR TITLE
feat: convert timeout flag to support time formats (e.g., 5s, 100ms)

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
@@ -32,9 +33,11 @@ type Options struct {
 	Nmap           bool // Invoke nmap detailed scan on results
 	InterfacesList bool // InterfacesList show interfaces list
 
-	Retries        int                 // Retries is the number of retries for the port
-	Rate           int                 // Rate is the rate of port scan requests
-	Timeout        int                 // Timeout is the milliseconds to wait for ports to respond
+	Retries int // Retries is the number of retries for the port
+	Rate    int // Rate is the rate of port scan requests
+	// Timeout        int                 // Timeout is the milliseconds to wait for ports to respond
+	Timeout        time.Duration
+	StrTimeout     string              // Timeout is the milliseconds to wait for ports to respond (1, 3ms, 4h etc)
 	WarmUpTime     int                 // WarmUpTime between scan phases
 	Host           goflags.StringSlice // Host is the single host or comma-separated list of hosts to find ports for
 	HostsFile      string              // HostsFile is the file containing list of hosts to find port for
@@ -189,7 +192,8 @@ func ParseOptions() *Options {
 
 	flagSet.CreateGroup("optimization", "Optimization",
 		flagSet.IntVar(&options.Retries, "retries", DefaultRetriesSynScan, "number of retries for the port scan"),
-		flagSet.IntVar(&options.Timeout, "timeout", DefaultPortTimeoutSynScan, "millisecond to wait before timing out"),
+		// flagSet.IntVar(&options.Timeout, "timeout", DefaultPortTimeoutSynScan, "millisecond to wait before timing out"),
+		flagSet.StringVar(&options.StrTimeout, "timeout", "1000ms", "millisecond to wait before timing out"),
 		flagSet.IntVar(&options.WarmUpTime, "warm-up-time", 2, "time in seconds between scan phases"),
 		flagSet.BoolVar(&options.Ping, "ping", false, "ping probes for verification of host"),
 		flagSet.BoolVar(&options.Verify, "verify", false, "validate the ports again with TCP verification"),
@@ -208,6 +212,14 @@ func ParseOptions() *Options {
 	)
 
 	_ = flagSet.Parse()
+
+	// Handle Timeout as int or Duration
+	if duration, err := time.ParseDuration(options.StrTimeout); err == nil {
+		options.Timeout = duration
+	} else if intVal, parseErr := strconv.Atoi(options.StrTimeout); parseErr == nil {
+		options.Timeout = time.Duration(intVal) * time.Millisecond
+	}
+	// fmt.Printf("-Parsed timeout as Duration: %v\n", options.Timeout)
 
 	if cfgFile != "" {
 		if !fileutil.FileExists(cfgFile) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -114,7 +114,7 @@ func NewRunner(options *Options) (*Runner, error) {
 	runner.unique = uniqueCache
 
 	scanOpts := &scan.Options{
-		Timeout:       time.Duration(options.Timeout) * time.Millisecond,
+		Timeout:       options.Timeout,
 		Retries:       options.Retries,
 		Rate:          options.Rate,
 		PortThreshold: options.PortThreshold,


### PR DESCRIPTION
### What does this PR do?
- Converts the timeout flag to use `flagSet.DurationVar` to support time formats (e.g., 5s, 500ms).
- Maintains backward compatibility for integer inputs as milliseconds.
- Applies a default timeout of 100ms for invalid inputs.

### Why is this needed?
- This enhancement improves flexibility for users by allowing them to specify timeouts in a more intuitive way.

### Related Issue
- Closes #1321 
