### PR TITLE
Adding mac address support

### DIFF
--- a/pkg/result/results.go
+++ b/pkg/result/results.go
@@ -1,7 +1,15 @@
 package result
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"os/exec"
+	"runtime"
+	"strings"
 	"sync"
+	"time"
+	"unicode"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/port"
 	"github.com/projectdiscovery/naabu/v2/pkg/result/confidence"
@@ -24,6 +32,7 @@ type HostResult struct {
 	Ports      []*port.Port
 	Confidence confidence.ConfidenceLevel
 	OS         *OSFingerprint
+	MacAddress string
 }
 
 // Result of the scan
@@ -82,7 +91,17 @@ func (r *Result) GetIPsPorts() chan *HostResult {
 			if r.HasSkipped(ip) {
 				confidenceLevel = confidence.Low
 			}
-			out <- &HostResult{IP: ip, Ports: maps.Values(ports), Confidence: confidenceLevel}
+
+			hostResult := &HostResult{IP: ip, Ports: maps.Values(ports), Confidence: confidenceLevel}
+
+			// Perform ARP lookup for private/local network IPs
+			if isPrivateIP(ip) {
+				if macAddr, err := GetMacAddress(ip); err == nil {
+					hostResult.MacAddress = macAddr
+				}
+			}
+
+			out <- hostResult
 		}
 	}()
 
@@ -199,4 +218,87 @@ func (r *Result) UpdateHostOS(ip string, osfp *OSFingerprint) {
 			return
 		}
 	}
