### PR TITLE
Update linux.yml

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -16,7 +16,7 @@ builds:
       - linux
     goarch:
       - amd64
-      # - arm64
+      - arm64
       
 archives:
 - format: zip


### PR DESCRIPTION
This re-enables linux/arm64 compilation for release files. In its current state, naabu cannot be downloaded via PDTM for linux/arm64 systems.