### PR TITLE
add file support for port

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -54,8 +54,8 @@ type Options struct {
 	ListOutputFields    bool                // OutputFields is the list of fields to output (comma separated)
 	ExcludeOutputFields goflags.StringSlice // ExcludeOutputFields is the list of fields to exclude from the output
 	Ports               string              // Ports is the ports to use for enumeration
-	PortsFile           string              // PortsFile is the file containing ports to use for enumeration
-	ExcludePorts        string              // ExcludePorts is the list of ports to exclude from enumeration
+	PortsFile           goflags.StringSlice // PortsFile is the file containing ports to use for enumeration
+	ExcludePorts        goflags.StringSlice // ExcludePorts is the list of ports to exclude from enumeration
 	ExcludeIps          string              // Ips or cidr to be excluded from the scan
 	ExcludeIpsFile      string              // File containing Ips or cidr to exclude from the scan
 	TopPorts            string              // Tops ports to scan
@@ -152,8 +152,8 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("port", "Port",
 		flagSet.StringVarP(&options.Ports, "p", "port", "", "ports to scan (80,443, 100-200)"),
 		flagSet.StringVarP(&options.TopPorts, "tp", "top-ports", "", "top ports to scan (default 100) [full,100,1000]"),
-		flagSet.StringVarP(&options.ExcludePorts, "ep", "exclude-ports", "", "ports to exclude from scan (comma-separated)"),
-		flagSet.StringVarP(&options.PortsFile, "pf", "ports-file", "", "list of ports to scan (file)"),
+		flagSet.StringSliceVarP(&options.ExcludePorts, "ep", "exclude-ports", nil, "ports to exclude from scan (file or comma-separated)", goflags.FileCommaSeparatedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.PortsFile, "pf", "ports-file", nil, "list of ports to scan (file or comma-separated)", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.IntVarP(&options.PortThreshold, "pts", "port-threshold", 0, "port threshold to skip port scan for the host"),
 		flagSet.BoolVarP(&options.ExcludeCDN, "ec", "exclude-cdn", false, "skip full port scans for CDN/WAF (only scan for port 80,443)"),
 		flagSet.BoolVarP(&options.OutputCDN, "cdn", "display-cdn", false, "display cdn in use"),

--- a/pkg/runner/ports.go
+++ b/pkg/runner/ports.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -25,12 +24,8 @@ func ParsePorts(options *Options) ([]*port.Port, error) {
 	var portsFileMap, portsCLIMap, topPortsCLIMap, portsConfigList []*port.Port
 
 	// If the user has specfied a ports file, use it
-	if options.PortsFile != "" {
-		data, err := os.ReadFile(options.PortsFile)
-		if err != nil {
-			return nil, fmt.Errorf("could not read ports: %s", err)
-		}
-		ports, err := parsePortsList(string(data))
+	if len(options.PortsFile) > 0 {
+		ports, err := parsePortsSlice(options.PortsFile)
 		if err != nil {
 			return nil, fmt.Errorf("could not read ports: %s", err)
 		}
@@ -114,14 +109,14 @@ func ParsePorts(options *Options) ([]*port.Port, error) {
 
 // excludePorts excludes the list of ports from the exclusion list
 func excludePorts(options *Options, ports []*port.Port) ([]*port.Port, error) {
-	if options.ExcludePorts == "" {
+	if len(options.ExcludePorts) == 0 {
 		return ports, nil
 	}
 
 	var filteredPorts []*port.Port
 
 	// Exclude the ports specified by the user in exclusion list
-	excludedPortsCLI, err := parsePortsList(options.ExcludePorts)
+	excludedPortsCLI, err := parsePortsSlice(options.ExcludePorts)
 	if err != nil {
 		return nil, fmt.Errorf("could not read exclusion ports: %s", err)
 	}

--- a/pkg/runner/ports_test.go
+++ b/pkg/runner/ports_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/naabu/v2/pkg/port"
 	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
 	"github.com/stretchr/testify/assert"
@@ -47,12 +48,12 @@ func TestExcludePorts(t *testing.T) {
 	assert.EqualValues(t, filteredPorts, ports)
 
 	// invalid filter
-	options.ExcludePorts = "a"
+	options.ExcludePorts = goflags.StringSlice{"a"}
 	_, err = excludePorts(&options, ports)
 	assert.NotNil(t, err)
 
 	// valid filter
-	options.ExcludePorts = "1"
+	options.ExcludePorts = goflags.StringSlice{"1"}
 	filteredPorts, err = excludePorts(&options, ports)
 	assert.Nil(t, err)
 	expectedPorts := []*port.Port{


### PR DESCRIPTION
closes https://github.com/projectdiscovery/naabu/issues/1558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ports input now supports multiple sources: provide one or more files and/or comma-separated lists for --ports-file and --exclude-ports.
  - Combine inputs flexibly (multiple flags and mixed formats) to build comprehensive include/exclude port sets.

- Documentation
  - Updated flag help text to clarify that values can come from files and/or comma-separated lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->