### PR TITLE
Add -f option for Json output to allow field filtering 

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -67,6 +67,7 @@ type Options struct {
 	OnResult          result.ResultFn // callback on final host result
 	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
+	Fields            goflags.StringSlice // 사용자가 선택할 필드
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool
@@ -141,6 +142,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Output, "output", "o", "", "file to write output to (optional)"),
 		flagSet.BoolVarP(&options.JSON, "json", "j", false, "write output in JSON lines format"),
 		flagSet.BoolVar(&options.CSV, "csv", false, "write output in csv format"),
+		flagSet.StringSliceVarP(&options.Fields, "f", "field", nil, "Specify fields to include in output (comma-separated)", goflags.NormalizedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("config", "Configuration",

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -67,7 +67,7 @@ type Options struct {
 	OnResult          result.ResultFn // callback on final host result
 	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
-	Fields            goflags.StringSlice // 사용자가 선택할 필드
+	Fields            goflags.StringSlice // Field for user selection
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -39,40 +39,45 @@ type jsonResult struct {
 }
 
 func (r *Result) JSON(selectedFields []string) ([]byte, error) {
-	data := jsonResult{}
-	data.TimeStamp = r.TimeStamp
-	if r.Host != r.IP {
-		data.Host = r.Host
-	}
-	data.IP = r.IP
-	data.IsCDNIP = r.IsCDNIP
-	data.CDNName = r.CDNName
-	data.PortNumber = r.Port
-	data.Protocol = r.Protocol
-	data.TLS = r.TLS
 
 	if len(selectedFields) == 0 {
+		data := jsonResult{}
+		data.TimeStamp = r.TimeStamp
+		if r.Host != r.IP {
+			data.Host = r.Host
+		}
+		data.IP = r.IP
+		data.IsCDNIP = r.IsCDNIP
+		data.CDNName = r.CDNName
+		data.PortNumber = r.Port
+		data.Protocol = r.Protocol
+		data.TLS = r.TLS
+
 		return json.Marshal(data)
 	}
 
 	dataMap := make(map[string]interface{})
 
-	vl := reflect.ValueOf(*r)
-	ty := reflect.TypeOf(*r)
-
-	for i := 0; i < vl.NumField(); i++ {
-		field := vl.Field(i)
-		fieldName := ty.Field(i).Name
-		jsonTag := ty.Field(i).Tag.Get("json")
-
-		if jsonTag == "" {
-			jsonTag = strings.ToLower(fieldName)
-		} else {
-			jsonTag = strings.Split(jsonTag, ",")[0] // json 옵션 (omitempty 등) 제거
-		}
-
-		if slices.Contains(selectedFields, jsonTag) {
-			dataMap[jsonTag] = field.Interface()
+	for _, field := range selectedFields {
+		switch field {
+		case "timestamp":
+			dataMap["timestamp"] = r.TimeStamp
+		case "host":
+			if r.Host != r.IP {
+				dataMap["host"] = r.Host
+			}
+		case "ip":
+			dataMap["ip"] = r.IP
+		case "IsCDNIP":
+			dataMap["IsCDNIP"] = r.IsCDNIP
+		case "CDNName":
+			dataMap["CDNName"] = r.CDNName
+		case "port":
+			dataMap["port"] = r.Port
+		case "protocol":
+			dataMap["protocol"] = r.Protocol
+		case "tls":
+			dataMap["tls"] = r.TLS
 		}
 	}
 

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -57,7 +57,6 @@ func (r *Result) JSON(selectedFields []string) ([]byte, error) {
 
 	dataMap := make(map[string]interface{})
 
-	// `reflect`를 사용하여 동적으로 선택된 필드만 추가
 	vl := reflect.ValueOf(*r)
 	ty := reflect.TypeOf(*r)
 
@@ -66,7 +65,6 @@ func (r *Result) JSON(selectedFields []string) ([]byte, error) {
 		fieldName := ty.Field(i).Name
 		jsonTag := ty.Field(i).Tag.Get("json")
 
-		// json 태그가 존재하지 않으면 필드 이름을 그대로 사용
 		if jsonTag == "" {
 			jsonTag = strings.ToLower(fieldName)
 		} else {

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -69,9 +69,9 @@ func (r *Result) JSON(selectedFields []string) ([]byte, error) {
 		case "ip":
 			dataMap["ip"] = r.IP
 		case "IsCDNIP":
-			dataMap["IsCDNIP"] = r.IsCDNIP
+			dataMap["cdn"] = r.IsCDNIP
 		case "CDNName":
-			dataMap["CDNName"] = r.CDNName
+			dataMap["cdn-name"] = r.CDNName
 		case "port":
 			dataMap["port"] = r.Port
 		case "protocol":

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -203,6 +203,7 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 		isCDNIP, cdnName, _ := r.scanner.CdnCheck(hostResult.IP)
 		// console output
 		if r.options.JSON || r.options.CSV {
+			selectedFields := r.options.Fields
 			data := &Result{IP: hostResult.IP, TimeStamp: time.Now().UTC()}
 			if r.options.OutputCDN {
 				data.IsCDNIP = isCDNIP
@@ -216,7 +217,7 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 				data.Protocol = p.Protocol.String()
 				data.TLS = p.TLS
 				if r.options.JSON {
-					b, err := data.JSON()
+					b, err := data.JSON(selectedFields)
 					if err != nil {
 						continue
 					}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -203,7 +203,6 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 		isCDNIP, cdnName, _ := r.scanner.CdnCheck(hostResult.IP)
 		// console output
 		if r.options.JSON || r.options.CSV {
-			selectedFields := r.options.Fields
 			data := &Result{IP: hostResult.IP, TimeStamp: time.Now().UTC()}
 			if r.options.OutputCDN {
 				data.IsCDNIP = isCDNIP
@@ -217,7 +216,7 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 				data.Protocol = p.Protocol.String()
 				data.TLS = p.TLS
 				if r.options.JSON {
-					b, err := data.JSON(selectedFields)
+					b, err := data.JSON(r.options.Fields)
 					if err != nil {
 						continue
 					}


### PR DESCRIPTION
### **Updated PR Message (for JSON field filtering)**  

### Description
This PR enhances the existing `-json` output functionality by adding support for a `-f` (or `--field`) option.  
Users can now specify which fields they want in the JSON output instead of always receiving all available fields.  

Additionally, unlike the previous `-csv` PR(https://github.com/projectdiscovery/naabu/pull/1372), the option name has been updated from `CSVFields` to `Fields` for consistency across output formats.  

### Related Issue
Closes https://github.com/projectdiscovery/naabu/issues/1371
  
### Related PR
https://github.com/projectdiscovery/naabu/pull/1372

### Changes Introduced
- Added `-f` option to allow field filtering when using `-json`.
- Updated JSON output logic to include only specified fields.

### Example Usage
Outputs only the `ip` and `port` fields instead of the full dataset.  
```
naabu$ ./naabu -host example.com -p 80,443 -j -f "ip,port"

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

		projectdiscovery.io

[INF] Current naabu version 2.3.4 (latest)
[INF] Host discovery disabled: less than two ports were specified
[INF] Running CONNECT scan with non root privileges
{"ip":"96.7.128.175","port":80}
{"ip":"96.7.128.175","port":443}
[INF] Found 2 ports on host example.com (96.7.128.175)

``` 

Looking forward to feedback