### PR TITLE
make IPv6 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ OUTPUT:
 CONFIGURATION:
    -config string                   path to the naabu configuration file (default $HOME/.config/naabu/config.yaml)
    -scan-all-ips, -sa               scan all the IP's associated with DNS record
-   -ip-version, -iv string[]        ip version to scan of hostname (4,6) - (default 4) (default ["4"])
+   -ip-version, -iv string[]        ip version to scan of hostname (4,6) - (default 4,6) (default ["4","6"])
    -scan-type, -s string            type of port scan (SYN/CONNECT) (default "c")
    -source-ip string                source ip and port (x.x.x.x:yyy - might not work on OSX) 
    -cp, -connect-payload string    payload to send in CONNECT scans (optional)
@@ -263,10 +263,10 @@ The speed can be controlled by changing the value of `rate` flag that represent 
 
 # IPv4 and IPv6
 
-Naabu supports both IPv4 and IPv6. Both ranges can be piped together as input. If IPv6 is used, connectivity must be correctly configured, and the network interface must have an IPv6 address assigned (`inet6`) and a default gateway.
+Naabu supports both IPv4 and IPv6, and both are enabled by default. If IPv6 is used, connectivity must be correctly configured, and the network interface must have an IPv6 address assigned (`inet6`) and a default gateway.
 
 ```console
-echo hackerone.com | dnsx -resp-only -a -aaaa -silent | naabu -p 80 -silent
+echo hackerone.com | naabu -p 80 -silent
 
 104.16.99.52:80
 104.16.100.52:80
@@ -274,7 +274,7 @@ echo hackerone.com | dnsx -resp-only -a -aaaa -silent | naabu -p 80 -silent
 2606:4700::6810:6334:80
 ```
 
-The option `-ip-version 6` makes the tool use IPv6 addresses while resolving domain names.
+The option `-ip-version 6` makes the tool use only IPv6 addresses while resolving domain names.
 
 ```console
 echo hackerone.com | ./naabu -p 80 -ip-version 6
@@ -293,10 +293,10 @@ Developers assume no liability and are not responsible for any misuse or damage.
 hackerone.com:80
 ```
 
-To scan all the IPs of both version, `ip-version 4,6` can be used along with `-scan-all-ips` flag.
+To scan all the IPs of both versions, `-scan-all-ips` flag can be used.
 
 ```console
-echo hackerone.com | ./naabu -iv 4,6 -sa -p 80 -silent
+echo hackerone.com | ./naabu -sa -p 80 -silent
 
 [INF] Found 1 ports on host hackerone.com (104.16.100.52)
 hackerone.com:80

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -181,7 +181,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("config", "Configuration",
 		flagSet.StringVar(&cfgFile, "config", "", "path to the naabu configuration file (default $HOME/.config/naabu/config.yaml)"),
 		flagSet.BoolVarP(&options.ScanAllIPS, "sa", "scan-all-ips", false, "scan all the IP's associated with DNS record"),
-		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{scan.IPv4}, "ip version to scan of hostname (4,6) - (default 4)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.IPVersion, "iv", "ip-version", []string{scan.IPv4, scan.IPv6}, "ip version to scan of hostname (4,6) - (default 4,6)", goflags.NormalizedStringSliceOptions),
 		flagSet.StringVarP(&options.ScanType, "s", "scan-type", ConnectScan, "type of port scan (SYN/CONNECT)"),
 		flagSet.StringVar(&options.SourceIP, "source-ip", "", "source ip and port (x.x.x.x:yyy - might not work on OSX) "),
 		flagSet.StringVarP(&options.ConnectPayload, "cp", "connect-payload", "", "payload to send in CONNECT scans (optional)"),

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -77,9 +77,9 @@ func NewRunner(options *Options) (*Runner, error) {
 
 	options.configureHostDiscovery(ports)
 
-	// default to ipv4 if no ipversion was specified
+	// default to ipv4 and ipv6 if no ipversion was specified
 	if len(options.IPVersion) == 0 {
-		options.IPVersion = []string{scan.IPv4}
+		options.IPVersion = []string{scan.IPv4, scan.IPv6}
 	}
 
 	if options.Retries == 0 {
@@ -98,7 +98,7 @@ func NewRunner(options *Options) (*Runner, error) {
 	dnsOptions := dnsx.DefaultOptions
 	dnsOptions.MaxRetries = runner.options.Retries
 	dnsOptions.Hostsfile = true
-	if sliceutil.Contains(options.IPVersion, "6") {
+	if sliceutil.Contains(options.IPVersion, scan.IPv6) {
 		dnsOptions.QuestionTypes = append(dnsOptions.QuestionTypes, dns.TypeAAAA)
 	}
 	if len(runner.options.baseResolvers) > 0 {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -45,7 +45,7 @@ func TestNewRunner(t *testing.T) {
 			validate: func(t *testing.T, runner *Runner) {
 				assert.Equal(t, 2, len(runner.scanner.Ports))
 
-				expected := []string{"4"}
+				expected := []string{"4", "6"}
 				actual := []string(runner.options.IPVersion)
 				assert.Equal(t, expected, actual)
 				assert.NotNil(t, runner.dnsclient)

--- a/pkg/runner/util.go
+++ b/pkg/runner/util.go
@@ -29,13 +29,18 @@ func (r *Runner) host2ips(target string) (targetIPsV4 []string, targetIPsV6 []st
 			}
 		} else {
 			targetIPsV4 = append(targetIPsV4, dnsData.A...)
+			targetIPsV6 = append(targetIPsV6, dnsData.AAAA...)
 		}
 		if len(targetIPsV4) == 0 && len(targetIPsV6) == 0 {
 			return targetIPsV4, targetIPsV6, fmt.Errorf("no IP addresses found for host: %s", target)
 		}
 	} else {
-		targetIPsV4 = append(targetIPsV6, target)
-		gologger.Debug().Msgf("Found %d addresses for %s\n", len(targetIPsV4), target)
+		if iputil.IsIPv4(target) {
+			targetIPsV4 = append(targetIPsV4, target)
+		} else if iputil.IsIPv6(target) {
+			targetIPsV6 = append(targetIPsV6, target)
+		}
+		gologger.Debug().Msgf("Found %d IPv4 and %d IPv6 addresses for %s\n", len(targetIPsV4), len(targetIPsV6), target)
 	}
 
 	return


### PR DESCRIPTION
closes https://github.com/projectdiscovery/naabu/issues/1255

```console
$ go run . -host 'ipv6.google.com' -v      

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.7 (latest)
[WRN] UI Dashboard is disabled, Use -dashboard option to enable
[DBG] Auto-detected IPv6 addresses for ipv6.google.com, enabling IPv6 scanning
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 is now enabled by default alongside IPv4, improving discovery when IPv6 targets are present.
  * DNS AAAA lookups are performed appropriately, enhancing IPv6 record resolution.
  * Direct IP inputs are correctly categorized and reported per IP version for clearer counts and results.

* **Documentation**
  * Help text and examples updated to reflect IPv4/IPv6 defaults and IPv6-specific usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->