### PR TITLE
Adding predictive scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,13 @@ HOST-DISCOVERY:
    -rev-ptr                       Reverse PTR lookup for input ips
 
 OPTIMIZATION:
-   -retries int       number of retries for the port scan (default 3)
-   -timeout int       millisecond to wait before timing out (default 1000)
-   -warm-up-time int  time in seconds between scan phases (default 2)
-   -ping              ping probes for verification of host
-   -verify            validate the ports again with TCP verification
+   -retries int                    number of retries for the port scan (default 3)
+   -timeout int                    millisecond to wait before timing out (default 1000)
+   -warm-up-time int               time in seconds between scan phases (default 2)
+   -ping                           ping probes for verification of host
+   -verify                         validate the ports again with TCP verification
+   -ss, -smart-scan                predictive port scanning using port correlation model
+   -pt, -prediction-threshold int  minimum confidence for port predictions (0-100%) (default 20)
 
 DEBUG:
    -health-check, -hc        run diagnostic check up

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057
-	github.com/Mzack9999/gopacket v0.0.0-20260306231411-c992bef03b8e
+	github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9
 	github.com/Ullaakut/nmap/v3 v3.0.6
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057
-	github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9
+	github.com/Mzack9999/gopacket v0.0.0-20260327205553-79da638732fe
 	github.com/Ullaakut/nmap/v3 v3.0.6
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057
-	github.com/Mzack9999/gopacket v0.0.0-20260327205553-79da638732fe
+	github.com/Mzack9999/gopacket v0.0.0-20260327212258-d211b432c22b
 	github.com/Ullaakut/nmap/v3 v3.0.6
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/Mzack9999/gopacket v0.0.0-20260306231411-c992bef03b8e h1:NETap0e0fMXT
 github.com/Mzack9999/gopacket v0.0.0-20260306231411-c992bef03b8e/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
 github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9 h1:22hgyaZlFnUs5OfRUJE1sAorctfTCu4V7z5JqfQg2XQ=
 github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
+github.com/Mzack9999/gopacket v0.0.0-20260327205553-79da638732fe h1:EDyoNXVKj2fDB4RIr2Ta6BuoBapHi5cABVWCVb/jY58=
+github.com/Mzack9999/gopacket v0.0.0-20260327205553-79da638732fe/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb888350
 github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809/go.mod h1:upgc3Zs45jBDnBT4tVRgRcgm26ABpaP7MoTSdgysca4=
 github.com/Mzack9999/gopacket v0.0.0-20260306231411-c992bef03b8e h1:NETap0e0fMXTpSl4+py1UIYDgdMD+39RgaWEMNTG+TM=
 github.com/Mzack9999/gopacket v0.0.0-20260306231411-c992bef03b8e/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
+github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9 h1:22hgyaZlFnUs5OfRUJE1sAorctfTCu4V7z5JqfQg2XQ=
+github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9 h1:22hgyaZlFnUs
 github.com/Mzack9999/gopacket v0.0.0-20260327204334-d21006e2d4a9/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
 github.com/Mzack9999/gopacket v0.0.0-20260327205553-79da638732fe h1:EDyoNXVKj2fDB4RIr2Ta6BuoBapHi5cABVWCVb/jY58=
 github.com/Mzack9999/gopacket v0.0.0-20260327205553-79da638732fe/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
+github.com/Mzack9999/gopacket v0.0.0-20260327212258-d211b432c22b h1:lEa6Fj9C2E+qKp0x57q7k8WmOnANjoTsqmTHNQt49e8=
+github.com/Mzack9999/gopacket v0.0.0-20260327212258-d211b432c22b/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=

--- a/pkg/prediction/default_model.go
+++ b/pkg/prediction/default_model.go
@@ -1,0 +1,143 @@
+package prediction
+
+// DefaultModel returns a model seeded with well-known port correlation
+// patterns derived from common service co-occurrence on Internet hosts.
+// Probabilities represent P(target | given), the likelihood that a host
+// with "given" port open also has "target" port open.
+func DefaultModel() *Model {
+	m := NewModel()
+
+	// Web (HTTP/HTTPS)
+	m.SetBidirectional(80, 443, 0.85, 0.90)
+	m.Set(80, 8080, 0.25)
+	m.Set(80, 8443, 0.20)
+	m.Set(80, 8000, 0.15)
+	m.Set(80, 8888, 0.12)
+	m.Set(80, 3000, 0.10)
+	m.Set(443, 8443, 0.22)
+	m.Set(443, 8080, 0.20)
+
+	// SSH
+	m.Set(22, 80, 0.70)
+	m.Set(22, 443, 0.65)
+	m.Set(22, 21, 0.20)
+	m.Set(22, 3306, 0.18)
+	m.Set(22, 5432, 0.12)
+	m.Set(22, 8080, 0.15)
+	m.Set(80, 22, 0.40)
+	m.Set(443, 22, 0.45)
+
+	// Mail
+	m.SetBidirectional(25, 110, 0.55, 0.60)
+	m.SetBidirectional(25, 143, 0.60, 0.65)
+	m.Set(25, 465, 0.55)
+	m.Set(25, 587, 0.60)
+	m.Set(25, 993, 0.50)
+	m.Set(25, 995, 0.45)
+	m.Set(25, 80, 0.35)
+	m.SetBidirectional(143, 993, 0.80, 0.85)
+	m.Set(143, 587, 0.55)
+	m.SetBidirectional(110, 995, 0.75, 0.80)
+	m.Set(110, 587, 0.50)
+	m.Set(465, 587, 0.70)
+	m.Set(587, 465, 0.65)
+
+	// Windows
+	m.SetBidirectional(445, 135, 0.85, 0.85)
+	m.SetBidirectional(445, 139, 0.70, 0.75)
+	m.Set(445, 3389, 0.50)
+	m.Set(445, 5985, 0.30)
+	m.Set(445, 5986, 0.20)
+	m.Set(135, 3389, 0.45)
+	m.Set(135, 5985, 0.25)
+	m.Set(3389, 445, 0.70)
+	m.Set(3389, 135, 0.65)
+	m.Set(3389, 139, 0.50)
+
+	// Database
+	m.Set(3306, 22, 0.60)
+	m.Set(3306, 80, 0.45)
+	m.Set(3306, 443, 0.40)
+	m.Set(3306, 33060, 0.25)
+	m.Set(5432, 22, 0.55)
+	m.Set(5432, 80, 0.40)
+	m.Set(5432, 443, 0.35)
+	m.Set(27017, 22, 0.45)
+	m.Set(27017, 80, 0.35)
+	m.Set(27017, 27018, 0.30)
+	m.Set(27017, 27019, 0.25)
+	m.Set(6379, 22, 0.50)
+	m.Set(6379, 80, 0.35)
+	m.Set(6379, 443, 0.30)
+
+	// IoT / Routers
+	m.Set(23, 80, 0.75)
+	m.Set(23, 443, 0.55)
+	m.Set(23, 8080, 0.40)
+	m.Set(23, 8443, 0.25)
+	m.Set(23, 8082, 0.20)
+
+	// Alternate web ports
+	m.Set(8080, 80, 0.60)
+	m.Set(8080, 443, 0.50)
+	m.Set(8080, 22, 0.30)
+	m.Set(8080, 8443, 0.25)
+	m.Set(8443, 443, 0.55)
+	m.Set(8443, 80, 0.50)
+	m.Set(8443, 8080, 0.30)
+	m.Set(8000, 80, 0.50)
+	m.Set(8000, 443, 0.40)
+	m.Set(8888, 80, 0.45)
+	m.Set(8888, 443, 0.35)
+
+	// FTP
+	m.Set(21, 22, 0.55)
+	m.Set(21, 80, 0.45)
+	m.Set(21, 443, 0.35)
+
+	// DNS
+	m.Set(53, 22, 0.40)
+	m.Set(53, 80, 0.35)
+	m.Set(53, 443, 0.30)
+
+	// Docker / Container
+	m.Set(2375, 22, 0.50)
+	m.Set(2375, 80, 0.40)
+	m.Set(2375, 443, 0.35)
+	m.Set(2375, 2376, 0.30)
+	m.Set(2376, 22, 0.50)
+	m.Set(2376, 80, 0.40)
+	m.Set(2376, 2375, 0.30)
+
+	// Monitoring / DevOps
+	m.Set(9090, 3000, 0.30)
+	m.Set(9090, 80, 0.35)
+	m.Set(9090, 443, 0.30)
+	m.Set(9090, 22, 0.35)
+	m.Set(3000, 80, 0.40)
+	m.Set(3000, 443, 0.35)
+	m.Set(3000, 9090, 0.25)
+
+	// Alternate SSH
+	m.Set(2222, 80, 0.45)
+	m.Set(2222, 443, 0.40)
+	m.Set(2222, 22, 0.30)
+
+	// Common app stacks
+	m.Set(9200, 9300, 0.60) // Elasticsearch
+	m.Set(9300, 9200, 0.65)
+	m.Set(5601, 9200, 0.50) // Kibana -> ES
+	m.Set(9200, 5601, 0.35)
+
+	m.Set(6443, 10250, 0.40) // Kubernetes API -> kubelet
+	m.Set(6443, 2379, 0.35)  // Kubernetes API -> etcd
+	m.Set(10250, 6443, 0.55)
+
+	m.Set(8161, 61616, 0.55) // ActiveMQ web -> broker
+	m.Set(61616, 8161, 0.60)
+
+	m.Set(15672, 5672, 0.70) // RabbitMQ management -> AMQP
+	m.Set(5672, 15672, 0.55)
+
+	return m
+}

