### PR TITLE
fix(runner): makes `PreProcessTarget` concurrent

### DIFF
--- a/pkg/runner/targets.go
+++ b/pkg/runner/targets.go
@@ -106,7 +106,7 @@ func (r *Runner) PreProcessTargets() error {
 	s := bufio.NewScanner(f)
 	for s.Scan() {
 		wg.Add()
-		func(target string) {
+		go func(target string) {
 			defer wg.Done()
 			if err := r.AddTarget(target); err != nil {
 				gologger.Warning().Msgf("%s\n", err)


### PR DESCRIPTION
by launching goroutines.

`*Runner.PreProcessTargets` prev executed work
inline, so sizedwaitgroup's `Add()` blocking
effectively serialized target processing.

Prefixing the worker with `go` restores true
concurrency capped by `Threads` opt.

```bash
hyperfine --warmup=5 --prepare='sleep 2' \
  './naabu-75db5d2 -silent -duc -l=/tmp/apple.com-1000.txt -p=80 -c=100 -warm-up-time=0' \
  './naabu-pr-1555 -silent -duc -l=/tmp/apple.com-1000.txt -p=80 --dns-concurrency=100 -warm-up-time=0' \
  './naabu -silent -duc -l=/tmp/apple.com-1000.txt -p=80 -c=100 -warm-up-time=0'
```

```
Benchmark 1: ./naabu-75db5d2 -silent -duc -l=/tmp/apple.com-1000.txt -p=80 -c=100 -warm-up-time=0
  Time (mean ± σ):     14.288 s ±  0.807 s    [User: 0.354 s, System: 0.331 s]
  Range (min … max):   13.863 s … 16.512 s    10 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.
 
Benchmark 2: ./naabu-pr-1555 -silent -duc -l=/tmp/apple.com-1000.txt -p=80 --dns-concurrency=100 -warm-up-time=0
  Time (mean ± σ):     13.950 s ±  0.761 s    [User: 0.379 s, System: 0.362 s]
  Range (min … max):   13.354 s … 15.997 s    10 runs
 
Benchmark 3: ./naabu -silent -duc -l=/tmp/apple.com-1000.txt -p=80 -c=100 -warm-up-time=0
  Time (mean ± σ):      5.186 s ±  1.056 s    [User: 0.286 s, System: 0.272 s]
  Range (min … max):    3.377 s …  6.953 s    10 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.
 
Summary
  ./naabu -silent -duc -l=/tmp/apple.com-1000.txt -p=80 -c=100 -warm-up-time=0 ran
    2.69 ± 0.57 times faster than ./naabu-pr-1555 -silent -duc -l=/tmp/apple.com-1000.txt -p=80 --dns-concurrency=100 -warm-up-time=0
    2.75 ± 0.58 times faster than ./naabu-75db5d2 -silent -duc -l=/tmp/apple.com-1000.txt -p=80 -c=100 -warm-up-time=0
```

>  [!NOTE]
> ./naabu-75db5d2 (dev) -- Fix host discovery (#1553)
> ./naabu-pr-1555 -- PR #1555.
> ./naabu -- this patch.

Fixes #1540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized target processing to run in parallel, reducing wait times when working with many targets. Users should see faster execution in workflows that involve adding or pre-processing multiple targets.
  * No user-facing behavior changes or configuration updates required. This update is backward-compatible and does not alter commands or output, only overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->