### PR TITLE
Add -f option for CSV output to allow field filtering

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -67,7 +67,7 @@ type Options struct {
 	OnResult          result.ResultFn // callback on final host result
 	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
-	CSVFields         goflags.StringSlice // Field for user selection
+	Fields            goflags.StringSlice // Field for user selection
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool
@@ -142,7 +142,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Output, "output", "o", "", "file to write output to (optional)"),
 		flagSet.BoolVarP(&options.JSON, "json", "j", false, "write output in JSON lines format"),
 		flagSet.BoolVar(&options.CSV, "csv", false, "write output in csv format"),
-		flagSet.StringSliceVarP(&options.CSVFields, "f", "field", nil, "Specify fields to include in CSV output (comma-separated)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.Fields, "f", "field", nil, "Specify fields to include in output (comma-separated)", goflags.NormalizedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("config", "Configuration",

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -67,7 +67,7 @@ type Options struct {
 	OnResult          result.ResultFn // callback on final host result
 	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
-	CSVFields         goflags.StringSlice // 사용자가 선택할 필드
+	CSVFields         goflags.StringSlice // Field for user selection
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -67,6 +67,7 @@ type Options struct {
 	OnResult          result.ResultFn // callback on final host result
 	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
+	CSVFields         goflags.StringSlice // 사용자가 선택할 필드
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool
@@ -141,6 +142,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Output, "output", "o", "", "file to write output to (optional)"),
 		flagSet.BoolVarP(&options.JSON, "json", "j", false, "write output in JSON lines format"),
 		flagSet.BoolVar(&options.CSV, "csv", false, "write output in csv format"),
+		flagSet.StringSliceVarP(&options.CSVFields, "f", "field", nil, "Specify fields to include in CSV output (comma-separated)", goflags.NormalizedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("config", "Configuration",

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -146,14 +146,11 @@ func WriteCsvOutput(host, ip string, ports []*port.Port, outputCDN bool, isCdn b
 	}
 	if header {
 		writeCSVHeaders(data, encoder, selectedFields)
-		gologger.Debug().Msgf("Parsed header Field Output: %s", selectedFields)
 	}
-
 	for _, p := range ports {
 		data.Port = p.Port
 		data.Protocol = p.Protocol.String()
 		data.TLS = p.TLS
-		gologger.Debug().Msgf("Parsed ports Field Output: %s", selectedFields)
 		writeCSVRow(data, encoder, selectedFields)
 	}
 	encoder.Flush()
@@ -180,7 +177,6 @@ func writeCSVHeaders(data *Result, writer *csv.Writer, selectedFields []string) 
 			gologger.Error().Msg(err.Error())
 			return
 		}
-
 		if err := writer.Write(headers); err != nil {
 			errMsg := errors.Wrap(err, "Could not write headers")
 			gologger.Error().Msg(errMsg.Error())

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -60,13 +60,12 @@ var (
 )
 
 func (r *Result) CSVHeaders(selectedFields []string) ([]string, error) {
-	var headers []string
 	ty := reflect.TypeOf(*r)
 	for i := 0; i < ty.NumField(); i++ {
 		field := ty.Field(i)
 		csvTag := field.Tag.Get("csv")
 
-		if selectedFields == nil || slices.Contains(selectedFields, csvTag) {
+		if len(selectedFields) == 0 || slices.Contains(selectedFields, csvTag) {
 			headers = append(headers, csvTag)
 		}
 	}
@@ -81,7 +80,7 @@ func (r *Result) CSVFields(selectedFields []string) ([]string, error) {
 		field := vl.Field(i)
 		csvTag := ty.Field(i).Tag.Get("csv")
 
-		if selectedFields == nil || slices.Contains(selectedFields, csvTag) {
+		if len(selectedFields) == 0 || slices.Contains(selectedFields, csvTag) {
 			fields = append(fields, fmt.Sprint(field.Interface()))
 		}
 	}

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
@@ -61,7 +62,6 @@ var (
 func (r *Result) CSVHeaders(selectedFields []string) ([]string, error) {
 	var headers []string
 	ty := reflect.TypeOf(*r)
-
 	for i := 0; i < ty.NumField(); i++ {
 		field := ty.Field(i)
 		csvTag := field.Tag.Get("csv")
@@ -77,7 +77,6 @@ func (r *Result) CSVFields(selectedFields []string) ([]string, error) {
 	var fields []string
 	vl := reflect.ValueOf(*r)
 	ty := reflect.TypeOf(*r)
-
 	for i := 0; i < vl.NumField(); i++ {
 		field := vl.Field(i)
 		csvTag := ty.Field(i).Tag.Get("csv")

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -223,10 +223,10 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 					buffer.Write([]byte(fmt.Sprintf("%s\n", b)))
 				} else if r.options.CSV {
 					if csvHeaderEnabled {
-						writeCSVHeaders(data, writer, r.options.CSVFields)
+						writeCSVHeaders(data, writer, r.options.Fields)
 						csvHeaderEnabled = false
 					}
-					writeCSVRow(data, writer, r.options.CSVFields)
+					writeCSVRow(data, writer, r.options.Fields)
 				}
 			}
 		}
@@ -1004,7 +1004,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						err = WriteJSONOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, r.options.CSVFields)
+						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, r.options.Fields)
 					} else {
 						err = WriteHostOutput(host, hostResult.Ports, r.options.OutputCDN, cdnName, file)
 					}
@@ -1066,7 +1066,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						err = WriteJSONOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, r.options.CSVFields)
+						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, r.options.Fields)
 					} else {
 						err = WriteHostOutput(host, nil, r.options.OutputCDN, cdnName, file)
 					}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -222,11 +222,23 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 					}
 					buffer.Write([]byte(fmt.Sprintf("%s\n", b)))
 				} else if r.options.CSV {
-					if csvHeaderEnabled {
-						writeCSVHeaders(data, writer)
-						csvHeaderEnabled = false
+					gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
+					if r.options.CSVFields != nil {
+						selectedFields := r.options.CSVFields
+						if csvHeaderEnabled {
+							writeSelectedCSVHeaders(data, writer, selectedFields)
+							csvHeaderEnabled = false
+						}
+						writeSelectedCSVRow(data, writer, selectedFields)
+
+					} else {
+						if csvHeaderEnabled {
+							writeCSVHeaders(data, writer)
+							csvHeaderEnabled = false
+						}
+						writeCSVRow(data, writer)
 					}
-					writeCSVRow(data, writer)
+
 				}
 			}
 		}