--- a/pkg/prediction/model.go
+++ b/pkg/prediction/model.go
@@ -80,7 +80,10 @@ func (m *Model) Predict(openPorts []int, threshold float64) []PortPrediction {
 	}
 
 	sort.Slice(predictions, func(i, j int) bool {
-		return predictions[i].Confidence > predictions[j].Confidence
+		if predictions[i].Confidence != predictions[j].Confidence {
+			return predictions[i].Confidence > predictions[j].Confidence
+		}
+		return predictions[i].Port < predictions[j].Port
 	})
 
 	return predictions
@@ -131,14 +134,24 @@ func (m *Model) Train(hostPorts map[string][]int) {
 
 // Merge adds correlations from another model, keeping the higher
 // probability when both models have data for the same pair.
+// Safe against cross-merge deadlocks: the source is snapshot-copied
+// before acquiring the destination lock.
 func (m *Model) Merge(other *Model) {
 	other.mu.RLock()
-	defer other.mu.RUnlock()
+	snapshot := make(map[int]map[int]float64, len(other.correlations))
+	for given, targets := range other.correlations {
+		cp := make(map[int]float64, len(targets))
+		for k, v := range targets {
+			cp[k] = v
+		}
+		snapshot[given] = cp
+	}
+	other.mu.RUnlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for given, targets := range other.correlations {
+	for given, targets := range snapshot {
 		if _, ok := m.correlations[given]; !ok {
 			m.correlations[given] = make(map[int]float64)
 		}

--- a/pkg/prediction/model.go
+++ b/pkg/prediction/model.go
@@ -1,0 +1,215 @@
+package prediction
+
+import (
+	"sort"
+	"sync"
+)
+
+const DefaultThreshold = 0.2
+
+// PortPrediction is a predicted port with its confidence score.
+type PortPrediction struct {
+	Port       int
+	Confidence float64
+}
+
+// Model holds conditional probability data: P(TargetPort | GivenPort).
+// The outer key is the known open port, the inner key is the predicted port.
+type Model struct {
+	mu           sync.RWMutex
+	correlations map[int]map[int]float64
+}
+
+// NewModel creates an empty model.
+func NewModel() *Model {
+	return &Model{correlations: make(map[int]map[int]float64)}
+}
+
+// Set stores P(target | given) in the model.
+func (m *Model) Set(given, target int, probability float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.correlations[given]; !ok {
+		m.correlations[given] = make(map[int]float64)
+	}
+	m.correlations[given][target] = probability
+}
+
+// SetBidirectional stores the probability in both directions.
+func (m *Model) SetBidirectional(portA, portB int, probAGivenB, probBGivenA float64) {
+	m.Set(portB, portA, probAGivenB)
+	m.Set(portA, portB, probBGivenA)
+}
+
+// Predict returns ports likely to be open given a set of known open ports.
+// For each candidate port, the maximum conditional probability across all
+// known ports is used (matching GPS's approach). Results are sorted by
+// descending confidence and filtered by the threshold.
+func (m *Model) Predict(openPorts []int, threshold float64) []PortPrediction {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	openSet := make(map[int]struct{}, len(openPorts))
+	for _, p := range openPorts {
+		openSet[p] = struct{}{}
+	}
+
+	// For each candidate port, track max P across all known open ports
+	candidates := make(map[int]float64)
+	for _, knownPort := range openPorts {
+		targets, ok := m.correlations[knownPort]
+		if !ok {
+			continue
+		}
+		for targetPort, prob := range targets {
+			if _, alreadyOpen := openSet[targetPort]; alreadyOpen {
+				continue
+			}
+			if prob > candidates[targetPort] {
+				candidates[targetPort] = prob
+			}
+		}
+	}
+
+	predictions := make([]PortPrediction, 0, len(candidates))
+	for p, conf := range candidates {
+		if conf >= threshold {
+			predictions = append(predictions, PortPrediction{Port: p, Confidence: conf})
+		}
+	}
+
+	sort.Slice(predictions, func(i, j int) bool {
+		return predictions[i].Confidence > predictions[j].Confidence
+	})
+
+	return predictions
+}
+
+// Train builds correlation data from observed scan results. Each entry
+// maps an IP to the set of open ports found on that host. This computes
+// P(PortA | PortB) = count(hosts with both A and B) / count(hosts with B).
+func (m *Model) Train(hostPorts map[string][]int) {
+	// Count how many hosts have each port open
+	portCount := make(map[int]int)
+	// Count how many hosts have both portA and portB open
+	cooccurrence := make(map[[2]int]int)
+
+	for _, ports := range hostPorts {
+		seen := make(map[int]struct{}, len(ports))
+		for _, p := range ports {
+			seen[p] = struct{}{}
+			portCount[p]++
+		}
+		portList := make([]int, 0, len(seen))
+		for p := range seen {
+			portList = append(portList, p)
+		}
+		for i := 0; i < len(portList); i++ {
+			for j := 0; j < len(portList); j++ {
+				if i == j {
+					continue
+				}
+				cooccurrence[[2]int{portList[i], portList[j]}]++
+			}
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for pair, count := range cooccurrence {
+		given := pair[0]
+		target := pair[1]
+		prob := float64(count) / float64(portCount[given])
+		if _, ok := m.correlations[given]; !ok {
+			m.correlations[given] = make(map[int]float64)
+		}
+		m.correlations[given][target] = prob
+	}
+}
+
+// Merge adds correlations from another model, keeping the higher
+// probability when both models have data for the same pair.
+func (m *Model) Merge(other *Model) {
+	other.mu.RLock()
+	defer other.mu.RUnlock()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for given, targets := range other.correlations {
+		if _, ok := m.correlations[given]; !ok {
+			m.correlations[given] = make(map[int]float64)
+		}
+		for target, prob := range targets {
+			if prob > m.correlations[given][target] {
+				m.correlations[given][target] = prob
+			}
+		}
+	}
+}
+
+// Prioritize ranks candidate ports by their likelihood of being open,
+// given a set of known open ports. For each candidate, the maximum
+// conditional probability across all known open ports is used.
+// All candidates are returned sorted by descending priority; candidates
+// with no correlation data receive a score of 0.
+func (m *Model) Prioritize(candidates []int, openPorts []int) []PortPrediction {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scores := make(map[int]float64, len(candidates))
+	for _, candidate := range candidates {
+		for _, open := range openPorts {
+			if targets, ok := m.correlations[open]; ok {
+				if prob, ok := targets[candidate]; ok && prob > scores[candidate] {
+					scores[candidate] = prob
+				}
+			}
+		}
+	}
+
+	predictions := make([]PortPrediction, len(candidates))
+	for i, c := range candidates {
+		predictions[i] = PortPrediction{Port: c, Confidence: scores[c]}
+	}
+
+	sort.Slice(predictions, func(i, j int) bool {
+		if predictions[i].Confidence != predictions[j].Confidence {
+			return predictions[i].Confidence > predictions[j].Confidence
+		}
+		return predictions[i].Port < predictions[j].Port
+	})
+
+	return predictions
+}
+
+// GetCorrelations returns all P(target | given) entries for a given port.
+// The returned map is a copy safe for concurrent use.
+func (m *Model) GetCorrelations(givenPort int) map[int]float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	targets, ok := m.correlations[givenPort]
+	if !ok {
+		return nil
+	}
+	out := make(map[int]float64, len(targets))
+	for k, v := range targets {
+		out[k] = v
+	}
+	return out
+}
+
+// Stats returns the number of source ports and total correlation entries.
+func (m *Model) Stats() (sourcePorts, totalEntries int) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	sourcePorts = len(m.correlations)
+	for _, targets := range m.correlations {
+		totalEntries += len(targets)
+	}
+	return
+}

--- a/pkg/prediction/model_test.go
+++ b/pkg/prediction/model_test.go
@@ -1,0 +1,206 @@
+package prediction
+
+import (
+	"testing"
+)
+
+func TestPredictBasic(t *testing.T) {
+	m := NewModel()
+	m.Set(80, 443, 0.85)
+	m.Set(80, 8080, 0.30)
+	m.Set(80, 8888, 0.10)
+	m.Set(22, 80, 0.70)
+
+	preds := m.Predict([]int{80}, 0.2)
+	if len(preds) != 2 {
+		t.Fatalf("expected 2 predictions above 0.2, got %d: %+v", len(preds), preds)
+	}
+	if preds[0].Port != 443 || preds[0].Confidence != 0.85 {
+		t.Errorf("first prediction should be 443@0.85, got %d@%.2f", preds[0].Port, preds[0].Confidence)
+	}
+	if preds[1].Port != 8080 || preds[1].Confidence != 0.30 {
+		t.Errorf("second prediction should be 8080@0.30, got %d@%.2f", preds[1].Port, preds[1].Confidence)
+	}
+}
+
+func TestPredictMaxAcrossPorts(t *testing.T) {
+	m := NewModel()
+	m.Set(80, 3306, 0.15)
+	m.Set(22, 3306, 0.40)
+
+	// With both 80 and 22 open, 3306 should use max(0.15, 0.40) = 0.40
+	preds := m.Predict([]int{80, 22}, 0.2)
+	found := false
+	for _, p := range preds {
+		if p.Port == 3306 {
+			found = true
+			if p.Confidence != 0.40 {
+				t.Errorf("expected confidence 0.40, got %.2f", p.Confidence)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected port 3306 in predictions")
+	}
+}
+
+func TestPredictSkipsOpenPorts(t *testing.T) {
+	m := NewModel()
+	m.Set(80, 443, 0.85)
+	m.Set(80, 22, 0.40)
+
+	// 443 is already open, should not be predicted
+	preds := m.Predict([]int{80, 443}, 0.2)
+	for _, p := range preds {
+		if p.Port == 443 || p.Port == 80 {
+			t.Errorf("should not predict already-open port %d", p.Port)
+		}
+	}
+}
+
+func TestPredictNoResults(t *testing.T) {
+	m := NewModel()
+	preds := m.Predict([]int{99999}, 0.2)
+	if len(preds) != 0 {
+		t.Errorf("expected 0 predictions for unknown port, got %d", len(preds))
+	}
+}
+
+func TestTrain(t *testing.T) {
+	m := NewModel()
+	hostPorts := map[string][]int{
+		"1.1.1.1": {80, 443, 22},
+		"2.2.2.2": {80, 443},
+		"3.3.3.3": {80, 22},
+		"4.4.4.4": {80},
+	}
+	m.Train(hostPorts)
+
+	// P(443 | 80) = 2/4 = 0.50 (hosts 1,2 have both)
+	preds := m.Predict([]int{80}, 0.0)
+	var found443, found22 bool
+	for _, p := range preds {
+		if p.Port == 443 {
+			found443 = true
+			if p.Confidence != 0.5 {
+				t.Errorf("P(443|80) should be 0.5, got %.4f", p.Confidence)
+			}
+		}
+		if p.Port == 22 {
+			found22 = true
+			if p.Confidence != 0.5 {
+				t.Errorf("P(22|80) should be 0.5, got %.4f", p.Confidence)
+			}
+		}
+	}
+	if !found443 {
+		t.Error("expected port 443 in trained predictions")
+	}
+	if !found22 {
+		t.Error("expected port 22 in trained predictions")
+	}
+
+	// P(80 | 22) = 2/2 = 1.0 (all hosts with 22 also have 80)
+	preds22 := m.Predict([]int{22}, 0.0)
+	for _, p := range preds22 {
+		if p.Port == 80 && p.Confidence != 1.0 {
+			t.Errorf("P(80|22) should be 1.0, got %.4f", p.Confidence)
+		}
+	}
+}
+
+func TestDefaultModel(t *testing.T) {
+	m := DefaultModel()
+	srcPorts, totalEntries := m.Stats()
+	if srcPorts == 0 || totalEntries == 0 {
+		t.Fatal("default model should have correlations")
+	}
+
+	// Basic sanity: port 80 should predict 443
+	preds := m.Predict([]int{80}, 0.5)
+	found := false
+	for _, p := range preds {
+		if p.Port == 443 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("default model should predict 443 given port 80")
+	}
+}
+
+func TestPrioritize(t *testing.T) {
+	m := NewModel()
+	m.Set(80, 443, 0.85)
+	m.Set(80, 8080, 0.30)
+	m.Set(22, 3306, 0.40)
+
+	// Given ports 80 and 22 are open, rank candidates [443, 8080, 3306, 9999]
+	ranked := m.Prioritize([]int{443, 8080, 3306, 9999}, []int{80, 22})
+	if len(ranked) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(ranked))
+	}
+	// 443 should be first (0.85), then 3306 (0.40), then 8080 (0.30), then 9999 (0.0)
+	expected := []struct {
+		port int
+		conf float64
+	}{
+		{443, 0.85},
+		{3306, 0.40},
+		{8080, 0.30},
+		{9999, 0.0},
+	}
+	for i, exp := range expected {
+		if ranked[i].Port != exp.port {
+			t.Errorf("position %d: expected port %d, got %d", i, exp.port, ranked[i].Port)
+		}
+		if ranked[i].Confidence != exp.conf {
+			t.Errorf("position %d: expected confidence %.2f, got %.2f", i, exp.conf, ranked[i].Confidence)
+		}
+	}
+}
+
+func TestPrioritizeNoOpenPorts(t *testing.T) {
+	m := NewModel()
+	m.Set(80, 443, 0.85)
+
+	// No open ports, all candidates should get 0 confidence
+	ranked := m.Prioritize([]int{443, 80, 22}, nil)
+	for _, r := range ranked {
+		if r.Confidence != 0 {
+			t.Errorf("expected 0 confidence with no open ports, got %.2f for port %d", r.Confidence, r.Port)
+		}
+	}
+}
+
+func TestMerge(t *testing.T) {
+	m1 := NewModel()
+	m1.Set(80, 443, 0.50)
+	m1.Set(80, 8080, 0.30)
+
+	m2 := NewModel()
+	m2.Set(80, 443, 0.90)
+	m2.Set(22, 80, 0.70)
+
+	m1.Merge(m2)
+
+	// Should keep higher probability for 80->443
+	preds := m1.Predict([]int{80}, 0.0)
+	for _, p := range preds {
+		if p.Port == 443 && p.Confidence != 0.90 {
+			t.Errorf("merged P(443|80) should be 0.90, got %.2f", p.Confidence)
+		}
+	}
+
+	// Should have new entry from m2
+	preds22 := m1.Predict([]int{22}, 0.0)
+	found := false
+	for _, p := range preds22 {
+		if p.Port == 80 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("merge should include 22->80 from m2")
+	}
+}

--- a/pkg/result/results.go
+++ b/pkg/result/results.go
@@ -185,6 +185,43 @@ func (r *Result) Len() int {
 	return len(r.ips)
 }
 
+// GetOpenPortNumbers returns the deduplicated set of port numbers that
+// have been found open across all hosts. It acquires a single RLock
+// and releases it before returning. Safe to call while writers
+// (ex. AddPort from TCPResultWorker) are active.
+func (r *Result) GetOpenPortNumbers() []int {
+	r.RLock()
+	defer r.RUnlock()
+
+	seen := make(map[int]struct{})
+	for _, ports := range r.ipPorts {
+		for _, p := range ports {
+			seen[p.Port] = struct{}{}
+		}
+	}
+	out := make([]int, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	return out
+}
+
+// GetHostCountForPort returns the number of unique hosts that have a
+// specific port open. Uses a single RLock, safe during concurrent writes.
+func (r *Result) GetHostCountForPort(portNum int) int {
+	r.RLock()
+	defer r.RUnlock()
+
+	key := fmt.Sprintf("%d", portNum)
+	count := 0
+	for _, ports := range r.ipPorts {
+		if _, ok := ports[key]; ok {
+			count++
+		}
+	}
+	return count
+}
+
 // GetPortCount returns the number of ports discovered for an ip
 func (r *Result) GetPortCount(host string) int {
 	r.RLock()

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"net"
 
 	"github.com/Mzack9999/gopacket/rawsend"
@@ -44,7 +45,11 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	if handler.SourceIp4 != nil {
 		srcIP = handler.SourceIp4
 	} else if scan.PkgRouter != nil {
-		_, _, srcIP, _ = scan.PkgRouter.Route(net.IPv4(1, 1, 1, 1))
+		var routeErr error
+		_, _, srcIP, routeErr = scan.PkgRouter.Route(net.IPv4(1, 1, 1, 1))
+		if routeErr != nil {
+			return nil, fmt.Errorf("route lookup failed: %w", routeErr)
+		}
 	}
 	if srcIP == nil {
 		return nil, errNoSourceIP

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -1,0 +1,244 @@
+package runner
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+
+	"github.com/Mzack9999/gopacket/rawsend"
+	"github.com/projectdiscovery/mapcidr"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
+)
+
+// SYNSender builds and sends raw TCP SYN packets without gopacket
+// serialization. Per-packet work: patch 3 fields + one sendto syscall.
+//
+// Sending is delegated to rawsend.Sender (direct sendto) with an
+// optional rawsend.Batch for sendmmsg on Linux.
+//
+// NOT safe for concurrent use, reuses internal buffers.
+type SYNSender struct {
+	sender  *rawsend.Sender
+	batch   *rawsend.Batch
+	srcPort uint16
+	baseSum uint32
+	seq     uint32
+	pkt     [24]byte
+}
+
+var (
+	errNoRawConn    = errors.New("no raw IPv4 connection")
+	errEthernetPath = errors.New("ethernet framing path requires standard sender")
+	errNoSourceIP   = errors.New("cannot determine source IP")
+)
+
+func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
+	if handler == nil || handler.TcpConn4 == nil {
+		return nil, errNoRawConn
+	}
+	if handler.SourceIp4 != nil && handler.SourceHW != nil {
+		return nil, errEthernetPath
+	}
+
+	var srcIP net.IP
+	if handler.SourceIp4 != nil {
+		srcIP = handler.SourceIp4
+	} else if scan.PkgRouter != nil {
+		_, _, srcIP, _ = scan.PkgRouter.Route(net.IPv4(1, 1, 1, 1))
+	}
+	if srcIP == nil {
+		return nil, errNoSourceIP
+	}
+	src4 := srcIP.To4()
+	if src4 == nil {
+		return nil, errNoSourceIP
+	}
+
+	sender, err := rawsend.NewFromIPConn(handler.TcpConn4)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &SYNSender{
+		sender:  sender,
+		batch:   rawsend.NewBatch(sender.FD(), 32, 24),
+		srcPort: uint16(handler.Port),
+	}
+
+	binary.BigEndian.PutUint16(s.pkt[0:2], s.srcPort)
+	s.pkt[12] = 0x60 // DataOffset: 6 words (24 bytes)
+	s.pkt[13] = 0x02 // Flags: SYN
+	binary.BigEndian.PutUint16(s.pkt[14:16], 1024)
+	s.pkt[20] = 2 // MSS option kind
+	s.pkt[21] = 4 // MSS option length
+	binary.BigEndian.PutUint16(s.pkt[22:24], 1460)
+
+	var sum uint32
+	sum += uint32(binary.BigEndian.Uint16(src4[0:2]))
+	sum += uint32(binary.BigEndian.Uint16(src4[2:4]))
+	sum += 6  // zero + protocol (TCP)
+	sum += 24 // TCP segment length
+	sum += uint32(s.srcPort)
+	sum += 0x6002 // DataOff(0x60) | SYN(0x02)
+	sum += 0x0400 // Window(1024)
+	sum += 0x0204 // MSS kind(2) + len(4)
+	sum += 0x05B4 // MSS value(1460)
+	s.baseSum = sum
+
+	return s, nil
+}
+
+func (s *SYNSender) send(dstIP [4]byte, dstPort uint16) error {
+	s.seq++
+	seq := s.seq
+
+	binary.BigEndian.PutUint16(s.pkt[2:4], dstPort)
+	binary.BigEndian.PutUint32(s.pkt[4:8], seq)
+
+	sum := s.baseSum +
+		uint32(binary.BigEndian.Uint16(dstIP[0:2])) +
+		uint32(binary.BigEndian.Uint16(dstIP[2:4])) +
+		uint32(dstPort) +
+		uint32(seq>>16) +
+		uint32(seq&0xffff)
+	sum = (sum >> 16) + (sum & 0xffff)
+	sum += sum >> 16
+	binary.BigEndian.PutUint16(s.pkt[16:18], ^uint16(sum))
+
+	if s.batch != nil {
+		return s.batch.Add(s.pkt[:], dstIP)
+	}
+	return s.sender.SendTo(s.pkt[:], dstIP)
+}
+
+func (s *SYNSender) flush() error {
+	if s.batch != nil {
+		return s.batch.Flush()
+	}
+	return nil
+}
+
+// parseIPv4Fast parses an IPv4 dotted-decimal string directly into a
+// [4]byte. Returns ok=false for IPv6, malformed input, or values > 255.
+// Zero heap allocations.
+func parseIPv4Fast(s string) (ip [4]byte, ok bool) {
+	var octet, dots int
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+			octet = octet*10 + int(c-'0')
+			if octet > 255 {
+				return ip, false
+			}
+		case c == '.':
+			if dots >= 3 {
+				return ip, false
+			}
+			ip[dots] = byte(octet)
+			dots++
+			octet = 0
+		default:
+			return ip, false
+		}
+	}
+	if dots != 3 {
+		return ip, false
+	}
+	ip[3] = byte(octet)
+	return ip, true
+}
+
+// targetIndex replaces PickIP's big.Int arithmetic with uint32 math.
+// For IPv4 targets, computing an IP from a Blackrock index goes from
+// ~3-5µs (big.Int + IntegerToIP + String) to ~10ns (uint32 add + shift).
+
+// indexEntry represents one CIDR block in the target list.
+type indexEntry struct {
+	isV4     bool
+	baseIPv4 uint32     // network base as uint32 (IPv4 only)
+	count    int64      // number of addresses in this CIDR
+	network  *net.IPNet // original, kept for IPv6 fallback
+}
+
+// targetIndex is a pre-computed lookup table that converts a linear
+// index (as produced by Blackrock) into an IPv4 [4]byte address using
+// pure uint32 arithmetic, no big.Int, no net.IP, no string conversion.
+type targetIndex struct {
+	entries []indexEntry
+	total   int64
+}
+
+func buildTargetIndex(targets []*net.IPNet) *targetIndex {
+	idx := &targetIndex{}
+	for _, t := range targets {
+		count := int64(mapcidr.AddressCountIpnet(t))
+		e := indexEntry{
+			count:   count,
+			network: t,
+		}
+		if ip4 := t.IP.To4(); ip4 != nil {
+			e.isV4 = true
+			e.baseIPv4 = binary.BigEndian.Uint32(ip4)
+		}
+		idx.entries = append(idx.entries, e)
+		idx.total += count
+	}
+	return idx
+}
+
+// pickIPv4 converts a global index to an IPv4 address. Returns the
+// address as both a [4]byte (for the fast sender) and a string (for
+// check functions that need map-key lookups).
+//
+// If the index maps to an IPv6 CIDR, isV4 is false and the caller
+// should fall back to the standard PickIP/PickSubnetIP path.
+//
+// Cost: ~10ns + ~25ns string format = ~35ns total, zero heap allocs
+// for the [4]byte path. (The string return does one small alloc.)
+func (t *targetIndex) pickIPv4(index int64) (ip [4]byte, ipStr string, isV4 bool) {
+	for i := range t.entries {
+		e := &t.entries[i]
+		if index < e.count {
+			if !e.isV4 {
+				return ip, "", false
+			}
+			val := e.baseIPv4 + uint32(index)
+			ip[0] = byte(val >> 24)
+			ip[1] = byte(val >> 16)
+			ip[2] = byte(val >> 8)
+			ip[3] = byte(val)
+			ipStr = formatIPv4(ip)
+			return ip, ipStr, true
+		}
+		index -= e.count
+	}
+	return ip, "", false
+}
+
+// formatIPv4 converts a [4]byte IPv4 address to its dotted-decimal
+// string representation. ~25ns, one small heap alloc for the string.
+func formatIPv4(ip [4]byte) string {
+	// Max length: "255.255.255.255" = 15 bytes
+	var buf [15]byte
+	n := 0
+	for i := 0; i < 4; i++ {
+		if i > 0 {
+			buf[n] = '.'
+			n++
+		}
+		v := ip[i]
+		if v >= 100 {
+			buf[n] = v/100 + '0'
+			n++
+			buf[n] = (v/10)%10 + '0'
+			n++
+		} else if v >= 10 {
+			buf[n] = v/10 + '0'
+			n++
+		}
+		buf[n] = v%10 + '0'
+		n++
+	}
+	return string(buf[:n])
+}

--- a/pkg/runner/fastsend_test.go
+++ b/pkg/runner/fastsend_test.go
@@ -1,0 +1,218 @@
+package runner
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+func TestParseIPv4Fast(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected [4]byte
+		ok       bool
+	}{
+		{"192.168.1.1", [4]byte{192, 168, 1, 1}, true},
+		{"0.0.0.0", [4]byte{0, 0, 0, 0}, true},
+		{"255.255.255.255", [4]byte{255, 255, 255, 255}, true},
+		{"10.0.0.1", [4]byte{10, 0, 0, 1}, true},
+		{"1.1.1.1", [4]byte{1, 1, 1, 1}, true},
+		{"256.0.0.1", [4]byte{}, false},
+		{"1.2.3", [4]byte{}, false},
+		{"1.2.3.4.5", [4]byte{}, false},
+		{"::1", [4]byte{}, false},
+		{"abc", [4]byte{}, false},
+		{"", [4]byte{}, false},
+	}
+
+	for _, tt := range tests {
+		ip, ok := parseIPv4Fast(tt.input)
+		if ok != tt.ok {
+			t.Errorf("parseIPv4Fast(%q): got ok=%v, want %v", tt.input, ok, tt.ok)
+			continue
+		}
+		if ok && ip != tt.expected {
+			t.Errorf("parseIPv4Fast(%q): got %v, want %v", tt.input, ip, tt.expected)
+		}
+	}
+}
+
+func TestSYNPacketChecksum(t *testing.T) {
+	// Manually compute the expected checksum for a known packet
+	// and verify our incremental approach matches.
+	srcIP := [4]byte{192, 168, 1, 100}
+	dstIP := [4]byte{10, 0, 0, 1}
+	srcPort := uint16(12345)
+	dstPort := uint16(80)
+	seq := uint32(42)
+
+	// Full checksum computation (reference implementation)
+	var fullSum uint32
+	// Pseudo-header
+	fullSum += uint32(binary.BigEndian.Uint16(srcIP[0:2]))
+	fullSum += uint32(binary.BigEndian.Uint16(srcIP[2:4]))
+	fullSum += uint32(binary.BigEndian.Uint16(dstIP[0:2]))
+	fullSum += uint32(binary.BigEndian.Uint16(dstIP[2:4]))
+	fullSum += 6  // protocol
+	fullSum += 24 // TCP length
+	// TCP header words
+	fullSum += uint32(srcPort)
+	fullSum += uint32(dstPort)
+	fullSum += uint32(seq >> 16)
+	fullSum += uint32(seq & 0xffff)
+	fullSum += 0      // ack high
+	fullSum += 0      // ack low
+	fullSum += 0x6002 // data offset + SYN
+	fullSum += 0x0400 // window
+	fullSum += 0      // checksum (zeroed)
+	fullSum += 0      // urgent
+	fullSum += 0x0204 // MSS kind+len
+	fullSum += 0x05B4 // MSS value
+	fullSum = (fullSum >> 16) + (fullSum & 0xffff)
+	fullSum += fullSum >> 16
+	expectedChecksum := ^uint16(fullSum)
+
+	// Incremental computation (our fast path)
+	var baseSum uint32
+	baseSum += uint32(binary.BigEndian.Uint16(srcIP[0:2]))
+	baseSum += uint32(binary.BigEndian.Uint16(srcIP[2:4]))
+	baseSum += 6
+	baseSum += 24
+	baseSum += uint32(srcPort)
+	baseSum += 0x6002
+	baseSum += 0x0400
+	baseSum += 0x0204
+	baseSum += 0x05B4
+
+	sum := baseSum +
+		uint32(binary.BigEndian.Uint16(dstIP[0:2])) +
+		uint32(binary.BigEndian.Uint16(dstIP[2:4])) +
+		uint32(dstPort) +
+		uint32(seq>>16) +
+		uint32(seq&0xffff)
+	sum = (sum >> 16) + (sum & 0xffff)
+	sum += sum >> 16
+	gotChecksum := ^uint16(sum)
+
+	if gotChecksum != expectedChecksum {
+		t.Errorf("checksum mismatch: incremental=0x%04x, reference=0x%04x", gotChecksum, expectedChecksum)
+	}
+}
+
+func TestFormatIPv4(t *testing.T) {
+	tests := []struct {
+		ip       [4]byte
+		expected string
+	}{
+		{[4]byte{192, 168, 1, 1}, "192.168.1.1"},
+		{[4]byte{0, 0, 0, 0}, "0.0.0.0"},
+		{[4]byte{255, 255, 255, 255}, "255.255.255.255"},
+		{[4]byte{10, 0, 0, 1}, "10.0.0.1"},
+		{[4]byte{1, 2, 3, 4}, "1.2.3.4"},
+		{[4]byte{100, 200, 30, 4}, "100.200.30.4"},
+	}
+	for _, tt := range tests {
+		got := formatIPv4(tt.ip)
+		if got != tt.expected {
+			t.Errorf("formatIPv4(%v) = %q, want %q", tt.ip, got, tt.expected)
+		}
+	}
+}
+
+func TestTargetIndex(t *testing.T) {
+	_, cidr24, _ := net.ParseCIDR("192.168.1.0/24")
+	_, cidr16, _ := net.ParseCIDR("10.0.0.0/16")
+
+	idx := buildTargetIndex([]*net.IPNet{cidr24, cidr16})
+
+	// First CIDR: 192.168.1.0/24 -> 256 addresses
+	ip, ipStr, ok := idx.pickIPv4(0)
+	if !ok || ip != [4]byte{192, 168, 1, 0} || ipStr != "192.168.1.0" {
+		t.Errorf("index 0: got ip=%v str=%q ok=%v", ip, ipStr, ok)
+	}
+
+	ip, ipStr, ok = idx.pickIPv4(255)
+	if !ok || ip != [4]byte{192, 168, 1, 255} || ipStr != "192.168.1.255" {
+		t.Errorf("index 255: got ip=%v str=%q ok=%v", ip, ipStr, ok)
+	}
+
+	// Second CIDR starts at index 256: 10.0.0.0/16
+	ip, ipStr, ok = idx.pickIPv4(256)
+	if !ok || ip != [4]byte{10, 0, 0, 0} || ipStr != "10.0.0.0" {
+		t.Errorf("index 256: got ip=%v str=%q ok=%v", ip, ipStr, ok)
+	}
+
+	ip, ipStr, ok = idx.pickIPv4(256 + 65535)
+	if !ok || ip != [4]byte{10, 0, 255, 255} || ipStr != "10.0.255.255" {
+		t.Errorf("index 256+65535: got ip=%v str=%q ok=%v", ip, ipStr, ok)
+	}
+
+	// Out of range
+	_, _, ok = idx.pickIPv4(256 + 65536)
+	if ok {
+		t.Error("expected ok=false for out-of-range index")
+	}
+}
+
+func TestFormatIPv4RoundTrip(t *testing.T) {
+	// Verify formatIPv4 and parseIPv4Fast are inverses.
+	ips := [][4]byte{
+		{0, 0, 0, 0}, {1, 2, 3, 4}, {10, 0, 0, 1},
+		{192, 168, 1, 100}, {255, 255, 255, 255},
+	}
+	for _, ip := range ips {
+		s := formatIPv4(ip)
+		parsed, ok := parseIPv4Fast(s)
+		if !ok || parsed != ip {
+			t.Errorf("round-trip failed: %v -> %q -> %v (ok=%v)", ip, s, parsed, ok)
+		}
+	}
+}
+
+func BenchmarkParseIPv4Fast(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		parseIPv4Fast("192.168.1.1")
+	}
+}
+
+func BenchmarkFormatIPv4(b *testing.B) {
+	ip := [4]byte{192, 168, 1, 100}
+	for i := 0; i < b.N; i++ {
+		_ = formatIPv4(ip)
+	}
+}
+
+func BenchmarkTargetIndexPickIPv4(b *testing.B) {
+	_, cidr, _ := net.ParseCIDR("10.0.0.0/8")
+	idx := buildTargetIndex([]*net.IPNet{cidr})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.pickIPv4(int64(i) % idx.total)
+	}
+}
+
+func BenchmarkSYNChecksum(b *testing.B) {
+	srcIP := [4]byte{192, 168, 1, 100}
+	var baseSum uint32
+	baseSum += uint32(binary.BigEndian.Uint16(srcIP[0:2]))
+	baseSum += uint32(binary.BigEndian.Uint16(srcIP[2:4]))
+	baseSum += 6 + 24 + 12345 + 0x6002 + 0x0400 + 0x0204 + 0x05B4
+
+	dstIP := [4]byte{10, 0, 0, 1}
+	dstPort := uint16(80)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		seq := uint32(i)
+		sum := baseSum +
+			uint32(binary.BigEndian.Uint16(dstIP[0:2])) +
+			uint32(binary.BigEndian.Uint16(dstIP[2:4])) +
+			uint32(dstPort) +
+			uint32(seq>>16) +
+			uint32(seq&0xffff)
+		sum = (sum >> 16) + (sum & 0xffff)
+		sum += sum >> 16
+		_ = ^uint16(sum)
+	}
+}

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -378,7 +378,7 @@ func (options *Options) hasProbes() bool {
 	//nolint
 	return options.ArpPing || options.IPv6NeighborDiscoveryPing || options.IcmpAddressMaskRequestProbe ||
 		options.IcmpEchoRequestProbe || options.IcmpTimestampRequestProbe || len(options.TcpAckPingProbes) > 0 ||
-		len(options.TcpAckPingProbes) > 0
+		len(options.TcpSynPingProbes) > 0
 }
 
 func (options *Options) shouldUseRawPackets() bool {

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -136,6 +136,13 @@ type Options struct {
 	// OnClose adds a callback function that is invoked when naabu is closed
 	// to be exact at end of existing closures
 	OnClose func()
+
+	// SmartScan enables predictive port scanning: after the initial scan,
+	// a correlation model predicts additional likely-open ports per host.
+	SmartScan bool
+	// PredictionThreshold is the minimum confidence percentage (0–100) to
+	// act on a port prediction (default 20, meaning 20%).
+	PredictionThreshold int
 }
 
 // ParseOptions parses the command line flags provided by a user
@@ -235,6 +242,8 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.WarmUpTime, "warm-up-time", 2, "time in seconds between scan phases"),
 		flagSet.BoolVar(&options.Ping, "ping", false, "ping probes for verification of host"),
 		flagSet.BoolVar(&options.Verify, "verify", false, "validate the ports again with TCP verification"),
