### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser/linux-amd64.yml
+++ b/.goreleaser/linux-amd64.yml
@@ -18,7 +18,8 @@ builds:
       - amd64
       
 archives:
-- format: zip
+- formats:
+  - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:

--- a/.goreleaser/linux-arm64.yml
+++ b/.goreleaser/linux-arm64.yml
@@ -18,7 +18,8 @@ builds:
       - arm64
       
 archives:
-- format: zip
+- formats:
+  - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -19,7 +19,8 @@ builds:
       # - arm64
       
 archives:
-- format: zip
+- formats:
+  - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:

--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -18,7 +18,8 @@ builds:
       - amd64
       - arm64
 archives:
-- format: zip
+- formats:
+  - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 

--- a/.goreleaser/windows.yml
+++ b/.goreleaser/windows.yml
@@ -19,7 +19,8 @@ builds:
       - arm64
       - 386
 archives:
-- format: zip
+- formats:
+  - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/projectdiscovery/naabu/actions/runs/15979394153/job/45070022768#step:5:24): 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```
It looks like not all the configuration files are actually being used, but I went ahead and updated all of them just to be safe. We could also consider removing the unused ones to keep things clean. Let me know what you prefer.