@@ -1004,7 +1016,10 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						err = WriteJSONOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file)
+						gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
+
+						selectedFields := r.options.CSVFields
+						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, selectedFields)
 					} else {
 						err = WriteHostOutput(host, hostResult.Ports, r.options.OutputCDN, cdnName, file)
 					}
@@ -1053,6 +1068,8 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					gologger.Silent().Msgf("%s", buffer.String())
 				} else if r.options.CSV {
 					writer.Flush()
+					gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
+
 					gologger.Silent().Msgf("%s", buffer.String())
 				} else {
 					if r.options.OutputCDN && isCDNIP {
@@ -1066,7 +1083,10 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						err = WriteJSONOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file)
+						selectedFields := r.options.CSVFields
+						gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
+
+						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, selectedFields)
 					} else {
 						err = WriteHostOutput(host, nil, r.options.OutputCDN, cdnName, file)
 					}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -222,7 +222,6 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 					}
 					buffer.Write([]byte(fmt.Sprintf("%s\n", b)))
 				} else if r.options.CSV {
-					gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
 					selectedFields := r.options.CSVFields
 					if csvHeaderEnabled {
 						writeCSVHeaders(data, writer, selectedFields)
@@ -1006,8 +1005,6 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						err = WriteJSONOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
-
 						selectedFields := r.options.CSVFields
 						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, selectedFields)
 					} else {
@@ -1058,8 +1055,6 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					gologger.Silent().Msgf("%s", buffer.String())
 				} else if r.options.CSV {
 					writer.Flush()
-					gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
-
 					gologger.Silent().Msgf("%s", buffer.String())
 				} else {
 					if r.options.OutputCDN && isCDNIP {
@@ -1074,8 +1069,6 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 						err = WriteJSONOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
 						selectedFields := r.options.CSVFields
-						gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
-
 						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, selectedFields)
 					} else {
 						err = WriteHostOutput(host, nil, r.options.OutputCDN, cdnName, file)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -222,12 +222,11 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 					}
 					buffer.Write([]byte(fmt.Sprintf("%s\n", b)))
 				} else if r.options.CSV {
-					selectedFields := r.options.CSVFields
 					if csvHeaderEnabled {
-						writeCSVHeaders(data, writer, selectedFields)
+						writeCSVHeaders(data, writer, r.options.CSVFields)
 						csvHeaderEnabled = false
 					}
-					writeCSVRow(data, writer, selectedFields)
+					writeCSVRow(data, writer, r.options.CSVFields)
 				}
 			}
 		}
