### PR TITLE
Fix concurrency issue with result handling

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/armon/go-socks5"
@@ -40,6 +41,7 @@ func main() {
 	defer os.RemoveAll(testFile)
 
 	var got bool
+	var mu sync.Mutex
 
 	options := runner.Options{
 		HostsFile: testFile,
@@ -48,7 +50,9 @@ func main() {
 		Proxy:     "127.0.0.1:38401",
 		ProxyAuth: "test:test",
 		OnResult: func(hr *result.HostResult) {
+			mu.Lock()
 			got = true
+			mu.Unlock()
 		},
 		WarmUpTime: 2,
 		Timeout:    10 * time.Second,
@@ -63,7 +67,10 @@ func main() {
 	if err = naabuRunner.RunEnumeration(context.TODO()); err != nil {
 		panic(err)
 	}
+
+	mu.Lock()
 	if !got {
 		panic("no results found")
 	}
+	mu.Unlock()
 }


### PR DESCRIPTION
- Added a sync.Mutex to safely access the got variable in the concurrent OnResult callback.
- Ensured proper synchronization when checking the got variable after the enumeration process.
- Prevented potential race conditions by locking and unlocking the mutex around got access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced system stability by improving the safety of concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->