### PR TITLE
Fixing ethernetworker

### DIFF
--- a/pkg/scan/ethernet_test.go
+++ b/pkg/scan/ethernet_test.go
@@ -17,26 +17,27 @@ func TestEthernetWriteWorkerConsumesPackets(t *testing.T) {
 		called.Add(1)
 	}
 
-	go EthernetWriteWorker()
-
 	for i := 0; i < 5; i++ {
 		ch <- &PkgSend{ip: "192.168.1.1", flag: Arp}
 	}
 
-	// swap the channel so EthernetWriteWorker reads from ours
 	oldChan := ethernetPacketSend
 	ethernetPacketSend = ch
-	defer func() { ethernetPacketSend = oldChan }()
 
-	go EthernetWriteWorker()
+	done := make(chan struct{})
+	go func() {
+		EthernetWriteWorker()
+		close(done)
+	}()
 
 	assert.Eventually(t, func() bool {
 		return called.Load() == 5
 	}, 2*time.Second, 10*time.Millisecond, "EthernetWriteWorker should have consumed all 5 ARP packets")
 
 	close(ch)
-	// wait for goroutine to fully exit before restoring
-	time.Sleep(50 * time.Millisecond)
+	<-done
+
+	ethernetPacketSend = oldChan
 	ArpRequestAsync = origArp
 }
 
@@ -48,26 +49,30 @@ func TestEthernetWriteWorkerDoesNotBlock(t *testing.T) {
 
 	oldChan := ethernetPacketSend
 	ethernetPacketSend = ch
-	defer func() { ethernetPacketSend = oldChan }()
 
-	go EthernetWriteWorker()
+	workerDone := make(chan struct{})
+	go func() {
+		EthernetWriteWorker()
+		close(workerDone)
+	}()
 
-	done := make(chan struct{})
+	sendDone := make(chan struct{})
 	go func() {
 		for i := 0; i < packetSendSize+100; i++ {
 			ch <- &PkgSend{ip: "10.0.0.1", flag: Arp}
 		}
-		close(done)
+		close(sendDone)
 	}()
 
 	select {
-	case <-done:
+	case <-sendDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("EnqueueEthernet blocked — EthernetWriteWorker is not draining the channel")
 	}
 
 	close(ch)
-	// wait for goroutine to fully exit before restoring
-	time.Sleep(50 * time.Millisecond)
+	<-workerDone
+
+	ethernetPacketSend = oldChan
 	ArpRequestAsync = origArp
 }

--- a/pkg/scan/ethernet_test.go
+++ b/pkg/scan/ethernet_test.go
@@ -1,0 +1,73 @@
+package scan
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEthernetWriteWorkerConsumesPackets(t *testing.T) {
+	ch := make(chan *PkgSend, 10)
+
+	var called atomic.Int32
+	origArp := ArpRequestAsync
+	ArpRequestAsync = func(ip string) {
+		called.Add(1)
+	}
+
+	go EthernetWriteWorker()
+
+	for i := 0; i < 5; i++ {
+		ch <- &PkgSend{ip: "192.168.1.1", flag: Arp}
+	}
+
+	// swap the channel so EthernetWriteWorker reads from ours
+	oldChan := ethernetPacketSend
+	ethernetPacketSend = ch
+	defer func() { ethernetPacketSend = oldChan }()
+
+	go EthernetWriteWorker()
+
+	assert.Eventually(t, func() bool {
+		return called.Load() == 5
+	}, 2*time.Second, 10*time.Millisecond, "EthernetWriteWorker should have consumed all 5 ARP packets")
+
+	close(ch)
+	// wait for goroutine to fully exit before restoring
+	time.Sleep(50 * time.Millisecond)
+	ArpRequestAsync = origArp
+}
+
+func TestEthernetWriteWorkerDoesNotBlock(t *testing.T) {
+	ch := make(chan *PkgSend, packetSendSize)
+
+	origArp := ArpRequestAsync
+	ArpRequestAsync = func(ip string) {}
+
+	oldChan := ethernetPacketSend
+	ethernetPacketSend = ch
+	defer func() { ethernetPacketSend = oldChan }()
+
+	go EthernetWriteWorker()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < packetSendSize+100; i++ {
+			ch <- &PkgSend{ip: "10.0.0.1", flag: Arp}
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("EnqueueEthernet blocked — EthernetWriteWorker is not draining the channel")
+	}
+
+	close(ch)
+	// wait for goroutine to fully exit before restoring
+	time.Sleep(50 * time.Millisecond)
+	ArpRequestAsync = origArp
+}

