### PR TITLE
fix: add system DNS fallback for split‑DNS/VPN resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ CONFIGURATION:
    -r string                        list of custom resolver dns resolution (comma separated or from file)
    -proxy string                    socks5 proxy (ip[:port] / fqdn[:port]
    -proxy-auth string               socks5 proxy authentication (username:password)
+   -dns-order string                dns resolution order (p/l/lp/pl) (default "l")
+   -sr, -system-resolver            use system DNS as fallback resolver
    -resume                          resume scan using resume.cfg
    -stream                          stream mode (disables resume, nmap, verify, retries, shuffling, etc)
    -passive                         display passive open ports using shodan internetdb api

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -80,6 +80,7 @@ type Options struct {
 	Resolvers         string              // Resolvers (comma separated or file)
 	baseResolvers     []string
 	DnsOrder          string              // DNS resolution order (p/l/lp/pl)
+	SystemResolver    bool                // Use system DNS resolver as fallback
 	OnResult          result.ResultFn // callback on final host result
 	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
@@ -195,6 +196,7 @@ func ParseOptions() *Options {
 		flagSet.StringVar(&options.Proxy, "proxy", "", "socks5 proxy (ip[:port] / fqdn[:port]"),
 		flagSet.StringVar(&options.ProxyAuth, "proxy-auth", "", "socks5 proxy authentication (username:password)"),
 		flagSet.StringVar(&options.DnsOrder, "dns-order", "l", "dns resolution order (p/l/lp/pl)"),
+		flagSet.BoolVarP(&options.SystemResolver, "system-resolver", "sr", false, "use system DNS as fallback resolver"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "resume scan using resume.cfg"),
 		flagSet.BoolVar(&options.Stream, "stream", false, "stream mode (disables resume, nmap, verify, retries, shuffling, etc)"),
 		flagSet.BoolVar(&options.Passive, "passive", false, "display passive open ports using shodan internetdb api"),

--- a/pkg/runner/util.go
+++ b/pkg/runner/util.go
@@ -48,11 +48,11 @@ func (r *Runner) host2ips(target string) (targetIPsV4 []string, targetIPsV6 []st
 			}
 		}
 
-		if len(targetIPsV4) == 0 && len(targetIPsV6) == 0 {
-			// Fallback to system resolver for split-DNS / VPN setups
+		if len(targetIPsV4) == 0 && len(targetIPsV6) == 0 && r.options.SystemResolver {
+			gologger.Debug().Msgf("primary DNS failed for %s, trying system resolver", target)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
 			ipAddrs, sysErr := net.DefaultResolver.LookupIPAddr(ctx, target)
+			cancel()
 			if sysErr == nil && len(ipAddrs) > 0 {
 				for _, ipAddr := range ipAddrs {
 					ip := ipAddr.IP
@@ -70,13 +70,13 @@ func (r *Runner) host2ips(target string) (targetIPsV4 []string, targetIPsV6 []st
 					}
 				}
 			}
-			if len(targetIPsV4) == 0 && len(targetIPsV6) == 0 {
-				if err != nil {
-					gologger.Warning().Msgf("Could not get IP for host: %s\n", target)
-					return nil, nil, err
-				}
-				return targetIPsV4, targetIPsV6, fmt.Errorf("no IP addresses found for host: %s", target)
+		}
+		if len(targetIPsV4) == 0 && len(targetIPsV6) == 0 {
+			if err != nil {
+				gologger.Warning().Msgf("Could not get IP for host: %s\n", target)
+				return nil, nil, err
 			}
+			return targetIPsV4, targetIPsV6, fmt.Errorf("no IP addresses found for host: %s", target)
 		}
 	} else {
 		if iputil.IsIPv4(target) {

--- a/pkg/runner/util_test.go
+++ b/pkg/runner/util_test.go
@@ -75,3 +75,33 @@ func Test_host2ips_DnsOrder(t *testing.T) {
 		assert.Equal(t, []string{"127.0.0.1"}, got)
 	})
 }
+
+func Test_host2ips_SystemResolver(t *testing.T) {
+	t.Run("system-resolver off does not fallback", func(t *testing.T) {
+		r, err := NewRunner(&Options{IPVersion: []string{scan.IPv4}, Retries: 1})
+		require.Nil(t, err)
+		assert.False(t, r.options.SystemResolver)
+
+		// "aaaa" is unresolvable by primary DNS; with SystemResolver off, no fallback
+		_, _, err = r.host2ips("aaaa")
+		assert.NotNil(t, err)
+	})
+
+	t.Run("system-resolver on enables fallback for valid host", func(t *testing.T) {
+		r, err := NewRunner(&Options{IPVersion: []string{scan.IPv4}, Retries: 1, SystemResolver: true})
+		require.Nil(t, err)
+
+		// localhost should be resolvable by the system resolver even if primary DNS fails
+		got, _, err := r.host2ips("localhost")
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"127.0.0.1"}, got)
+	})
+
+	t.Run("system-resolver on still errors for unresolvable host", func(t *testing.T) {
+		r, err := NewRunner(&Options{IPVersion: []string{scan.IPv4}, Retries: 1, SystemResolver: true})
+		require.Nil(t, err)
+
+		_, _, err = r.host2ips("this-host-does-not-exist-xyz.invalid")
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
**Summary**
- Add a system DNS fallback when `dnsx` returns no IPs or throws an error.

**Motivation**
- Split‑DNS/VPN environments often resolve internal domains only via the OS resolver, while public resolvers used by `dnsx` return empty results.

**Behavior**
- Try `dnsx` first.
- If no IPs, query `net.DefaultResolver` with a short timeout.
- If still empty, return the original `dnsx` error (if any) or `no IP addresses found`.

**Risk**
- Low. Default flow is unchanged; fallback triggers only on empty `dnsx` results or error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to enable using the system DNS resolver as a fallback.

* **Bug Fixes**
  * Added automatic fallback to the system DNS resolver with a short timeout when primary DNS resolution returns no addresses.
  * Improved IPv4/IPv6 selection so address results respect configured IP-version constraints and return clearer errors when none are found.

* **Tests**
  * Added tests covering system-resolver fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->