### PR TITLE
Fix host discovery

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -322,7 +322,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 		discoverCidr := func(cidr *net.IPNet) {
 			ipStream, _ := mapcidr.IPAddressesAsStream(cidr.String())
 			for ip := range ipStream {
-				if r.excludedIpsNP != nil && r.excludedIpsNP.ValidateAddress(ip) {
+				if r.excludedIpsNP == nil || (r.excludedIpsNP != nil && r.excludedIpsNP.ValidateAddress(ip)) {
 					r.handleHostDiscovery(ip)
 				}
 			}


### PR DESCRIPTION
Fixes #1531 

Bug introduced in PR #1431 if no `excludedIpsNP` is set on runner.

## Version 2.3.5

Host discovery is not outputted.

```bash
$ sudo naabu -host google.com -sn

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.5 (latest)
[WRN] UI Dashboard is disabled, Use -dashboard option to enable
[INF] Running host discovery scan
```

Host discovery outputs as expected when a host is excluded.

```bash
$ sudo naabu -host google.com -sn -exclude-hosts 0.0.0.0

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.5 (latest)
[WRN] UI Dashboard is disabled, Use -dashboard option to enable
[INF] Running host discovery scan
[INF] Found alive host google.com (74.125.206.100)
google.com
```

## This PR

Host discovery outputs again as expected

```bash
$ sudo ./naabu -host google.com -sn                       

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.5 (latest)
[WRN] UI Dashboard is disabled, Use -dashboard option to enable
[INF] Running host discovery scan
[INF] Found alive host google.com (74.125.206.139)
google.com
```