+		flagSet.BoolVarP(&options.SmartScan, "smart-scan", "ss", false, "predictive port scanning using port correlation model"),
+		flagSet.IntVarP(&options.PredictionThreshold, "prediction-threshold", "pt", 20, "minimum confidence for port predictions (0-100%)"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -545,132 +545,139 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 		targetsWithPortCount = uint64(len(targetsWithPort))
 
 		r.scanner.ListenHandler.Phase.Set(scan.Scan)
-		Range := targetsCount * portsCount
-		if r.options.EnableProgressBar {
-			r.stats.AddStatic("ports", portsCount)
-			r.stats.AddStatic("hosts", targetsCount)
-			r.stats.AddStatic("retries", r.options.Retries)
-			r.stats.AddStatic("startedAt", time.Now())
-			r.stats.AddCounter("packets", uint64(0))
-			r.stats.AddCounter("errors", uint64(0))
-			r.stats.AddCounter("total", Range*uint64(r.options.Retries)+targetsWithPortCount)
-			r.stats.AddStatic("hosts_with_port", targetsWithPortCount)
-			if err := r.stats.Start(); err != nil {
-				gologger.Warning().Msgf("Couldn't start statistics: %s\n", err)
+
+		if r.options.SmartScan {
+			// Predictive scan: two-phase priority-ordered scan of the
+			// user's port list, reordered by the correlation model.
+			r.runPredictiveScan(ctx, targets, targetsWithPort, shouldUseRawPackets)
+		} else {
+			Range := targetsCount * portsCount
+			if r.options.EnableProgressBar {
+				r.stats.AddStatic("ports", portsCount)
+				r.stats.AddStatic("hosts", targetsCount)
+				r.stats.AddStatic("retries", r.options.Retries)
+				r.stats.AddStatic("startedAt", time.Now())
+				r.stats.AddCounter("packets", uint64(0))
+				r.stats.AddCounter("errors", uint64(0))
+				r.stats.AddCounter("total", Range*uint64(r.options.Retries)+targetsWithPortCount)
+				r.stats.AddStatic("hosts_with_port", targetsWithPortCount)
+				if err := r.stats.Start(); err != nil {
+					gologger.Warning().Msgf("Couldn't start statistics: %s\n", err)
+				}
 			}
-		}
 
-		// Retries are performed regardless of the previous scan results due to network unreliability
-		for currentRetry := 0; currentRetry < r.options.Retries; currentRetry++ {
-			if currentRetry < r.options.ResumeCfg.Retry {
-				gologger.Debug().Msgf("Skipping Retry: %d\n", currentRetry)
-				continue
-			}
-
-			// Use current time as seed
-			currentSeed := time.Now().UnixNano()
-			r.options.ResumeCfg.RLock()
-			if r.options.ResumeCfg.Seed > 0 {
-				currentSeed = r.options.ResumeCfg.Seed
-			}
-			r.options.ResumeCfg.RUnlock()
-
-			// keep track of current retry and seed for resume
-			r.options.ResumeCfg.Lock()
-			r.options.ResumeCfg.Retry = currentRetry
-			r.options.ResumeCfg.Seed = currentSeed
-			r.options.ResumeCfg.Unlock()
-
-			b := blackrock.New(int64(Range), currentSeed)
-			for index := int64(0); index < int64(Range); index++ {
-				xxx := b.Shuffle(index)
-				ipIndex := xxx / int64(portsCount)
-				portIndex := int(xxx % int64(portsCount))
-				ip := r.PickIP(targets, ipIndex)
-
-				if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
+			// Retries are performed regardless of the previous scan results due to network unreliability
+			for currentRetry := 0; currentRetry < r.options.Retries; currentRetry++ {
+				if currentRetry < r.options.ResumeCfg.Retry {
+					gologger.Debug().Msgf("Skipping Retry: %d\n", currentRetry)
 					continue
 				}
 
-				port := r.PickPort(portIndex)
-
+				// Use current time as seed
+				currentSeed := time.Now().UnixNano()
 				r.options.ResumeCfg.RLock()
-				resumeCfgIndex := r.options.ResumeCfg.Index
-				r.options.ResumeCfg.RUnlock()
-				if index < resumeCfgIndex {
-					gologger.Debug().Msgf("Skipping \"%s:%d\": Resume - Port scan already completed\n", ip, port.Port)
-					continue
+				if r.options.ResumeCfg.Seed > 0 {
+					currentSeed = r.options.ResumeCfg.Seed
 				}
+				r.options.ResumeCfg.RUnlock()
 
-				// resume cfg logic
+				// keep track of current retry and seed for resume
 				r.options.ResumeCfg.Lock()
-				r.options.ResumeCfg.Index = index
+				r.options.ResumeCfg.Retry = currentRetry
+				r.options.ResumeCfg.Seed = currentSeed
 				r.options.ResumeCfg.Unlock()
 
-				if r.scanner.ScanResults.HasSkipped(ip) {
-					continue
-				}
-				if r.options.PortThreshold > 0 && r.scanner.ScanResults.GetPortCount(ip) >= r.options.PortThreshold {
-					hosts, _ := r.scanner.IPRanger.GetHostsByIP(ip)
-					gologger.Info().Msgf("Skipping %s %v, Threshold reached \n", ip, hosts)
-					r.scanner.ScanResults.AddSkipped(ip)
-					continue
+				b := blackrock.New(int64(Range), currentSeed)
+				for index := int64(0); index < int64(Range); index++ {
+					xxx := b.Shuffle(index)
+					ipIndex := xxx / int64(portsCount)
+					portIndex := int(xxx % int64(portsCount))
+					ip := r.PickIP(targets, ipIndex)
+
+					if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
+						continue
+					}
+
+					port := r.PickPort(portIndex)
+
+					r.options.ResumeCfg.RLock()
+					resumeCfgIndex := r.options.ResumeCfg.Index
+					r.options.ResumeCfg.RUnlock()
+					if index < resumeCfgIndex {
+						gologger.Debug().Msgf("Skipping \"%s:%d\": Resume - Port scan already completed\n", ip, port.Port)
+						continue
+					}
+
+					// resume cfg logic
+					r.options.ResumeCfg.Lock()
+					r.options.ResumeCfg.Index = index
+					r.options.ResumeCfg.Unlock()
+
+					if r.scanner.ScanResults.HasSkipped(ip) {
+						continue
+					}
+					if r.options.PortThreshold > 0 && r.scanner.ScanResults.GetPortCount(ip) >= r.options.PortThreshold {
+						hosts, _ := r.scanner.IPRanger.GetHostsByIP(ip)
+						gologger.Info().Msgf("Skipping %s %v, Threshold reached \n", ip, hosts)
+						r.scanner.ScanResults.AddSkipped(ip)
+						continue
+					}
+
+					// connect scan
+					if shouldUseRawPackets {
+						r.RawSocketEnumeration(ctx, ip, port)
+					} else {
+						r.wgscan.Add()
+						go r.handleHostPort(ctx, ip, payload, port)
+					}
+					if r.options.EnableProgressBar {
+						r.stats.IncrementCounter("packets", 1)
+					}
 				}
 
-				// connect scan
-				if shouldUseRawPackets {
-					r.RawSocketEnumeration(ctx, ip, port)
-				} else {
-					r.wgscan.Add()
-					go r.handleHostPort(ctx, ip, payload, port)
+				// handle the ip:port combination
+				for _, targetWithPort := range targetsWithPort {
+					ip, p, err := net.SplitHostPort(targetWithPort)
+					if err != nil {
+						gologger.Debug().Msgf("Skipping %s: %v\n", targetWithPort, err)
+						continue
+					}
+
+					// naive port find
+					pp, err := strconv.Atoi(p)
+					if err != nil {
+						gologger.Debug().Msgf("Skipping %s, could not cast port %s: %v\n", targetWithPort, p, err)
+						continue
+					}
+					var portWithMetadata = port.Port{
+						Port:     pp,
+						Protocol: protocol.TCP,
+					}
+
+					// connect scan
+					if shouldUseRawPackets {
+						r.RawSocketEnumeration(ctx, ip, &portWithMetadata)
+					} else {
+						r.wgscan.Add()
+						go r.handleHostPort(ctx, ip, payload, &portWithMetadata)
+					}
+					if r.options.EnableProgressBar {
+						r.stats.IncrementCounter("packets", 1)
+					}
 				}
-				if r.options.EnableProgressBar {
-					r.stats.IncrementCounter("packets", 1)
+
+				r.wgscan.Wait()
+
+				r.options.ResumeCfg.Lock()
+				if r.options.ResumeCfg.Seed > 0 {
+					r.options.ResumeCfg.Seed = 0
 				}
+				if r.options.ResumeCfg.Index > 0 {
+					// zero also the current index as we are restarting the scan
+					r.options.ResumeCfg.Index = 0
+				}
+				r.options.ResumeCfg.Unlock()
 			}
-
-			// handle the ip:port combination
-			for _, targetWithPort := range targetsWithPort {
-				ip, p, err := net.SplitHostPort(targetWithPort)
-				if err != nil {
-					gologger.Debug().Msgf("Skipping %s: %v\n", targetWithPort, err)
-					continue
-				}
-
-				// naive port find
-				pp, err := strconv.Atoi(p)
-				if err != nil {
-					gologger.Debug().Msgf("Skipping %s, could not cast port %s: %v\n", targetWithPort, p, err)
-					continue
-				}
-				var portWithMetadata = port.Port{
-					Port:     pp,
-					Protocol: protocol.TCP,
-				}
-
-				// connect scan
-				if shouldUseRawPackets {
-					r.RawSocketEnumeration(ctx, ip, &portWithMetadata)
-				} else {
-					r.wgscan.Add()
-					go r.handleHostPort(ctx, ip, payload, &portWithMetadata)
-				}
-				if r.options.EnableProgressBar {
-					r.stats.IncrementCounter("packets", 1)
-				}
-			}
-
-			r.wgscan.Wait()
-
-			r.options.ResumeCfg.Lock()
-			if r.options.ResumeCfg.Seed > 0 {
-				r.options.ResumeCfg.Seed = 0
-			}
-			if r.options.ResumeCfg.Index > 0 {
-				// zero also the current index as we are restarting the scan
-				r.options.ResumeCfg.Index = 0
-			}
-			r.options.ResumeCfg.Unlock()
 		}
 
 		warmUpTime := 2 * time.Second

--- a/pkg/runner/smartscan.go
+++ b/pkg/runner/smartscan.go
@@ -416,14 +416,20 @@ func buildPopularityRank() map[int]int {
 		segment = strings.TrimSpace(segment)
 		if strings.Contains(segment, "-") {
 			parts := strings.Split(segment, "-")
-			start, _ := strconv.Atoi(parts[0])
-			end, _ := strconv.Atoi(parts[1])
+			start, err1 := strconv.Atoi(parts[0])
+			end, err2 := strconv.Atoi(parts[1])
+			if err1 != nil || err2 != nil {
+				continue
+			}
 			for p := start; p <= end; p++ {
 				rank[p] = idx
 				idx++
 			}
 		} else {
-			p, _ := strconv.Atoi(segment)
+			p, err := strconv.Atoi(segment)
+			if err != nil {
+				continue
+			}
 			rank[p] = idx
 			idx++
 		}

--- a/pkg/runner/smartscan.go
+++ b/pkg/runner/smartscan.go
@@ -1,0 +1,432 @@
+package runner
+
+import (
+	"container/heap"
+	"context"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/projectdiscovery/blackrock"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/mapcidr"
+	"github.com/projectdiscovery/naabu/v2/pkg/port"
+	"github.com/projectdiscovery/naabu/v2/pkg/prediction"
+	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
+	"github.com/projectdiscovery/naabu/v2/pkg/result"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
+)
+
+// runPredictiveScan replaces the Blackrock scan loop with a priority-queue
+// based scan. Ports are dequeued in priority order (most-likely-open first).
+// When a port is found open, the OnReceive callback boosts correlated
+// ports in the queue so they're scanned sooner. The user's port list is
+// never modified, only the scan order changes.
+//
+// For SYN scans, a fast raw-socket sender bypasses gopacket serialization
+// and the single-writer channel, sending packets directly via WriteTo.
+func (r *Runner) runPredictiveScan(ctx context.Context, targets []*net.IPNet, targetsWithPort []string, shouldUseRawPackets bool) {
+	model := prediction.DefaultModel()
+
+	var targetsCount uint64
+	for _, t := range targets {
+		targetsCount += mapcidr.AddressCountIpnet(t)
+	}
+
+	srcPorts, totalCorrelations := model.Stats()
+	gologger.Info().Msgf("Smart scan: model loaded (%d source ports, %d correlations)", srcPorts, totalCorrelations)
+
+	// Fast SYN sender: bypasses gopacket + channel + single writer.
+	// Falls back to standard path for Ethernet framing or IPv6.
+	var sender *SYNSender
+	if shouldUseRawPackets {
+		var err error
+		sender, err = newSYNSender(r.scanner.ListenHandler)
+		if err != nil {
+			gologger.Debug().Msgf("Fast sender unavailable (%s), using standard path\n", err)
+		} else {
+			gologger.Info().Msgf("Smart scan: fast SYN sender active (direct raw socket, zero-copy template)")
+		}
+	}
+
+	// Atomic pointer so the OnReceive callback (fired from
+	// TCPResultWorker goroutine) can safely read the current queue
+	// while the main goroutine replaces it between retries.
+	var queuePtr atomic.Pointer[portQueue]
+
+	origOnReceive := r.scanner.OnReceive
+	wrappedOnReceive := func(hr *result.HostResult) {
+		if q := queuePtr.Load(); q != nil {
+			for _, p := range hr.Ports {
+				q.boostCorrelated(p.Port, model)
+			}
+		}
+		if origOnReceive != nil {
+			origOnReceive(hr)
+		}
+	}
+
+	// OnReceive is read by TCPResultWorker. Phase.Set(scan.Scan) has
+	// already been called by the caller, but no probes have been sent
+	// yet so TcpChan is drained, the write here is ordered before any
+	// SYN-ACK processing.
+	r.scanner.OnReceive = wrappedOnReceive
+	defer func() {
+		r.scanner.OnReceive = origOnReceive
+	}()
+
+	// Pre-compute the target index so per-packet IP generation uses
+	// uint32 arithmetic instead of big.Int.
+	tgtIdx := buildTargetIndex(targets)
+
+	// Monotonic seed for Blackrock: ensures each port gets a unique
+	// IP permutation even when ports are dequeued in rapid succession.
+	var brSeed int64
+
+	timeout := r.options.GetTimeout()
+
+	for retry := 0; retry < r.options.Retries; retry++ {
+		knownOpen := r.collectOpenPorts()
+		pq := newPortQueue(r.scanner.Ports, model, knownOpen)
+		queuePtr.Store(pq)
+
+		if retry == 0 {
+			gologger.Info().Msgf("Smart scan: scanning %d ports across %d hosts (priority queue)", pq.len(), targetsCount)
+		} else {
+			gologger.Info().Msgf("Smart scan: retry %d/%d (%d ports remaining, %d already open)",
+				retry, r.options.Retries-1, pq.len(), len(knownOpen))
+		}
+
+		for {
+			p, ok := pq.pop()
+			if !ok {
+				break
+			}
+			brSeed++
+			r.scanSinglePortOnTargets(ctx, targets, tgtIdx, p, targetsCount, shouldUseRawPackets, sender, brSeed)
+			if sender != nil {
+				sender.flush()
+			}
+		}
+
+		if !shouldUseRawPackets {
+			r.wgscan.Wait()
+		}
+
+		// Wait for in-flight SYN responses before the next retry
+		// so the retry can skip IPs that responded.
+		if shouldUseRawPackets && retry < r.options.Retries-1 {
+			time.Sleep(timeout)
+		}
+	}
+
+	// Detach the queue so late-arriving SYN-ACKs don't try to boost a
+	// stale queue after we return.
+	queuePtr.Store(nil)
+
+	// Let last in-flight SYN packets get responses.
+	if shouldUseRawPackets {
+		time.Sleep(timeout)
+	}
+
+	r.scanTargetsWithPort(ctx, targetsWithPort, shouldUseRawPackets)
+}
+
+// scanSinglePortOnTargets scans one port across all target IPs.
+//
+// When sender is non-nil (fast SYN path), the entire hot loop avoids
+// big.Int, gopacket, channels, and most string allocations:
+//
+//	IP generation:  uint32 add + shift        (~10ns)
+//	IP formatting:  manual decimal formatter   (~25ns)
+//	Packet build:   template patch + checksum  (~15ns)
+//	Send:           direct WriteTo syscall     (~2µs)
+//	                                    total  ~2.1µs/pkt -> ~475K pps
+//
+// The rate limiter is the only intentional throttle.
+func (r *Runner) scanSinglePortOnTargets(ctx context.Context, targets []*net.IPNet, tgtIdx *targetIndex, p *port.Port, targetsCount uint64, shouldUseRawPackets bool, sender *SYNSender, seed int64) {
+	payload := r.options.ConnectPayload
+	b := blackrock.New(int64(targetsCount), seed)
+	useFastPath := sender != nil && p.Protocol == protocol.TCP
+
+	for i := int64(0); i < int64(targetsCount); i++ {
+		if i&0x3ff == 0 {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
+
+		ipIndex := b.Shuffle(i)
+
+		// fast IPv4 path: uint32 arithmetic, no big.Int
+		if useFastPath {
+			dstIP, ip, isV4 := tgtIdx.pickIPv4(ipIndex)
+			if !isV4 {
+				// IPv6: fall back to standard path for this target.
+				ipStr := r.PickIP(targets, ipIndex)
+				if ipStr == "" {
+					continue
+				}
+				r.limiter.Take()
+				r.scanner.EnqueueTCP(ipStr, scan.Syn, p)
+				if r.options.EnableProgressBar {
+					r.stats.IncrementCounter("packets", 1)
+				}
+				continue
+			}
+
+			if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
+				continue
+			}
+			if r.scanner.ScanResults.HasSkipped(ip) {
+				continue
+			}
+			if r.options.PortThreshold > 0 && r.scanner.ScanResults.GetPortCount(ip) >= r.options.PortThreshold {
+				hosts, _ := r.scanner.IPRanger.GetHostsByIP(ip)
+				gologger.Info().Msgf("Skipping %s %v, Threshold reached \n", ip, hosts)
+				r.scanner.ScanResults.AddSkipped(ip)
+				continue
+			}
+			if r.scanner.ScanResults.IPHasPort(ip, p) {
+				continue
+			}
+			if !r.canIScanIfCDN(ip, p) {
+				continue
+			}
+
+			r.limiter.Take()
+			if err := sender.send(dstIP, uint16(p.Port)); err != nil {
+				gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, p.Port, err)
+			}
+			if r.options.EnableProgressBar {
+				r.stats.IncrementCounter("packets", 1)
+			}
+			continue
+		}
+
+		// standard path (CONNECT scan, UDP, no fast sender)
+		ip := r.PickIP(targets, ipIndex)
+		if ip == "" {
+			continue
+		}
+		if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
+			continue
+		}
+		if r.scanner.ScanResults.HasSkipped(ip) {
+			continue
+		}
+		if r.options.PortThreshold > 0 && r.scanner.ScanResults.GetPortCount(ip) >= r.options.PortThreshold {
+			hosts, _ := r.scanner.IPRanger.GetHostsByIP(ip)
+			gologger.Info().Msgf("Skipping %s %v, Threshold reached \n", ip, hosts)
+			r.scanner.ScanResults.AddSkipped(ip)
+			continue
+		}
+
+		if shouldUseRawPackets {
+			if r.scanner.ScanResults.IPHasPort(ip, p) {
+				continue
+			}
+			if !r.canIScanIfCDN(ip, p) {
+				continue
+			}
+			r.limiter.Take()
+			switch p.Protocol {
+			case protocol.TCP:
+				r.scanner.EnqueueTCP(ip, scan.Syn, p)
+			case protocol.UDP:
+				r.scanner.EnqueueUDP(ip, p)
+			}
+		} else {
+			if r.scanner.ScanResults.IPHasPort(ip, p) {
+				continue
+			}
+			if !r.canIScanIfCDN(ip, p) {
+				continue
+			}
+			r.wgscan.Add()
+			go r.handleHostPort(ctx, ip, payload, p)
+		}
+
+		if r.options.EnableProgressBar {
+			r.stats.IncrementCounter("packets", 1)
+		}
+	}
+}
+
+// scanTargetsWithPort handles explicit ip:port targets.
+func (r *Runner) scanTargetsWithPort(ctx context.Context, targetsWithPort []string, shouldUseRawPackets bool) {
+	payload := r.options.ConnectPayload
+	for _, targetWithPort := range targetsWithPort {
+		ip, p, err := net.SplitHostPort(targetWithPort)
+		if err != nil {
+			gologger.Debug().Msgf("Skipping %s: %v\n", targetWithPort, err)
+			continue
+		}
+		pp, err := strconv.Atoi(p)
+		if err != nil {
+			gologger.Debug().Msgf("Skipping %s, could not cast port %s: %v\n", targetWithPort, p, err)
+			continue
+		}
+		portMeta := port.Port{Port: pp, Protocol: protocol.TCP}
+		if shouldUseRawPackets {
+			r.RawSocketEnumeration(ctx, ip, &portMeta)
+		} else {
+			r.wgscan.Add()
+			go r.handleHostPort(ctx, ip, payload, &portMeta)
+		}
+		if r.options.EnableProgressBar {
+			r.stats.IncrementCounter("packets", 1)
+		}
+	}
+	r.wgscan.Wait()
+}
+
+// collectOpenPorts returns the deduplicated set of open port numbers
+// found across all hosts so far.
+func (r *Runner) collectOpenPorts() []int {
+	return r.scanner.ScanResults.GetOpenPortNumbers()
+}
+
+// portQueue: a thread-safe max-heap that maintains a port -> index map so
+// correlated ports can be boosted in O(log n) via heap.Fix.
+
+type pqItem struct {
+	port     *port.Port
+	priority float64
+	heapIdx  int
+}
+
+type portQueue struct {
+	mu    sync.Mutex
+	items []*pqItem
+	index map[int]int // port number -> position in heap
+}
+
+// heap.Interface, called only while mu is held by the public methods.
+func (pq *portQueue) Len() int { return len(pq.items) }
+func (pq *portQueue) Less(i, j int) bool {
+	if pq.items[i].priority != pq.items[j].priority {
+		return pq.items[i].priority > pq.items[j].priority
+	}
+	return pq.items[i].port.Port < pq.items[j].port.Port
+}
+func (pq *portQueue) Swap(i, j int) {
+	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
+	pq.items[i].heapIdx = i
+	pq.items[j].heapIdx = j
+	pq.index[pq.items[i].port.Port] = i
+	pq.index[pq.items[j].port.Port] = j
+}
+func (pq *portQueue) Push(x interface{}) {
+	item := x.(*pqItem)
+	item.heapIdx = len(pq.items)
+	pq.index[item.port.Port] = item.heapIdx
+	pq.items = append(pq.items, item)
+}
+func (pq *portQueue) Pop() interface{} {
+	old := pq.items
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.heapIdx = -1
+	pq.items = old[:n-1]
+	delete(pq.index, item.port.Port)
+	return item
+}
+
+func newPortQueue(ports []*port.Port, model *prediction.Model, knownOpen []int) *portQueue {
+	rank := buildPopularityRank()
+
+	pq := &portQueue{
+		items: make([]*pqItem, 0, len(ports)),
+		index: make(map[int]int, len(ports)),
+	}
+
+	for _, p := range ports {
+		r, ok := rank[p.Port]
+		if !ok {
+			r = 100000 + p.Port
+		}
+		pri := 1.0 / float64(r) // rank 1 -> 1.0, rank 100 -> 0.01
+
+		// Boost from correlations with already-known open ports
+		for _, open := range knownOpen {
+			if corr := model.GetCorrelations(open); corr != nil {
+				if prob, ok := corr[p.Port]; ok && prob > pri {
+					pri = prob
+				}
+			}
+		}
+
+		heap.Push(pq, &pqItem{port: p, priority: pri})
+	}
+
+	return pq
+}
+
+func (pq *portQueue) pop() (*port.Port, bool) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	if len(pq.items) == 0 {
+		return nil, false
+	}
+	item := heap.Pop(pq).(*pqItem)
+	return item.port, true
+}
+
+// boostCorrelated is called from OnReceive when a port is found open.
+// It increases the priority of every port correlated with the newly
+// discovered open port, causing the heap to surface them sooner.
+func (pq *portQueue) boostCorrelated(openPort int, model *prediction.Model) {
+	corr := model.GetCorrelations(openPort)
+	if len(corr) == 0 {
+		return
+	}
+
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	for targetPort, prob := range corr {
+		idx, ok := pq.index[targetPort]
+		if !ok {
+			continue // already scanned / not in user's list
+		}
+		if prob > pq.items[idx].priority {
+			pq.items[idx].priority = prob
+			heap.Fix(pq, idx)
+		}
+	}
+}
+
+func (pq *portQueue) len() int {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	return len(pq.items)
+}
+
+func buildPopularityRank() map[int]int {
+	rank := make(map[int]int, 1200)
+	idx := 1
+	for _, segment := range strings.Split(NmapTop1000, ",") {
+		segment = strings.TrimSpace(segment)
+		if strings.Contains(segment, "-") {
+			parts := strings.Split(segment, "-")
+			start, _ := strconv.Atoi(parts[0])
+			end, _ := strconv.Atoi(parts[1])
+			for p := start; p <= end; p++ {
+				rank[p] = idx
+				idx++
+			}
+		} else {
+			p, _ := strconv.Atoi(segment)
+			rank[p] = idx
+			idx++
+		}
+	}
+	return rank
+}

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -167,6 +167,16 @@ func (options *Options) ValidateOptions() error {
 		options.WarmUpTime = 2
 	}
 
+	if options.SmartScan && options.Stream {
+		return errors.New("smart scan is not supported in stream mode")
+	}
+	if options.SmartScan && options.Passive {
+		return errors.New("smart scan is not supported in passive mode")
+	}
+	if options.PredictionThreshold < 0 || options.PredictionThreshold > 100 {
+		return errors.New("prediction threshold must be between 0 and 100")
+	}
+
 	return nil
 }
 

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -753,13 +753,27 @@ func TransportReadWorker() {
 					if err != nil {
 						continue
 					}
+					hasTransport := false
 					for _, layerType := range decoded {
 						if layerType == layers.LayerTypeTCP || layerType == layers.LayerTypeUDP {
-							srcIP4 := ToString(ip4.SrcIP)
-							srcIP6 := ToString(ip6.SrcIP)
-							transportReaderCallback(tcp, udp, srcIP4, srcIP6)
+							hasTransport = true
+							break
 						}
 					}
+					if !hasTransport {
+						continue
+					}
+					var srcIP4, srcIP6 string
+					for _, layerType := range decoded {
+						switch layerType {
+						case layers.LayerTypeIPv4:
+							srcIP4 = ToString(ip4.SrcIP)
+						case layers.LayerTypeIPv6:
+							srcIP6 = ToString(ip6.SrcIP)
+						}
+					}
+					transportReaderCallback(tcp, udp, srcIP4, srcIP6)
+					break
 				}
 			}
 		}(handler)

--- a/pkg/scan/scan_type_test.go
+++ b/pkg/scan/scan_type_test.go
@@ -103,7 +103,7 @@ func TestNewScanner_FallbackFromSynToConnect(t *testing.T) {
 		ListenHandlers = origHandlers
 	}()
 
-	// Set up: router exists, privileged, but all handlers busy → Acquire fails for SYN
+	// Set up: router exists, privileged, but all handlers busy -> Acquire fails for SYN
 	PkgRouter = &stubRouter{}
 	privileges.IsPrivileged = true
 	ListenHandlers = []*ListenHandler{{Busy: true, Phase: &Phase{}}}


### PR DESCRIPTION
## Description
Adds a smart scan mode that reorders user-provided ports based on a port correlation model, prioritizing ports most likely to be open. When a port is found open, correlated ports get dynamically boosted in the scan queue. This doesn't add or remove any ports from the user's list, it only changes the order they're scanned in. In local benchmarks against a /24 subnet with 1000 ports, smart scan achieved full coverage parity with the standard scan while completing ~95x faster by finding open ports early and deprioritizing unlikely candidates.

```
# standard scan
root@box:~# time naabu -host 192.168.5.0/24 -s s -top-ports 100 -rate 10000 -retries 3 -silent | wc -l
89
real	18m44.473s
user	0m11.407s
sys	0m22.912s

# smart scan (-ss)
root@box:~# time naabu -host 192.168.5.0/24 -s s -top-ports 100 -rate 10000 -retries 3 -silent -ss | wc -l
89
real	0m11.820s
user	0m0.437s
sys	0m1.527s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Predictive "smart scan" mode that prioritizes ports using a learned port-correlation model
  * Flags to enable smart scan and set prediction confidence threshold (0–100%, default 20)
  * Faster raw TCP SYN sender and optimized IPv4 target indexing for high-speed IPv4 scanning
  * New queries to list discovered open ports and count hosts per port

* **Bug Fixes**
  * Improved transport packet handling to validate transport-layer presence before processing

* **Documentation**
  * README updated with new optimization flags and alignment fixes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->