### PR TITLE
fix: prevent nmap service info from being copied to unrelated ports

### DIFF
--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -222,7 +222,6 @@ func WriteJSONOutputWithMac(host, ip, macAddress string, ports []*port.Port, out
 		//nolint
 		result.TLS = p.TLS
 
-		// copy or clear the service fields
 		copyServiceFields(result, p.Service)
 
 		b, err := result.JSON(excludedFields)
@@ -266,7 +265,6 @@ func WriteCsvOutputWithMac(host, ip, macAddress string, ports []*port.Port, outp
 			//nolint
 			data.TLS = p.TLS
 
-			// copy or clear the service fields
 			copyServiceFields(data, p.Service)
 
 			writeCSVRow(data, encoder, excludedFields)
@@ -307,7 +305,6 @@ func copyServiceFields(result *Result, service *port.Service) {
 	if service != nil {
 		s = service
 	} else {
-		// empty service to clear fields
 		s = &port.Service{}
 	}
 


### PR DESCRIPTION

## Problem
When using naabu with nmap integration (`-nmap-cli`), service information was being incorrectly copied to ports that don't have service data from nmap.

**Example:**
- Port 22 (SSH) has service info from nmap
- Ports 2080, 5173 have NO service info
- But output showed all ports with SSH service details

**Before fix:**
```json
{"ip":"192.168.1.117","port":22,"extra_info":"protocol 2.0","name":"ssh","product":"OpenSSH","version":"10.0p2 Debian 5"}
{"ip":"192.168.1.117","port":2080,"extra_info":"protocol 2.0","name":"ssh","product":"OpenSSH","version":"10.0p2 Debian 5"}  // Wrong!
{"ip":"192.168.1.117","port":5173,"extra_info":"protocol 2.0","name":"ssh","product":"OpenSSH","version":"10.0p2 Debian 5"}  // Wrong!
```

**After fix:**
```json
{"ip":"192.168.1.117","port":22,"extra_info":"protocol 2.0","name":"ssh","product":"OpenSSH","version":"10.0p2 Debian 5"}
{"ip":"192.168.1.117","port":2080}  // Correct - no service info
{"ip":"192.168.1.117","port":5173}  // Correct - no service info
```

## Root Cause
In `pkg/runner/output.go`, the `Result` struct was reused across port iterations. When a port had no service info (`p.Service == nil`), the service fields from the previous port were not cleared, causing data leakage.

## Solution
Added `else` blocks to clear all service-related fields when `p.Service == nil` in both:

1. `WriteJSONOutputWithMac()` - for JSON output
2. `WriteCsvOutputWithMac()` - for CSV output

## Changes
- Modified `pkg/runner/output.go`
- Fixed service info propagation bug in both JSON and CSV output functions
- Added field clearing logic for ports without service data

## Testing
Tested with port 22 (with SSH service info) followed by ports 2080, 5173 (no service info):
- JSON output: Only port 22 shows service info
- CSV output: Only port 22 shows service info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON and CSV outputs now consistently clear service-related fields when a port has no associated service, preventing values from carrying over between entries and ensuring outputs accurately reflect absent service data.
  * Internal handling of service field population centralized and simplified to improve consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->