### PR TITLE
docs: clarify OnResult vs OnReceive

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ func main() {
 }
 ```
 
+> **`OnResult`** is called once after the scan completes with aggregated results. To process results **in real-time** as ports are discovered, use **`OnReceive`** instead. The `Stream` option only controls async target loading — it does not affect when callbacks fire.
+
 # Notes
 
 - Naabu allows arbitrary binary execution as a feature to support [nmap integration](https://github.com/projectdiscovery/naabu#nmap-integration).


### PR DESCRIPTION
Closes #1652

Adds a note to the library usage section clarifying that `OnResult` fires after scan completion, and `OnReceive` should be used for real-time results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on callback behavior for result processing.
  * Updated guidance on OnResult invocation timing versus OnReceive usage.
  * Clarified how the Stream option affects async operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->