### PR TITLE
runner: bump version constant to 2.6.0

### DIFF
--- a/pkg/runner/banners.go
+++ b/pkg/runner/banners.go
@@ -20,7 +20,7 @@ const banner = `
 `
 
 // Version is the current Version of naabu
-const Version = `2.5.0`
+const Version = `2.6.0`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
This updates `pkg/runner/banners.go` to report `2.6.0` instead of `2.5.0`.

The v2.6.0 source currently reports the older version at runtime (`naabu --version`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version from 2.5.0 to 2.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->