### PR TITLE
fix: In synscan mode, complete the expected sleep.

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -398,7 +398,9 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 			}
 		}
 		r.wgscan.Wait()
-		time.Sleep(r.options.GetTimeout())
+
+		time.Sleep(time.Duration(r.options.WarmUpTime) * time.Second)
+
 		r.handleOutput(r.scanner.ScanResults)
 		return nil
 	case r.options.Stream && r.options.Passive: // stream passive


### PR DESCRIPTION
In synscan mode, the program exits immediately after sending all packets, but some packets may still be missing. Following the original definition of Timeout, a sleep period is added to compensate for any unreceived packets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan reliability by adding a short stabilization delay after streaming scan completion, ensuring results are fully processed before output.
  * Reduces intermittent missing or incomplete output, yielding more consistent final results and reports.
  * Provides a smoother, more predictable user experience when viewing scan progress and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->