--- a/pkg/scan/ethernet_test.go
+++ b/pkg/scan/ethernet_test.go
@@ -16,17 +16,17 @@ func TestEthernetWriteWorkerConsumesPackets(t *testing.T) {
 	ArpRequestAsync = func(ip string) {
 		called.Add(1)
 	}
+	defer func() {
+		ArpRequestAsync = origArp
+	}()
 
 	for i := 0; i < 5; i++ {
 		ch <- &PkgSend{ip: "192.168.1.1", flag: Arp}
 	}
 
-	oldChan := ethernetPacketSend
-	ethernetPacketSend = ch
-
 	done := make(chan struct{})
 	go func() {
-		EthernetWriteWorker()
+		EthernetWriteWorker(ch)
 		close(done)
 	}()
 
@@ -36,9 +36,6 @@ func TestEthernetWriteWorkerConsumesPackets(t *testing.T) {
 
 	close(ch)
 	<-done
-
-	ethernetPacketSend = oldChan
-	ArpRequestAsync = origArp
 }
 
 func TestEthernetWriteWorkerDoesNotBlock(t *testing.T) {
@@ -46,13 +43,13 @@ func TestEthernetWriteWorkerDoesNotBlock(t *testing.T) {
 
 	origArp := ArpRequestAsync
 	ArpRequestAsync = func(ip string) {}
-
-	oldChan := ethernetPacketSend
-	ethernetPacketSend = ch
+	defer func() {
+		ArpRequestAsync = origArp
+	}()
 
 	workerDone := make(chan struct{})
 	go func() {
-		EthernetWriteWorker()
+		EthernetWriteWorker(ch)
 		close(workerDone)
 	}()
 
@@ -72,7 +69,4 @@ func TestEthernetWriteWorkerDoesNotBlock(t *testing.T) {
 
 	close(ch)
 	<-workerDone
-
-	ethernetPacketSend = oldChan
-	ArpRequestAsync = origArp
 }

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -82,6 +82,7 @@ func init() {
 	go TransportReadWorker()
 	go TransportWriteWorker()
 	go ICMPWriteWorker()
+	go EthernetWriteWorker()
 }
 
 func buildListenHandler() (*ListenHandler, error) {

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -82,7 +82,7 @@ func init() {
 	go TransportReadWorker()
 	go TransportWriteWorker()
 	go ICMPWriteWorker()
-	go EthernetWriteWorker()
+	go EthernetWriteWorker(ethernetPacketSend)
 }
 
 func buildListenHandler() (*ListenHandler, error) {
@@ -137,8 +137,8 @@ func ICMPWriteWorker() {
 }
 
 // EthernetWriteWorker writes packet to the network layer
-func EthernetWriteWorker() {
-	for pkg := range ethernetPacketSend {
+func EthernetWriteWorker(ch <-chan *PkgSend) {
+	for pkg := range ch {
 		switch pkg.flag {
 		case Arp:
 			ArpRequestAsync(pkg.ip)


### PR DESCRIPTION
Close #1162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying the ethernet packet worker consumes queued packets and does not block producers under load.

* **Refactor**
  * Added a background ethernet writer so queued ethernet packets are processed asynchronously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->