@@ -1005,8 +1004,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						err = WriteJSONOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						selectedFields := r.options.CSVFields
-						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, selectedFields)
+						err = WriteCsvOutput(host, hostResult.IP, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, r.options.CSVFields)
 					} else {
 						err = WriteHostOutput(host, hostResult.Ports, r.options.OutputCDN, cdnName, file)
 					}
@@ -1068,8 +1066,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						err = WriteJSONOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, file)
 					} else if r.options.CSV {
-						selectedFields := r.options.CSVFields
-						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, selectedFields)
+						err = WriteCsvOutput(host, hostIP, nil, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, file, r.options.CSVFields)
 					} else {
 						err = WriteHostOutput(host, nil, r.options.OutputCDN, cdnName, file)
 					}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -223,22 +223,12 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 					buffer.Write([]byte(fmt.Sprintf("%s\n", b)))
 				} else if r.options.CSV {
 					gologger.Debug().Msgf("WriteCsvOutput ports Field Output")
-					if r.options.CSVFields != nil {
-						selectedFields := r.options.CSVFields
-						if csvHeaderEnabled {
-							writeSelectedCSVHeaders(data, writer, selectedFields)
-							csvHeaderEnabled = false
-						}
-						writeSelectedCSVRow(data, writer, selectedFields)
-
-					} else {
-						if csvHeaderEnabled {
-							writeCSVHeaders(data, writer)
-							csvHeaderEnabled = false
-						}
-						writeCSVRow(data, writer)
+					selectedFields := r.options.CSVFields
+					if csvHeaderEnabled {
+						writeCSVHeaders(data, writer, selectedFields)
+						csvHeaderEnabled = false
 					}
-
+					writeCSVRow(data, writer, selectedFields)
 				}
 			}
 		}


### PR DESCRIPTION
### Description
This PR enhances the existing -csv output functionality by adding support for a -f (or --fields) option. Users can now specify which columns they want in the CSV output instead of always receiving all available fields.

### Related Issue
Closeshttps://github.com/projectdiscovery/naabu/issues/1371

### Changes Introduced
Added -f option to allow field filtering when using -csv.
Updated CSV output logic to include only specified fields.

### Example Usage
 Outputs only the ip and port columns instead of the full dataset.
```
naabu$ ./naabu -host example.com -p 80,443 -csv -f "ip,port"

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

		projectdiscovery.io

[INF] Current naabu version 2.3.4 (latest)
[INF] Host discovery disabled: less than two ports were specified
[INF] Running CONNECT scan with non root privileges
ip,port
23.215.0.138,443
ip,port
23.215.0.138,80
[INF] Found 2 ports on host example.com (23.215.0.138)
```

In a future update, we can extend this functionality so that -json -f "ip,port" also filters the JSON response accordingly.

Looking forward to feedback!