+}
+
+// isPrivateIP checks if an IP address is in a private/local network range
+func isPrivateIP(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	return ip.IsPrivate()
+}
+
+// GetMacAddress retrieves the MAC address for a given target (IP address or hostname).
+// It resolves hostnames to IP addresses first, then queries the ARP table.
+// Returns an empty string if the MAC address cannot be found.
+func GetMacAddress(target string) (string, error) {
+	// Resolve hostname to IP if needed
+	ip := target
+	if net.ParseIP(target) == nil {
+		// Not a valid IP, try to resolve as hostname
+		ips, err := net.LookupIP(target)
+		if err != nil || len(ips) == 0 {
+			return "", fmt.Errorf("failed to resolve hostname %s: %w", target, err)
+		}
+		// Use the first IPv4 address if available, otherwise use the first address
+		for _, addr := range ips {
+			if addr.To4() != nil {
+				ip = addr.String()
+				break
+			}
+		}
+		if ip == target {
+			ip = ips[0].String()
+		}
+	}
+
+	// Determine ARP command arguments based on OS
+	var arpArgs []string
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		// Linux and macOS use the same command format
+		arpArgs = []string{"-n", ip}
+	case "windows":
+		// Windows uses different arguments
+		arpArgs = []string{"-a", ip}
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+
+	// Query ARP table
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "arp", arpArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute arp command: %w", err)
+	}
+
+	// Parse ARP output to find MAC address
+	outputStr := string(output)
+
+	// Windows output is line-based, so check each line for the IP
+	if runtime.GOOS == "windows" {
+		lines := strings.Split(outputStr, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, ip) {
+				for _, field := range strings.FieldsFunc(line, unicode.IsSpace) {
+					if mac, err := net.ParseMAC(field); err == nil {
+						return mac.String(), nil
+					}
+				}
+			}
+		}
+	} else {
+		// Linux and macOS: parse all fields in the output
+		for _, field := range strings.FieldsFunc(outputStr, unicode.IsSpace) {
+			if mac, err := net.ParseMAC(field); err == nil {
+				return mac.String(), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("MAC address not found in ARP table for %s", ip)
 }

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -22,14 +22,15 @@ import (
 
 // Result contains the result for a host
 type Result struct {
-	Host      string    `json:"host,omitempty" csv:"host"`
-	IP        string    `json:"ip,omitempty" csv:"ip"`
-	Port      int       `json:"port,omitempty" csv:"port"`
-	Protocol  string    `json:"protocol,omitempty" csv:"protocol"`
-	TLS       bool      `json:"tls,omitempty" csv:"tls"`
-	IsCDNIP   bool      `json:"cdn,omitempty" csv:"cdn"`
-	CDNName   string    `json:"cdn-name,omitempty" csv:"cdn-name"`
-	TimeStamp time.Time `json:"timestamp,omitempty" csv:"timestamp"`
+	Host       string    `json:"host,omitempty" csv:"host"`
+	IP         string    `json:"ip,omitempty" csv:"ip"`
+	Port       int       `json:"port,omitempty" csv:"port"`
+	Protocol   string    `json:"protocol,omitempty" csv:"protocol"`
+	TLS        bool      `json:"tls,omitempty" csv:"tls"`
+	IsCDNIP    bool      `json:"cdn,omitempty" csv:"cdn"`
+	CDNName    string    `json:"cdn-name,omitempty" csv:"cdn-name"`
+	TimeStamp  time.Time `json:"timestamp,omitempty" csv:"timestamp"`
+	MacAddress string    `json:"mac_address,omitempty" csv:"mac_address"`
 
 	// TODO: flattening fields should be fully reworked to reuse nested structs
 	// just add the service flat structure
@@ -54,14 +55,15 @@ type Result struct {
 // - Many structures like the following one appears redundant and to complicate the codebase
 // - Dynamic fields filtering seems to be out of scope of the tool, complicating output handling
 type jsonResult struct {
-	Host      string    `json:"host,omitempty" csv:"host"`
-	IP        string    `json:"ip,omitempty" csv:"ip"`
-	IsCDNIP   bool      `json:"cdn,omitempty" csv:"cdn"`
-	CDNName   string    `json:"cdn-name,omitempty" csv:"cdn-name"`
-	TimeStamp time.Time `json:"timestamp,omitempty" csv:"timestamp"`
-	Port      int       `json:"port"`
-	Protocol  string    `json:"protocol"`
-	TLS       bool      `json:"tls"`
+	Host       string    `json:"host,omitempty" csv:"host"`
+	IP         string    `json:"ip,omitempty" csv:"ip"`
+	IsCDNIP    bool      `json:"cdn,omitempty" csv:"cdn"`
+	CDNName    string    `json:"cdn-name,omitempty" csv:"cdn-name"`
+	TimeStamp  time.Time `json:"timestamp,omitempty" csv:"timestamp"`
+	Port       int       `json:"port"`
+	Protocol   string    `json:"protocol"`
+	TLS        bool      `json:"tls"`
+	MacAddress string    `json:"mac_address,omitempty" csv:"mac_address"`
 
 	// TODO: flattening fields should be fully reworked to reuse nested structs
 	// just add the service flat structure
@@ -94,6 +96,7 @@ func (r *Result) JSON(excludedFields []string) ([]byte, error) {
 	data.Port = r.Port
 	data.Protocol = r.Protocol
 	data.TLS = r.TLS
+	data.MacAddress = r.MacAddress
 
 	// copy the service fields
 	data.DeviceType = r.DeviceType
@@ -188,10 +191,16 @@ func WriteHostOutput(host string, ports []*port.Port, outputCDN bool, cdnName st
 
 // WriteJSONOutput writes the output list of subdomain in JSON to an io.Writer
 func WriteJSONOutput(host, ip string, ports []*port.Port, outputCDN bool, isCdn bool, cdnName string, excludedFields []string, writer io.Writer) error {
+	return WriteJSONOutputWithMac(host, ip, "", ports, outputCDN, isCdn, cdnName, excludedFields, writer)
+}
+
+// WriteJSONOutputWithMac writes the output list of subdomain in JSON to an io.Writer with MAC address
+func WriteJSONOutputWithMac(host, ip, macAddress string, ports []*port.Port, outputCDN bool, isCdn bool, cdnName string, excludedFields []string, writer io.Writer) error {
 	result := &Result{
-		Host:      host,
-		IP:        ip,
-		TimeStamp: time.Now().UTC(),
+		Host:       host,
+		IP:         ip,
+		MacAddress: macAddress,
+		TimeStamp:  time.Now().UTC(),
 	}
 	if outputCDN {
 		result.IsCDNIP = isCdn
@@ -237,8 +246,13 @@ func WriteJSONOutput(host, ip string, ports []*port.Port, outputCDN bool, isCdn 
 
 // WriteCsvOutput writes the output list of subdomain in csv format to an io.Writer
 func WriteCsvOutput(host, ip string, ports []*port.Port, outputCDN bool, isCdn bool, cdnName string, header bool, excludedFields []string, writer io.Writer) error {
+	return WriteCsvOutputWithMac(host, ip, "", ports, outputCDN, isCdn, cdnName, header, excludedFields, writer)
+}
+
+// WriteCsvOutputWithMac writes the output list of subdomain in csv format to an io.Writer with MAC address
+func WriteCsvOutputWithMac(host, ip, macAddress string, ports []*port.Port, outputCDN bool, isCdn bool, cdnName string, header bool, excludedFields []string, writer io.Writer) error {
 	encoder := csv.NewWriter(writer)
-	data := &Result{IP: ip, TimeStamp: time.Now().UTC(), Port: 0, Protocol: protocol.TCP.String(), TLS: false}
+	data := &Result{IP: ip, MacAddress: macAddress, TimeStamp: time.Now().UTC(), Port: 0, Protocol: protocol.TCP.String(), TLS: false}
 	if host != ip {
 		data.Host = host
 	}


### PR DESCRIPTION
Lookup private ip mac address via native `arp` command

Closes #1581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced MAC address discovery for identified hosts on private networks using ARP queries
  * MAC addresses now included in JSON and CSV output formats for better host identification
  * Automatic MAC resolution integrated into scan results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->