### PR TITLE
add UDP probes opt-in via -uP

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ all ports that return a reply.
  - **Host Discovery** scan (**experimental**)
  - **NMAP** integration for service discovery
  - **Custom UDP payloads** for CONNECT scans
+ - **Native UDP service probes** powered by nmap-service-probes
  - Multiple input support - **STDIN/HOST/IP/CIDR/ASN**
  - Multiple output format support - **JSON/TXT/STDOUT**
 
@@ -93,6 +94,7 @@ SERVICES-DISCOVERY:
    -sV-timeout duration              timeout for service version probes (default 5s)
    -sV-workers int                   number of concurrent service version workers (default 25)
    -sV-probes string                 custom nmap-service-probes file path (auto-detected if empty)
+   -uP, -udp-probes                  send protocol-specific payloads on UDP scans using nmap-service-probes
 
 CONFIGURATION:
    -config string                   path to the naabu configuration file (default $HOME/.config/naabu/config.yaml)
@@ -404,6 +406,21 @@ Available flags:
 | `-sD` | Service discovery (match port number to service name, no active probing) |
 
 The `-sV` flag requires the `nmap-service-probes` database file. Naabu automatically looks for it in standard nmap installation paths. To use a custom file, specify the path with `-sV-probes`.
+
+# UDP Service Probes
+
+UDP services typically stay silent when they receive an empty datagram, so a blind UDP port scan misses most of them. With `-uP` (`-udp-probes`) naabu picks a protocol-specific payload from the `nmap-service-probes` database for each UDP port being scanned (DNS query for 53, NTP request for 123, SNMPv1 GetRequest for 161, and so on), so real services have something to reply to and naabu can report them as open.
+
+```sh
+naabu -host scanme.sh -p u:53,u:123,u:161 -uP
+```
+
+Notes:
+
+- `-uP` is opt-in and additive. When disabled (the default) UDP scans keep their historical zero-length-datagram behavior.
+- The selected probe is the highest-priority (lowest-rarity) match for the destination port; if no probe is registered for a port the scan falls back to the empty datagram.
+- A user-supplied payload via `-cp` always wins over the automatic probe for that port.
+- `-uP` reuses the same probe database as `-sV`, so you can combine the two without paying the parse cost twice. The probe file is auto-located from standard nmap install paths; use `-sV-probes` to point at a custom file. If no database can be found `-uP` logs a warning and is silently disabled.
 
 # CDN/WAF Exclusion
 

--- a/pkg/fingerprint/udp_probes.go
+++ b/pkg/fingerprint/udp_probes.go
@@ -1,0 +1,47 @@
+package fingerprint
+
+import "sort"
+
+// UDPProbesForPort returns every UDP probe from the loaded probe DB
+// whose declared ports include targetPort, ordered by ascending Rarity
+// (most common first). Probes that do not list any port are skipped:
+// the port-scan path only sends bytes when nmap explicitly hinted that
+// they belong on this destination. The slice is empty when the DB is
+// nil or when no probe applies, in which case callers fall back to
+// whatever default they want (typically: empty UDP payload).
+//
+// The returned probes are owned by the ProbeDB and must not be mutated.
+func (db *ProbeDB) UDPProbesForPort(targetPort int) []*ServiceProbe {
+	if db == nil {
+		return nil
+	}
+	var matches []*ServiceProbe
+	for _, sp := range db.Probes {
+		if sp.Protocol != "UDP" {
+			continue
+		}
+		if sp.Ports == nil || !sp.Ports.Contains(targetPort) {
+			continue
+		}
+		if len(sp.Data) == 0 {
+			continue
+		}
+		matches = append(matches, sp)
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return matches[i].Rarity < matches[j].Rarity
+	})
+	return matches
+}
+
+// UDPProbeForPort returns the payload of the highest-priority UDP
+// probe that targets the given port. It returns nil when no probe
+// applies, signalling to the caller that the legacy empty-payload
+// behavior should be kept.
+func (db *ProbeDB) UDPProbeForPort(targetPort int) []byte {
+	probes := db.UDPProbesForPort(targetPort)
+	if len(probes) == 0 {
+		return nil
+	}
+	return probes[0].Data
+}

--- a/pkg/fingerprint/udp_probes_test.go
+++ b/pkg/fingerprint/udp_probes_test.go
@@ -1,0 +1,127 @@
+package fingerprint
+
+import (
+	"bytes"
+	"testing"
+)
+
+func newDNSProbe(rarity int, ports ...int) *ServiceProbe {
+	ps := NewPortSet()
+	for _, p := range ports {
+		ps.Add(p)
+	}
+	return &ServiceProbe{
+		Protocol: "UDP",
+		Name:     "DNSVersionBindReq",
+		Data:     []byte{0x00, 0x06, 0x01, 0x00, 0x00, 0x01},
+		Ports:    ps,
+		Rarity:   rarity,
+	}
+}
+
+func newSNMPProbe(rarity int, ports ...int) *ServiceProbe {
+	ps := NewPortSet()
+	for _, p := range ports {
+		ps.Add(p)
+	}
+	return &ServiceProbe{
+		Protocol: "UDP",
+		Name:     "SNMPv1public",
+		Data:     []byte{0x30, 0x26, 0x02, 0x01, 0x00, 0x04, 0x06, 'p', 'u', 'b', 'l', 'i', 'c'},
+		Ports:    ps,
+		Rarity:   rarity,
+	}
+}
+
+// TestUDPProbesForPortReturnsOnlyMatchingPort pins that probes without
+// the target port are filtered out, so the scanner never sends DNS
+// bytes to an SNMP port (or vice-versa).
+func TestUDPProbesForPortReturnsOnlyMatchingPort(t *testing.T) {
+	db := &ProbeDB{
+		Probes: []*ServiceProbe{
+			newDNSProbe(1, 53),
+			newSNMPProbe(2, 161, 162),
+		},
+	}
+	dns := db.UDPProbesForPort(53)
+	if len(dns) != 1 || dns[0].Name != "DNSVersionBindReq" {
+		t.Fatalf("expected DNS probe for :53, got %+v", dns)
+	}
+	snmp := db.UDPProbesForPort(161)
+	if len(snmp) != 1 || snmp[0].Name != "SNMPv1public" {
+		t.Fatalf("expected SNMP probe for :161, got %+v", snmp)
+	}
+	if got := db.UDPProbesForPort(7); len(got) != 0 {
+		t.Fatalf("expected no probes for :7, got %+v", got)
+	}
+}
+
+// TestUDPProbesForPortOrderedByRarity confirms that the lowest-rarity
+// (most common) probe wins so we don't blow the budget on obscure
+// services first.
+func TestUDPProbesForPortOrderedByRarity(t *testing.T) {
+	common := newDNSProbe(1, 53)
+	common.Name = "Common"
+	rare := newDNSProbe(8, 53)
+	rare.Name = "Rare"
+	db := &ProbeDB{Probes: []*ServiceProbe{rare, common}}
+
+	got := db.UDPProbesForPort(53)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 probes, got %d", len(got))
+	}
+	if got[0].Name != "Common" || got[1].Name != "Rare" {
+		t.Fatalf("probes out of order: %s, %s", got[0].Name, got[1].Name)
+	}
+}
+
+// TestUDPProbesForPortSkipsTCPAndEmpty guarantees that TCP entries and
+// probes with empty payloads (the "NULL" probe family) never reach the
+// UDP scan path.
+func TestUDPProbesForPortSkipsTCPAndEmpty(t *testing.T) {
+	tcpProbe := newDNSProbe(1, 53)
+	tcpProbe.Protocol = "TCP"
+
+	empty := newDNSProbe(1, 53)
+	empty.Data = nil
+
+	db := &ProbeDB{Probes: []*ServiceProbe{tcpProbe, empty}}
+	if got := db.UDPProbesForPort(53); len(got) != 0 {
+		t.Fatalf("expected no usable probes, got %+v", got)
+	}
+}
+
+// TestUDPProbeForPortHappyPath checks the convenience accessor used by
+// the scan path: it must return the bytes of the highest-priority
+// probe.
+func TestUDPProbeForPortHappyPath(t *testing.T) {
+	db := &ProbeDB{Probes: []*ServiceProbe{newDNSProbe(1, 53)}}
+	payload := db.UDPProbeForPort(53)
+	want := []byte{0x00, 0x06, 0x01, 0x00, 0x00, 0x01}
+	if !bytes.Equal(payload, want) {
+		t.Fatalf("UDPProbeForPort(53) = %x, want %x", payload, want)
+	}
+}
+
+// TestUDPProbeForPortMissing documents that an empty result means "no
+// probe configured" - callers must treat this as the signal to fall
+// back to the legacy empty-payload behavior.
+func TestUDPProbeForPortMissing(t *testing.T) {
+	db := &ProbeDB{}
+	if got := db.UDPProbeForPort(53); got != nil {
+		t.Fatalf("expected nil for empty DB, got %x", got)
+	}
+}
+
+// TestUDPProbeForPortNilDB pins the nil-receiver contract: when the
+// runner could not load nmap-service-probes the *ProbeDB is nil, and
+// the scan path must still work.
+func TestUDPProbeForPortNilDB(t *testing.T) {
+	var db *ProbeDB
+	if got := db.UDPProbeForPort(53); got != nil {
+		t.Fatalf("expected nil result from nil DB, got %x", got)
+	}
+	if got := db.UDPProbesForPort(53); got != nil {
+		t.Fatalf("expected nil slice from nil DB, got %+v", got)
+	}
+}

--- a/pkg/runner/ips.go
+++ b/pkg/runner/ips.go
@@ -20,11 +20,10 @@ func (r *Runner) parseExcludedIps(options *Options) ([]string, error) {
 	}
 
 	if options.ExcludeIpsFile != "" {
-		cdata, err := fileutil.ReadFile(options.ExcludeIpsFile)
-		if err != nil {
-			return excludedIps, err
-		}
-		for host := range cdata {
+		for host, err := range fileutil.Lines(options.ExcludeIpsFile) {
+			if err != nil {
+				return excludedIps, err
+			}
 			ips, err := r.getExcludeItems(host)
 			if err != nil {
 				return nil, err

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -119,6 +119,12 @@ type Options struct {
 	ServiceVersionWorkers int
 	// ServiceProbesFile is an optional path to a custom nmap-service-probes file
 	ServiceProbesFile string
+	// UDPProbes enables port-scan-time UDP probing using the
+	// nmap-service-probes data already shipped with naabu. When set,
+	// each UDP packet's payload is replaced with the highest-priority
+	// probe known for the destination port, instead of an empty
+	// datagram. A caller-supplied connect payload (-cp) still wins.
+	UDPProbes bool
 	// ReversePTR lookup for ips
 	ReversePTR bool
 	//DisableUpdateCheck disables automatic update check
@@ -246,6 +252,7 @@ func ParseOptions() *Options {
 		flagSet.DurationVar(&options.ServiceVersionTimeout, "sV-timeout", 5*time.Second, "timeout for service version probes"),
 		flagSet.IntVar(&options.ServiceVersionWorkers, "sV-workers", 25, "number of concurrent service version workers"),
 		flagSet.StringVar(&options.ServiceProbesFile, "sV-probes", "", "custom nmap-service-probes file path (auto-detected if empty)"),
+		flagSet.BoolVarP(&options.UDPProbes, "udp-probes", "uP", false, "send protocol-specific payloads on UDP scans using nmap-service-probes"),
 	)
 
 	flagSet.CreateGroup("optimization", "Optimization",

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -66,6 +66,11 @@ type Runner struct {
 	fpMu         sync.Mutex
 	fpCancel     context.CancelFunc
 	fpCloseOnce  sync.Once
+	// probeDB is the parsed nmap-service-probes database, shared
+	// between service version detection (-sV) and the UDP probe
+	// injection path (-uP). It is nil until one of those features
+	// triggers a successful load.
+	probeDB *fingerprint.ProbeDB
 }
 
 type Target struct {
@@ -386,6 +391,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 	}
 
 	r.initServiceDetection(ctx)
+	r.initUDPProbes()
 
 	if r.options.Stream {
 		go r.Load() //nolint
@@ -1094,15 +1100,13 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 		return
 	}
 
-	db, err := fingerprint.ParseProbeFile(probeFile)
+	db, err := r.loadProbeDB(probeFile)
 	if err != nil {
 		gologger.Info().Label("WRN").Msgf("could not load service probes from %s, skipping -sV", probeFile)
 		r.options.ServiceVersion = false
 		scan.EnableTLSDetection = false
 		return
 	}
-
-	gologger.Info().Msgf("Loaded %d probes from %s", len(db.Probes), probeFile)
 
 	var opts []fingerprint.Option
 	opts = append(opts, fingerprint.WithWorkers(r.options.ServiceVersionWorkers))

--- a/pkg/runner/udp_probes.go
+++ b/pkg/runner/udp_probes.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
-	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 )
 
 // loadProbeDB parses the nmap-service-probes file at path the first
@@ -38,17 +37,20 @@ func (a udpProbeAdapter) UDPProbe(port int) []byte {
 	return a.db.UDPProbeForPort(port)
 }
 
-// initUDPProbes wires the runner's parsed probe database into the
-// scan package's UDP send path. The feature is opt-in via -uP; when
-// disabled or when no probe file is available the call is a no-op and
-// UDP scanning keeps its historical empty-payload behavior.
+// initUDPProbes wires the runner's parsed probe database into its
+// scanner. The feature is opt-in via -uP; when disabled or when no
+// probe file is available the call is a no-op and UDP scanning keeps
+// its historical empty-payload behavior.
 //
-// The global provider is reset up-front so a stale adapter from a
-// previous Runner (when naabu is used as a library) cannot leak into
-// the current scan; the real adapter is installed only after the
-// probe database is parsed successfully.
+// The provider is reset on the scanner up-front so a previous
+// SetUDPProbeProvider call on this scanner cannot leak into a follow
+// up run that no longer wants probing; the real adapter is installed
+// only after the probe database is parsed successfully.
 func (r *Runner) initUDPProbes() {
-	scan.SetUDPProbeProvider(nil)
+	if r.scanner == nil {
+		return
+	}
+	r.scanner.SetUDPProbeProvider(nil)
 	if !r.options.UDPProbes {
 		return
 	}
@@ -67,5 +69,5 @@ func (r *Runner) initUDPProbes() {
 		r.options.UDPProbes = false
 		return
 	}
-	scan.SetUDPProbeProvider(udpProbeAdapter{db: db})
+	r.scanner.SetUDPProbeProvider(udpProbeAdapter{db: db})
 }

--- a/pkg/runner/udp_probes.go
+++ b/pkg/runner/udp_probes.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
+)
+
+// loadProbeDB parses the nmap-service-probes file at path the first
+// time it is asked and memoises the result on the runner, so a follow
+// up call from a different feature (e.g. -uP after -sV) reuses the
+// already-parsed database instead of paying the parse cost twice.
+func (r *Runner) loadProbeDB(path string) (*fingerprint.ProbeDB, error) {
+	if r.probeDB != nil {
+		return r.probeDB, nil
+	}
+	db, err := fingerprint.ParseProbeFile(path)
+	if err != nil {
+		return nil, err
+	}
+	gologger.Info().Msgf("Loaded %d probes from %s", len(db.Probes), path)
+	r.probeDB = db
+	return db, nil
+}
+
+// udpProbeAdapter satisfies scan.UDPProbeProvider by delegating to the
+// loaded fingerprint database. Keeping it in the runner package avoids
+// pulling pkg/fingerprint into pkg/scan and the import cycle that
+// would imply.
+type udpProbeAdapter struct {
+	db *fingerprint.ProbeDB
+}
+
+func (a udpProbeAdapter) UDPProbe(port int) []byte {
+	if a.db == nil {
+		return nil
+	}
+	return a.db.UDPProbeForPort(port)
+}
+
+// initUDPProbes wires the runner's parsed probe database into the
+// scan package's UDP send path. The feature is opt-in via -uP; when
+// disabled or when no probe file is available the call is a no-op and
+// UDP scanning keeps its historical empty-payload behavior.
+func (r *Runner) initUDPProbes() {
+	if !r.options.UDPProbes {
+		return
+	}
+	probeFile := r.options.ServiceProbesFile
+	if probeFile == "" {
+		probeFile = fingerprint.LocateNmapProbes()
+	}
+	if probeFile == "" {
+		gologger.Info().Label("WRN").Msgf("could not find nmap-service-probes, -uP has nothing to send. Install nmap or specify the path with --sV-probes")
+		r.options.UDPProbes = false
+		return
+	}
+	db, err := r.loadProbeDB(probeFile)
+	if err != nil {
+		gologger.Info().Label("WRN").Msgf("could not load service probes from %s for -uP: %s", probeFile, err)
+		r.options.UDPProbes = false
+		return
+	}
+	scan.SetUDPProbeProvider(udpProbeAdapter{db: db})
+}

--- a/pkg/runner/udp_probes.go
+++ b/pkg/runner/udp_probes.go
@@ -42,7 +42,13 @@ func (a udpProbeAdapter) UDPProbe(port int) []byte {
 // scan package's UDP send path. The feature is opt-in via -uP; when
 // disabled or when no probe file is available the call is a no-op and
 // UDP scanning keeps its historical empty-payload behavior.
+//
+// The global provider is reset up-front so a stale adapter from a
+// previous Runner (when naabu is used as a library) cannot leak into
+// the current scan; the real adapter is installed only after the
+// probe database is parsed successfully.
 func (r *Runner) initUDPProbes() {
+	scan.SetUDPProbeProvider(nil)
 	if !r.options.UDPProbes {
 		return
 	}

--- a/pkg/runner/udp_probes_test.go
+++ b/pkg/runner/udp_probes_test.go
@@ -1,0 +1,63 @@
+package runner
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
+)
+
+func makeUDPProbe(name string, rarity int, payload []byte, ports ...int) *fingerprint.ServiceProbe {
+	ps := fingerprint.NewPortSet()
+	for _, p := range ports {
+		ps.Add(p)
+	}
+	return &fingerprint.ServiceProbe{
+		Protocol: "UDP",
+		Name:     name,
+		Data:     payload,
+		Ports:    ps,
+		Rarity:   rarity,
+	}
+}
+
+// TestUDPProbeAdapterReturnsBytes is the happy-path contract: a probe
+// DB containing a UDP probe for a port produces that probe's payload
+// when the scan package asks for it.
+func TestUDPProbeAdapterReturnsBytes(t *testing.T) {
+	db := &fingerprint.ProbeDB{
+		Probes: []*fingerprint.ServiceProbe{
+			makeUDPProbe("DNS", 1, []byte{0x00, 0x06, 0x01}, 53),
+		},
+	}
+	a := udpProbeAdapter{db: db}
+	got := a.UDPProbe(53)
+	if !bytes.Equal(got, []byte{0x00, 0x06, 0x01}) {
+		t.Fatalf("UDPProbe(53) = %x, want 000601", got)
+	}
+}
+
+// TestUDPProbeAdapterUnknownPort documents that ports without a probe
+// produce nil, which is the signal the scan layer uses to keep its
+// empty-payload behavior.
+func TestUDPProbeAdapterUnknownPort(t *testing.T) {
+	db := &fingerprint.ProbeDB{
+		Probes: []*fingerprint.ServiceProbe{
+			makeUDPProbe("DNS", 1, []byte{0xAA}, 53),
+		},
+	}
+	a := udpProbeAdapter{db: db}
+	if got := a.UDPProbe(8080); got != nil {
+		t.Fatalf("UDPProbe(8080) = %x, want nil", got)
+	}
+}
+
+// TestUDPProbeAdapterNilDB confirms the nil-receiver contract: the
+// adapter must work even when the probe file could not be loaded, so
+// the scan path never panics on a misconfigured runner.
+func TestUDPProbeAdapterNilDB(t *testing.T) {
+	a := udpProbeAdapter{db: nil}
+	if got := a.UDPProbe(53); got != nil {
+		t.Fatalf("UDPProbe(53) with nil DB = %x, want nil", got)
+	}
+}

--- a/pkg/runner/udp_probes_test.go
+++ b/pkg/runner/udp_probes_test.go
@@ -67,36 +67,65 @@ func TestUDPProbeAdapterNilDB(t *testing.T) {
 	}
 }
 
-// TestInitUDPProbesDisabledClearsStaleProvider guards the library use
-// case where two runners share a process: a previous run that turned
-// -uP on must not leak its provider into a follow-up run that has
-// -uP off. initUDPProbes restores the no-op provider before doing
-// anything else, so the global is clean regardless of which path is
-// taken.
-func TestInitUDPProbesDisabledClearsStaleProvider(t *testing.T) {
-	scan.SetUDPProbeProvider(stubProvider{payload: []byte{0xDE, 0xAD}})
-	t.Cleanup(func() { scan.SetUDPProbeProvider(nil) })
+// newScannerWithStaleProvider returns a bare *scan.Scanner pre-loaded
+// with a stub UDP probe provider. The Scanner is intentionally not
+// constructed via scan.NewScanner: we only want to exercise the
+// provider plumbing (Scanner field + ListenHandler field), not raw
+// sockets, so a hand-rolled instance keeps the test deterministic on
+// machines without raw-socket privileges.
+func newScannerWithStaleProvider(payload []byte) *scan.Scanner {
+	s := &scan.Scanner{ListenHandler: scan.NewListenHandler()}
+	s.SetUDPProbeProvider(stubProvider{payload: payload})
+	return s
+}
 
-	r := &Runner{options: &Options{UDPProbes: false}}
+// TestInitUDPProbesDisabledClearsStaleProvider guards the library use
+// case where the same Runner is reused or two Runners share a
+// scanner: a previous run that turned -uP on must not leak its
+// provider into a follow-up run that has -uP off. initUDPProbes
+// resets the scanner before doing anything else, so the provider is
+// cleared regardless of which path is taken.
+func TestInitUDPProbesDisabledClearsStaleProvider(t *testing.T) {
+	scanner := newScannerWithStaleProvider([]byte{0xDE, 0xAD})
+
+	r := &Runner{scanner: scanner, options: &Options{UDPProbes: false}}
 	r.initUDPProbes()
 
-	if got := scan.GetUDPProbeProvider().UDPProbe(53); got != nil {
-		t.Fatalf("stale provider leaked: UDPProbe(53) = %x, want nil", got)
+	if got := scanner.UDPProbeProvider; got != nil {
+		t.Fatalf("stale provider leaked on scanner: %#v, want nil", got)
+	}
+	if got := scanner.ListenHandler.UDPProbeProvider; got != nil {
+		t.Fatalf("stale provider leaked on handler: %#v, want nil", got)
 	}
 }
 
 // TestInitUDPProbesMissingFileClearsStaleProvider documents the same
 // invariant for the failure path: enabling -uP without a discoverable
 // nmap-service-probes file must not silently keep a previous run's
-// adapter active.
+// adapter active on the scanner.
 func TestInitUDPProbesMissingFileClearsStaleProvider(t *testing.T) {
-	scan.SetUDPProbeProvider(stubProvider{payload: []byte{0xBE, 0xEF}})
-	t.Cleanup(func() { scan.SetUDPProbeProvider(nil) })
+	scanner := newScannerWithStaleProvider([]byte{0xBE, 0xEF})
 
-	r := &Runner{options: &Options{UDPProbes: true, ServiceProbesFile: "/does/not/exist/nmap-service-probes"}}
+	r := &Runner{
+		scanner: scanner,
+		options: &Options{UDPProbes: true, ServiceProbesFile: "/does/not/exist/nmap-service-probes"},
+	}
 	r.initUDPProbes()
 
-	if got := scan.GetUDPProbeProvider().UDPProbe(53); got != nil {
-		t.Fatalf("stale provider leaked on load failure: UDPProbe(53) = %x, want nil", got)
+	if got := scanner.UDPProbeProvider; got != nil {
+		t.Fatalf("stale provider leaked on load failure (scanner): %#v, want nil", got)
 	}
+	if got := scanner.ListenHandler.UDPProbeProvider; got != nil {
+		t.Fatalf("stale provider leaked on load failure (handler): %#v, want nil", got)
+	}
+}
+
+// TestInitUDPProbesNilScannerNoPanic confirms initUDPProbes is safe
+// to call before the runner's scanner is constructed (e.g. in tests
+// that drive RunEnumeration paths in isolation). Without a scanner
+// there is nothing to install on, and the function must return
+// without panicking.
+func TestInitUDPProbesNilScannerNoPanic(t *testing.T) {
+	r := &Runner{options: &Options{UDPProbes: true}}
+	r.initUDPProbes()
 }

--- a/pkg/runner/udp_probes_test.go
+++ b/pkg/runner/udp_probes_test.go
@@ -5,7 +5,12 @@ import (
 	"testing"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 )
+
+type stubProvider struct{ payload []byte }
+
+func (s stubProvider) UDPProbe(int) []byte { return s.payload }
 
 func makeUDPProbe(name string, rarity int, payload []byte, ports ...int) *fingerprint.ServiceProbe {
 	ps := fingerprint.NewPortSet()
@@ -59,5 +64,39 @@ func TestUDPProbeAdapterNilDB(t *testing.T) {
 	a := udpProbeAdapter{db: nil}
 	if got := a.UDPProbe(53); got != nil {
 		t.Fatalf("UDPProbe(53) with nil DB = %x, want nil", got)
+	}
+}
+
+// TestInitUDPProbesDisabledClearsStaleProvider guards the library use
+// case where two runners share a process: a previous run that turned
+// -uP on must not leak its provider into a follow-up run that has
+// -uP off. initUDPProbes restores the no-op provider before doing
+// anything else, so the global is clean regardless of which path is
+// taken.
+func TestInitUDPProbesDisabledClearsStaleProvider(t *testing.T) {
+	scan.SetUDPProbeProvider(stubProvider{payload: []byte{0xDE, 0xAD}})
+	t.Cleanup(func() { scan.SetUDPProbeProvider(nil) })
+
+	r := &Runner{options: &Options{UDPProbes: false}}
+	r.initUDPProbes()
+
+	if got := scan.GetUDPProbeProvider().UDPProbe(53); got != nil {
+		t.Fatalf("stale provider leaked: UDPProbe(53) = %x, want nil", got)
+	}
+}
+
+// TestInitUDPProbesMissingFileClearsStaleProvider documents the same
+// invariant for the failure path: enabling -uP without a discoverable
+// nmap-service-probes file must not silently keep a previous run's
+// adapter active.
+func TestInitUDPProbesMissingFileClearsStaleProvider(t *testing.T) {
+	scan.SetUDPProbeProvider(stubProvider{payload: []byte{0xBE, 0xEF}})
+	t.Cleanup(func() { scan.SetUDPProbeProvider(nil) })
+
+	r := &Runner{options: &Options{UDPProbes: true, ServiceProbesFile: "/does/not/exist/nmap-service-probes"}}
+	r.initUDPProbes()
+
+	if got := scan.GetUDPProbeProvider().UDPProbe(53); got != nil {
+		t.Fatalf("stale provider leaked on load failure: UDPProbe(53) = %x, want nil", got)
 	}
 }

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -68,11 +68,10 @@ func (options *Options) ValidateOptions() error {
 	}
 
 	if fileutil.FileExists(options.Resolvers) {
-		chanResolvers, err := fileutil.ReadFile(options.Resolvers)
-		if err != nil {
-			return err
-		}
-		for resolver := range chanResolvers {
+		for resolver, err := range fileutil.Lines(options.Resolvers) {
+			if err != nil {
+				return err
+			}
 			options.baseResolvers = append(options.baseResolvers, resolver)
 		}
 	} else if options.Resolvers != "" {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -455,7 +455,15 @@ func (s *Scanner) ConnectPort(host, payload string, p *port.Port, timeout time.D
 		if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
 			return false, err
 		}
-		if _, err := conn.Write([]byte(payload)); err != nil {
+		// When the caller did not pass a custom payload (-cp), let the
+		// configured UDPProbeProvider produce one for the destination
+		// port. With the no-op provider the bytes stay empty and the
+		// legacy behavior is preserved.
+		body := []byte(payload)
+		if len(body) == 0 {
+			body = udpProbePayload(p.Port)
+		}
+		if _, err := conn.Write(body); err != nil {
 			return false, err
 		}
 		if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -105,6 +105,13 @@ type Scanner struct {
 	ListenHandler        *ListenHandler
 	OnReceive            result.ResultFn
 	workersWg            sync.WaitGroup
+	// UDPProbeProvider supplies per-port UDP payloads when the
+	// scanner runs in -uP mode. Keeping it on the Scanner (rather
+	// than as a package-global) lets independent runners coexist in
+	// the same process without clobbering each other; SetUDPProbeProvider
+	// also pushes the value into the ListenHandler so the raw send
+	// path sees it.
+	UDPProbeProvider UDPProbeProvider
 }
 
 // PkgSend is a TCP package
@@ -456,12 +463,12 @@ func (s *Scanner) ConnectPort(host, payload string, p *port.Port, timeout time.D
 			return false, err
 		}
 		// When the caller did not pass a custom payload (-cp), let the
-		// configured UDPProbeProvider produce one for the destination
-		// port. With the no-op provider the bytes stay empty and the
-		// legacy behavior is preserved.
+		// configured per-scanner UDPProbeProvider produce one for the
+		// destination port. With no provider the bytes stay empty
+		// and the legacy behavior is preserved.
 		body := []byte(payload)
 		if len(body) == 0 {
-			body = udpProbePayload(p.Port)
+			body = s.udpProbePayload(p.Port)
 		}
 		if _, err := conn.Write(body); err != nil {
 			return false, err

--- a/pkg/scan/scan_common.go
+++ b/pkg/scan/scan_common.go
@@ -39,6 +39,12 @@ type ListenHandler struct {
 	Port                                   int
 	TcpConn4, UdpConn4, TcpConn6, UdpConn6 *net.IPConn
 	TcpChan, UdpChan, HostDiscoveryChan    chan *PkgResult
+	// UDPProbeProvider is the per-handler probe source used by the
+	// raw UDP send path. It is copied here from the owning Scanner so
+	// sendAsyncUDP4/6 do not need a Scanner reference; nil means "no
+	// probing", which preserves the legacy zero-length-datagram
+	// behavior for callers that have not opted in to -uP.
+	UDPProbeProvider UDPProbeProvider
 }
 
 func NewListenHandler() *ListenHandler {

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -307,7 +307,7 @@ func sendAsyncUDP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 			return
 		}
 
-		err = sendWithConn(ip, listenHandler.UdpConn4, &udp)
+		err = sendWithConn(ip, listenHandler.UdpConn4, udpLayersWithProbe(&udp, p.Port)...)
 		if err != nil {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 		}
@@ -413,7 +413,7 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 			return
 		}
 
-		err = sendWithConn(ip, listenHandler.UdpConn6, &udp)
+		err = sendWithConn(ip, listenHandler.UdpConn6, udpLayersWithProbe(&udp, p.Port)...)
 		if err != nil {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 		}

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -307,7 +307,7 @@ func sendAsyncUDP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 			return
 		}
 
-		err = sendWithConn(ip, listenHandler.UdpConn4, udpLayersWithProbe(&udp, p.Port)...)
+		err = sendWithConn(ip, listenHandler.UdpConn4, listenHandler.udpLayersWithProbe(&udp, p.Port)...)
 		if err != nil {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 		}
@@ -413,7 +413,7 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 			return
 		}
 
-		err = sendWithConn(ip, listenHandler.UdpConn6, udpLayersWithProbe(&udp, p.Port)...)
+		err = sendWithConn(ip, listenHandler.UdpConn6, listenHandler.udpLayersWithProbe(&udp, p.Port)...)
 		if err != nil {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 		}

--- a/pkg/scan/udpprobe.go
+++ b/pkg/scan/udpprobe.go
@@ -1,8 +1,6 @@
 package scan
 
 import (
-	"sync/atomic"
-
 	"github.com/Mzack9999/gopacket"
 	"github.com/Mzack9999/gopacket/layers"
 )
@@ -12,68 +10,63 @@ import (
 // use from multiple goroutines. Returning nil or an empty slice signals
 // "no probe known for this port" and the scan path falls back to its
 // historical behavior of sending an empty UDP datagram.
+//
+// Providers are installed per *Scanner via Scanner.SetUDPProbeProvider
+// rather than as a process-global, so concurrent scanners can carry
+// independent probe behavior without clobbering each other.
 type UDPProbeProvider interface {
 	UDPProbe(port int) []byte
 }
 
-// nopUDPProbeProvider is the default until the runner installs a real
-// provider. It keeps the legacy "send an empty UDP datagram" behavior
-// so existing callers see no change.
-type nopUDPProbeProvider struct{}
-
-func (nopUDPProbeProvider) UDPProbe(int) []byte { return nil }
-
-// udpProbeProvider holds the currently-installed provider behind an
-// atomic pointer so SetUDPProbeProvider can be called from any
-// goroutine without locking the scan hot path. atomic.Pointer is used
-// rather than atomic.Value because callers swap in providers of
-// different concrete types, which Value rejects.
-var udpProbeProvider atomic.Pointer[UDPProbeProvider]
-
-func init() {
-	var noop UDPProbeProvider = nopUDPProbeProvider{}
-	udpProbeProvider.Store(&noop)
-}
-
-// SetUDPProbeProvider installs the global UDP probe provider used by
-// the raw UDP send path and by ConnectPort when the caller passes an
-// empty payload. Passing nil restores the no-op provider.
-func SetUDPProbeProvider(p UDPProbeProvider) {
-	if p == nil {
-		var noop UDPProbeProvider = nopUDPProbeProvider{}
-		udpProbeProvider.Store(&noop)
-		return
+// udpProbePayload returns the bytes the configured provider wants for
+// the destination port, or nil when no provider is installed. The
+// nil-receiver and nil-provider cases collapse to the same "no probe"
+// signal so callers never have to nil-check before calling.
+func (s *Scanner) udpProbePayload(port int) []byte {
+	if s == nil || s.UDPProbeProvider == nil {
+		return nil
 	}
-	udpProbeProvider.Store(&p)
+	return s.UDPProbeProvider.UDPProbe(port)
 }
 
-// GetUDPProbeProvider returns the currently-installed provider. It is
-// never nil.
-func GetUDPProbeProvider() UDPProbeProvider {
-	if p := udpProbeProvider.Load(); p != nil {
-		return *p
+// udpProbePayload is the raw-send-path counterpart of the Scanner
+// helper: sendAsyncUDP4/6 only have a *ListenHandler in scope, so the
+// provider rides on the handler. NewScanner copies the scanner's
+// provider into the handler once the handler is acquired.
+func (l *ListenHandler) udpProbePayload(port int) []byte {
+	if l == nil || l.UDPProbeProvider == nil {
+		return nil
 	}
-	return nopUDPProbeProvider{}
-}
-
-// udpProbePayload is the indirection point that send paths call. It
-// returns the bytes to put in the UDP datagram for the given port, or
-// nil when no probe is configured.
-func udpProbePayload(port int) []byte {
-	return GetUDPProbeProvider().UDPProbe(port)
+	return l.UDPProbeProvider.UDPProbe(port)
 }
 
 // udpLayersWithProbe assembles the serialize-layer slice handed to
-// sendWithConn. When the active provider returns a non-empty probe
-// for the destination port we append it as the UDP payload so the
-// resulting datagram is no longer a zero-length probe. Returning a
-// slice (rather than mutating sendWithConn's signature) keeps the
-// hot-path call sites readable and lets a no-op provider stay
+// sendWithConn. When the handler's provider returns a non-empty
+// payload for the destination port we append it as the UDP payload so
+// the resulting datagram is no longer a zero-length probe. Returning
+// a slice (rather than mutating sendWithConn's signature) keeps the
+// hot-path call sites readable and lets a missing provider stay
 // allocation-free.
-func udpLayersWithProbe(udp *layers.UDP, port int) []gopacket.SerializableLayer {
-	payload := udpProbePayload(port)
+func (l *ListenHandler) udpLayersWithProbe(udp *layers.UDP, port int) []gopacket.SerializableLayer {
+	payload := l.udpProbePayload(port)
 	if len(payload) == 0 {
 		return []gopacket.SerializableLayer{udp}
 	}
 	return []gopacket.SerializableLayer{udp, gopacket.Payload(payload)}
+}
+
+// SetUDPProbeProvider installs the provider used by the raw UDP send
+// path and by ConnectPort when the caller passes an empty payload.
+// Passing nil disables UDP probing for this scanner; subsequent UDP
+// scans send the historical zero-length datagram. The change is
+// propagated to the scanner's ListenHandler so the raw send path
+// (sendAsyncUDP4/6) sees it without needing to look at the scanner.
+func (s *Scanner) SetUDPProbeProvider(p UDPProbeProvider) {
+	if s == nil {
+		return
+	}
+	s.UDPProbeProvider = p
+	if s.ListenHandler != nil {
+		s.ListenHandler.UDPProbeProvider = p
+	}
 }

--- a/pkg/scan/udpprobe.go
+++ b/pkg/scan/udpprobe.go
@@ -1,0 +1,79 @@
+package scan
+
+import (
+	"sync/atomic"
+
+	"github.com/Mzack9999/gopacket"
+	"github.com/Mzack9999/gopacket/layers"
+)
+
+// UDPProbeProvider returns the UDP payload that should be sent when
+// scanning a given destination port. Implementations must be safe for
+// use from multiple goroutines. Returning nil or an empty slice signals
+// "no probe known for this port" and the scan path falls back to its
+// historical behavior of sending an empty UDP datagram.
+type UDPProbeProvider interface {
+	UDPProbe(port int) []byte
+}
+
+// nopUDPProbeProvider is the default until the runner installs a real
+// provider. It keeps the legacy "send an empty UDP datagram" behavior
+// so existing callers see no change.
+type nopUDPProbeProvider struct{}
+
+func (nopUDPProbeProvider) UDPProbe(int) []byte { return nil }
+
+// udpProbeProvider holds the currently-installed provider behind an
+// atomic pointer so SetUDPProbeProvider can be called from any
+// goroutine without locking the scan hot path. atomic.Pointer is used
+// rather than atomic.Value because callers swap in providers of
+// different concrete types, which Value rejects.
+var udpProbeProvider atomic.Pointer[UDPProbeProvider]
+
+func init() {
+	var noop UDPProbeProvider = nopUDPProbeProvider{}
+	udpProbeProvider.Store(&noop)
+}
+
+// SetUDPProbeProvider installs the global UDP probe provider used by
+// the raw UDP send path and by ConnectPort when the caller passes an
+// empty payload. Passing nil restores the no-op provider.
+func SetUDPProbeProvider(p UDPProbeProvider) {
+	if p == nil {
+		var noop UDPProbeProvider = nopUDPProbeProvider{}
+		udpProbeProvider.Store(&noop)
+		return
+	}
+	udpProbeProvider.Store(&p)
+}
+
+// GetUDPProbeProvider returns the currently-installed provider. It is
+// never nil.
+func GetUDPProbeProvider() UDPProbeProvider {
+	if p := udpProbeProvider.Load(); p != nil {
+		return *p
+	}
+	return nopUDPProbeProvider{}
+}
+
+// udpProbePayload is the indirection point that send paths call. It
+// returns the bytes to put in the UDP datagram for the given port, or
+// nil when no probe is configured.
+func udpProbePayload(port int) []byte {
+	return GetUDPProbeProvider().UDPProbe(port)
+}
+
+// udpLayersWithProbe assembles the serialize-layer slice handed to
+// sendWithConn. When the active provider returns a non-empty probe
+// for the destination port we append it as the UDP payload so the
+// resulting datagram is no longer a zero-length probe. Returning a
+// slice (rather than mutating sendWithConn's signature) keeps the
+// hot-path call sites readable and lets a no-op provider stay
+// allocation-free.
+func udpLayersWithProbe(udp *layers.UDP, port int) []gopacket.SerializableLayer {
+	payload := udpProbePayload(port)
+	if len(payload) == 0 {
+		return []gopacket.SerializableLayer{udp}
+	}
+	return []gopacket.SerializableLayer{udp, gopacket.Payload(payload)}
+}

--- a/pkg/scan/udpprobe_test.go
+++ b/pkg/scan/udpprobe_test.go
@@ -1,0 +1,367 @@
+package scan
+
+import (
+	"bytes"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mzack9999/gopacket"
+	"github.com/Mzack9999/gopacket/layers"
+	"github.com/miekg/dns"
+	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
+	"github.com/projectdiscovery/naabu/v2/pkg/port"
+	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
+)
+
+// stubProvider is a test provider that returns a fixed payload for a
+// configured port and nil for every other port.
+type stubProvider struct {
+	wantPort int
+	payload  []byte
+}
+
+func (s stubProvider) UDPProbe(p int) []byte {
+	if p == s.wantPort {
+		return s.payload
+	}
+	return nil
+}
+
+// withProvider installs a provider for the duration of t and restores
+// the previous one on cleanup. Tests that touch the global provider
+// must use this helper so the state never leaks across tests.
+func withProvider(t *testing.T, p UDPProbeProvider) {
+	t.Helper()
+	prev := GetUDPProbeProvider()
+	SetUDPProbeProvider(p)
+	t.Cleanup(func() { SetUDPProbeProvider(prev) })
+}
+
+// TestDefaultProviderIsNoop documents the at-rest behavior: with no
+// SetUDPProbeProvider call the global accessor returns the no-op
+// provider, which always yields nil.
+func TestDefaultProviderIsNoop(t *testing.T) {
+	if got := udpProbePayload(53); got != nil {
+		t.Fatalf("expected nil payload from default provider, got %x", got)
+	}
+}
+
+// TestSetUDPProbeProviderRoundTrips confirms a provider can be
+// installed and retrieved across goroutines (atomic.Value semantics).
+func TestSetUDPProbeProviderRoundTrips(t *testing.T) {
+	withProvider(t, stubProvider{wantPort: 53, payload: []byte{0xAA, 0xBB}})
+
+	var wg sync.WaitGroup
+	results := make([][]byte, 8)
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = udpProbePayload(53)
+		}(i)
+	}
+	wg.Wait()
+	for _, r := range results {
+		if !bytes.Equal(r, []byte{0xAA, 0xBB}) {
+			t.Fatalf("goroutine got %x, want AABB", r)
+		}
+	}
+}
+
+// TestSetNilRestoresNoop guarantees that passing nil reverts to the
+// no-op provider instead of panicking on a nil receiver later.
+func TestSetNilRestoresNoop(t *testing.T) {
+	withProvider(t, stubProvider{wantPort: 53, payload: []byte{0x01}})
+	SetUDPProbeProvider(nil)
+	if got := udpProbePayload(53); got != nil {
+		t.Fatalf("expected nil after SetUDPProbeProvider(nil), got %x", got)
+	}
+}
+
+// TestUDPLayersWithProbeAppendsPayload pins the wire format: when the
+// provider returns bytes for the destination port, those bytes appear
+// as the UDP payload in the serialized packet. This is the contract
+// that the raw scan path relies on.
+func TestUDPLayersWithProbeAppendsPayload(t *testing.T) {
+	probe := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	withProvider(t, stubProvider{wantPort: 53, payload: probe})
+
+	udp := &layers.UDP{
+		SrcPort: layers.UDPPort(12345),
+		DstPort: layers.UDPPort(53),
+	}
+	ip4 := &layers.IPv4{
+		Version:  4,
+		SrcIP:    net.IPv4(127, 0, 0, 1),
+		DstIP:    net.IPv4(127, 0, 0, 2),
+		TTL:      255,
+		Protocol: layers.IPProtocolUDP,
+	}
+	if err := udp.SetNetworkLayerForChecksum(ip4); err != nil {
+		t.Fatalf("SetNetworkLayerForChecksum: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	if err := gopacket.SerializeLayers(buf, opts, udpLayersWithProbe(udp, 53)...); err != nil {
+		t.Fatalf("SerializeLayers: %v", err)
+	}
+	if !bytes.HasSuffix(buf.Bytes(), probe) {
+		t.Fatalf("serialized packet does not end with probe payload: % x", buf.Bytes())
+	}
+}
+
+// TestUDPLayersWithProbeEmptyKeepsLegacyShape documents that when the
+// provider has nothing to say for a port, the serialized packet
+// matches the pre-feature shape (just the UDP header), preserving the
+// historical wire behavior for callers who don't opt in.
+func TestUDPLayersWithProbeEmptyKeepsLegacyShape(t *testing.T) {
+	withProvider(t, stubProvider{wantPort: 999})
+
+	udp := &layers.UDP{
+		SrcPort: layers.UDPPort(12345),
+		DstPort: layers.UDPPort(53),
+	}
+	ip4 := &layers.IPv4{
+		Version:  4,
+		SrcIP:    net.IPv4(127, 0, 0, 1),
+		DstIP:    net.IPv4(127, 0, 0, 2),
+		TTL:      255,
+		Protocol: layers.IPProtocolUDP,
+	}
+	if err := udp.SetNetworkLayerForChecksum(ip4); err != nil {
+		t.Fatalf("SetNetworkLayerForChecksum: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	if err := gopacket.SerializeLayers(buf, opts, udpLayersWithProbe(udp, 53)...); err != nil {
+		t.Fatalf("SerializeLayers: %v", err)
+	}
+	if got := len(buf.Bytes()); got != 8 {
+		t.Fatalf("expected 8-byte UDP header only, got %d bytes: % x", got, buf.Bytes())
+	}
+}
+
+// startDNSServer spins up an in-process DNS server on an ephemeral
+// UDP port backed by miekg/dns. The server understands real DNS
+// queries (including the CHAOS TXT version.bind query that nmap's
+// DNSVersionBindReq sends) and answers them with a synthetic record.
+// This lets the test drive ConnectPort with the exact bytes nmap
+// would put on the wire, then observe a real protocol-conformant
+// response coming back.
+func startDNSServer(t *testing.T) (int, func()) {
+	t.Helper()
+	pc, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("DNS listen: %v", err)
+	}
+	srv := &dns.Server{
+		PacketConn: pc,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			for _, q := range r.Question {
+				m.Answer = append(m.Answer, &dns.TXT{
+					Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: q.Qclass, Ttl: 0},
+					Txt: []string{"naabu-test"},
+				})
+			}
+			_ = w.WriteMsg(m)
+		}),
+	}
+	started := make(chan struct{})
+	srv.NotifyStartedFunc = func() { close(started) }
+	go func() { _ = srv.ActivateAndServe() }()
+	<-started
+	port := pc.LocalAddr().(*net.UDPAddr).Port
+	return port, func() { _ = srv.Shutdown() }
+}
+
+// startNTPServer spins up a minimal NTPv4 server: any 48-byte client
+// datagram is answered with a server-mode response so the scanner
+// sees a real reply. This is enough to validate that the
+// NTPRequest probe (a 48-byte mode-3 client packet) reaches the wire
+// and produces a response.
+func startNTPServer(t *testing.T) (int, func()) {
+	t.Helper()
+	pc, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("NTP listen: %v", err)
+	}
+	port := pc.LocalAddr().(*net.UDPAddr).Port
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 1500)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = pc.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
+			n, src, err := pc.ReadFromUDP(buf)
+			if err != nil {
+				if ne, ok := err.(net.Error); ok && ne.Timeout() {
+					continue
+				}
+				return
+			}
+			if n < 1 {
+				continue
+			}
+			// Server-mode NTPv4 response: LI=0, VN=4, Mode=4
+			// (server), stratum 1, poll 6, precision -20.
+			resp := make([]byte, 48)
+			resp[0] = (0 << 6) | (4 << 3) | 4
+			resp[1] = 1
+			resp[2] = 6
+			resp[3] = 0xEC
+			_, _ = pc.WriteToUDP(resp, src)
+		}
+	}()
+	return port, func() {
+		close(stop)
+		_ = pc.Close()
+		<-done
+	}
+}
+
+// remapProvider wraps a fingerprint.ProbeDB and serves probes for an
+// ephemeral test port using the well-known port the probe was
+// authored for. This is how we exercise the full provider path
+// (scan -> provider -> fingerprint -> nmap-service-probes) without
+// having to ask the kernel for privileged ports 53/123.
+type remapProvider struct {
+	db    *fingerprint.ProbeDB
+	remap map[int]int
+}
+
+func (r remapProvider) UDPProbe(p int) []byte {
+	if wk, ok := r.remap[p]; ok {
+		return r.db.UDPProbeForPort(wk)
+	}
+	return r.db.UDPProbeForPort(p)
+}
+
+// TestUDPProbesAgainstRealServers is the headline end-to-end test:
+// it loads the real nmap-service-probes file installed on the host,
+// stands up real DNS and NTP responders in-process, and drives
+// ConnectPort. A port is reported as open only when the actual probe
+// bytes nmap ships for that service elicit a real protocol response,
+// which is the user-visible behavior naabu#1633 is asking for. The
+// test skips cleanly on hosts without nmap installed.
+func TestUDPProbesAgainstRealServers(t *testing.T) {
+	probesPath := fingerprint.LocateNmapProbes()
+	if probesPath == "" {
+		t.Skip("nmap-service-probes not found on system")
+	}
+	db, err := fingerprint.ParseProbeFile(probesPath)
+	if err != nil {
+		t.Fatalf("parse nmap-service-probes: %v", err)
+	}
+
+	dnsPort, dnsCleanup := startDNSServer(t)
+	defer dnsCleanup()
+	ntpPort, ntpCleanup := startNTPServer(t)
+	defer ntpCleanup()
+
+	withProvider(t, remapProvider{
+		db:    db,
+		remap: map[int]int{dnsPort: 53, ntpPort: 123},
+	})
+
+	scanner, err := NewScanner(&Options{})
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		port   int
+		probed bool // do we expect db to have a probe for the well-known port?
+		wkPort int
+	}{
+		{"DNS", dnsPort, true, 53},
+		{"NTP", ntpPort, true, 123},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if probe := db.UDPProbeForPort(tc.wkPort); len(probe) == 0 {
+				t.Skipf("host's nmap-service-probes has no UDP probe for port %d", tc.wkPort)
+			}
+			p := &port.Port{Port: tc.port, Protocol: protocol.UDP}
+			open, err := scanner.ConnectPort("127.0.0.1", "", p, 2*time.Second)
+			if err != nil {
+				t.Fatalf("ConnectPort: %v", err)
+			}
+			if !open {
+				t.Fatal("expected port reported as open after probing real server")
+			}
+		})
+	}
+
+	// Sanity: with the no-op provider an empty UDP datagram does not
+	// elicit a DNS reply (the server can't decode it), so the same
+	// port comes back as not-open. This locks in the legacy behavior
+	// users get without -uP.
+	t.Run("NoProviderNoOpen", func(t *testing.T) {
+		SetUDPProbeProvider(nil)
+		t.Cleanup(func() {
+			SetUDPProbeProvider(remapProvider{db: db, remap: map[int]int{dnsPort: 53}})
+		})
+		open, err := scanner.ConnectPort("127.0.0.1", "",
+			&port.Port{Port: dnsPort, Protocol: protocol.UDP}, 500*time.Millisecond)
+		if err != nil {
+			t.Fatalf("ConnectPort: %v", err)
+		}
+		if open {
+			t.Fatal("expected not-open with no probe payload, the DNS server should drop the malformed datagram")
+		}
+	})
+}
+
+// TestUDPProbesCallerPayloadWinsAgainstRealServer documents the
+// priority rule using a real DNS server: a non-empty caller payload
+// (i.e. -cp) takes precedence over the provider. We pass the real
+// nmap DNS probe as the caller payload while installing a broken
+// provider that would otherwise produce garbage. The server replies,
+// proving the bytes actually came from the caller and not from the
+// provider.
+func TestUDPProbesCallerPayloadWinsAgainstRealServer(t *testing.T) {
+	probesPath := fingerprint.LocateNmapProbes()
+	if probesPath == "" {
+		t.Skip("nmap-service-probes not found on system")
+	}
+	db, err := fingerprint.ParseProbeFile(probesPath)
+	if err != nil {
+		t.Fatalf("parse nmap-service-probes: %v", err)
+	}
+	dnsProbe := db.UDPProbeForPort(53)
+	if len(dnsProbe) == 0 {
+		t.Skip("host's nmap-service-probes has no UDP probe for :53")
+	}
+
+	dnsPort, cleanup := startDNSServer(t)
+	defer cleanup()
+
+	withProvider(t, stubProvider{wantPort: dnsPort, payload: []byte{0xDE, 0xAD}})
+
+	scanner, err := NewScanner(&Options{})
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	open, err := scanner.ConnectPort("127.0.0.1", string(dnsProbe),
+		&port.Port{Port: dnsPort, Protocol: protocol.UDP}, 2*time.Second)
+	if err != nil {
+		t.Fatalf("ConnectPort: %v", err)
+	}
+	if !open {
+		t.Fatal("expected open when caller supplied a real DNS probe (provider has bogus bytes)")
+	}
+}

--- a/pkg/scan/udpprobe_test.go
+++ b/pkg/scan/udpprobe_test.go
@@ -29,29 +29,52 @@ func (s stubProvider) UDPProbe(p int) []byte {
 	return nil
 }
 
-// withProvider installs a provider for the duration of t and restores
-// the previous one on cleanup. Tests that touch the global provider
-// must use this helper so the state never leaks across tests.
-func withProvider(t *testing.T, p UDPProbeProvider) {
-	t.Helper()
-	prev := GetUDPProbeProvider()
-	SetUDPProbeProvider(p)
-	t.Cleanup(func() { SetUDPProbeProvider(prev) })
+// newScannerWithProvider builds a Scanner backed by a synthetic
+// ListenHandler (no raw sockets) and installs the given provider on
+// both. Using a synthetic handler keeps the unit tests deterministic
+// on hosts where Acquire would otherwise need privileges, and the
+// integration tests below upgrade to NewScanner where they need the
+// full stack.
+func newScannerWithProvider(p UDPProbeProvider) *Scanner {
+	s := &Scanner{ListenHandler: NewListenHandler()}
+	s.SetUDPProbeProvider(p)
+	return s
 }
 
-// TestDefaultProviderIsNoop documents the at-rest behavior: with no
-// SetUDPProbeProvider call the global accessor returns the no-op
-// provider, which always yields nil.
-func TestDefaultProviderIsNoop(t *testing.T) {
-	if got := udpProbePayload(53); got != nil {
+// TestNilProviderIsNoop documents the at-rest behavior: a Scanner
+// with no provider installed reports nil for any port, which keeps
+// the legacy zero-length-datagram path active.
+func TestNilProviderIsNoop(t *testing.T) {
+	s := &Scanner{ListenHandler: NewListenHandler()}
+	if got := s.udpProbePayload(53); got != nil {
 		t.Fatalf("expected nil payload from default provider, got %x", got)
+	}
+	if got := s.ListenHandler.udpProbePayload(53); got != nil {
+		t.Fatalf("expected nil payload from default handler, got %x", got)
 	}
 }
 
-// TestSetUDPProbeProviderRoundTrips confirms a provider can be
-// installed and retrieved across goroutines (atomic.Value semantics).
-func TestSetUDPProbeProviderRoundTrips(t *testing.T) {
-	withProvider(t, stubProvider{wantPort: 53, payload: []byte{0xAA, 0xBB}})
+// TestSetUDPProbeProviderPropagates confirms the provider set on the
+// Scanner is also visible on its ListenHandler, which is the surface
+// the raw send path consults.
+func TestSetUDPProbeProviderPropagates(t *testing.T) {
+	s := newScannerWithProvider(stubProvider{wantPort: 53, payload: []byte{0xAA, 0xBB}})
+
+	if got := s.udpProbePayload(53); !bytes.Equal(got, []byte{0xAA, 0xBB}) {
+		t.Fatalf("scanner got %x, want AABB", got)
+	}
+	if got := s.ListenHandler.udpProbePayload(53); !bytes.Equal(got, []byte{0xAA, 0xBB}) {
+		t.Fatalf("handler got %x, want AABB", got)
+	}
+}
+
+// TestSetUDPProbeProviderConcurrentReads confirms repeated reads from
+// many goroutines see a consistent provider. The atomic story is gone
+// (the provider lives in plain struct fields), so this guards the
+// invariant that we install the provider once before the scan starts
+// rather than mutating it mid-flight.
+func TestSetUDPProbeProviderConcurrentReads(t *testing.T) {
+	s := newScannerWithProvider(stubProvider{wantPort: 53, payload: []byte{0xAA, 0xBB}})
 
 	var wg sync.WaitGroup
 	results := make([][]byte, 8)
@@ -59,7 +82,7 @@ func TestSetUDPProbeProviderRoundTrips(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			results[i] = udpProbePayload(53)
+			results[i] = s.udpProbePayload(53)
 		}(i)
 	}
 	wg.Wait()
@@ -70,23 +93,27 @@ func TestSetUDPProbeProviderRoundTrips(t *testing.T) {
 	}
 }
 
-// TestSetNilRestoresNoop guarantees that passing nil reverts to the
-// no-op provider instead of panicking on a nil receiver later.
-func TestSetNilRestoresNoop(t *testing.T) {
-	withProvider(t, stubProvider{wantPort: 53, payload: []byte{0x01}})
-	SetUDPProbeProvider(nil)
-	if got := udpProbePayload(53); got != nil {
-		t.Fatalf("expected nil after SetUDPProbeProvider(nil), got %x", got)
+// TestSetUDPProbeProviderNilDisables guarantees that passing nil
+// clears the provider on both the scanner and its handler, returning
+// to the legacy zero-length-datagram behavior.
+func TestSetUDPProbeProviderNilDisables(t *testing.T) {
+	s := newScannerWithProvider(stubProvider{wantPort: 53, payload: []byte{0x01}})
+	s.SetUDPProbeProvider(nil)
+	if got := s.udpProbePayload(53); got != nil {
+		t.Fatalf("scanner expected nil after SetUDPProbeProvider(nil), got %x", got)
+	}
+	if got := s.ListenHandler.udpProbePayload(53); got != nil {
+		t.Fatalf("handler expected nil after SetUDPProbeProvider(nil), got %x", got)
 	}
 }
 
 // TestUDPLayersWithProbeAppendsPayload pins the wire format: when the
-// provider returns bytes for the destination port, those bytes appear
-// as the UDP payload in the serialized packet. This is the contract
-// that the raw scan path relies on.
+// handler's provider returns bytes for the destination port, those
+// bytes appear as the UDP payload in the serialized packet. This is
+// the contract that the raw scan path relies on.
 func TestUDPLayersWithProbeAppendsPayload(t *testing.T) {
 	probe := []byte{0xDE, 0xAD, 0xBE, 0xEF}
-	withProvider(t, stubProvider{wantPort: 53, payload: probe})
+	s := newScannerWithProvider(stubProvider{wantPort: 53, payload: probe})
 
 	udp := &layers.UDP{
 		SrcPort: layers.UDPPort(12345),
@@ -105,7 +132,7 @@ func TestUDPLayersWithProbeAppendsPayload(t *testing.T) {
 
 	buf := gopacket.NewSerializeBuffer()
 	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
-	if err := gopacket.SerializeLayers(buf, opts, udpLayersWithProbe(udp, 53)...); err != nil {
+	if err := gopacket.SerializeLayers(buf, opts, s.ListenHandler.udpLayersWithProbe(udp, 53)...); err != nil {
 		t.Fatalf("SerializeLayers: %v", err)
 	}
 	if !bytes.HasSuffix(buf.Bytes(), probe) {
@@ -118,7 +145,7 @@ func TestUDPLayersWithProbeAppendsPayload(t *testing.T) {
 // matches the pre-feature shape (just the UDP header), preserving the
 // historical wire behavior for callers who don't opt in.
 func TestUDPLayersWithProbeEmptyKeepsLegacyShape(t *testing.T) {
-	withProvider(t, stubProvider{wantPort: 999})
+	s := newScannerWithProvider(stubProvider{wantPort: 999})
 
 	udp := &layers.UDP{
 		SrcPort: layers.UDPPort(12345),
@@ -137,7 +164,7 @@ func TestUDPLayersWithProbeEmptyKeepsLegacyShape(t *testing.T) {
 
 	buf := gopacket.NewSerializeBuffer()
 	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
-	if err := gopacket.SerializeLayers(buf, opts, udpLayersWithProbe(udp, 53)...); err != nil {
+	if err := gopacket.SerializeLayers(buf, opts, s.ListenHandler.udpLayersWithProbe(udp, 53)...); err != nil {
 		t.Fatalf("SerializeLayers: %v", err)
 	}
 	if got := len(buf.Bytes()); got != 8 {
@@ -270,15 +297,15 @@ func TestUDPProbesAgainstRealServers(t *testing.T) {
 	ntpPort, ntpCleanup := startNTPServer(t)
 	defer ntpCleanup()
 
-	withProvider(t, remapProvider{
-		db:    db,
-		remap: map[int]int{dnsPort: 53, ntpPort: 123},
-	})
-
 	scanner, err := NewScanner(&Options{})
 	if err != nil {
 		t.Fatalf("NewScanner: %v", err)
 	}
+	t.Cleanup(func() { _ = scanner.Close() })
+	scanner.SetUDPProbeProvider(remapProvider{
+		db:    db,
+		remap: map[int]int{dnsPort: 53, ntpPort: 123},
+	})
 
 	cases := []struct {
 		name   string
@@ -311,9 +338,9 @@ func TestUDPProbesAgainstRealServers(t *testing.T) {
 	// port comes back as not-open. This locks in the legacy behavior
 	// users get without -uP.
 	t.Run("NoProviderNoOpen", func(t *testing.T) {
-		SetUDPProbeProvider(nil)
+		scanner.SetUDPProbeProvider(nil)
 		t.Cleanup(func() {
-			SetUDPProbeProvider(remapProvider{db: db, remap: map[int]int{dnsPort: 53}})
+			scanner.SetUDPProbeProvider(remapProvider{db: db, remap: map[int]int{dnsPort: 53}})
 		})
 		open, err := scanner.ConnectPort("127.0.0.1", "",
 			&port.Port{Port: dnsPort, Protocol: protocol.UDP}, 500*time.Millisecond)
@@ -350,12 +377,12 @@ func TestUDPProbesCallerPayloadWinsAgainstRealServer(t *testing.T) {
 	dnsPort, cleanup := startDNSServer(t)
 	defer cleanup()
 
-	withProvider(t, stubProvider{wantPort: dnsPort, payload: []byte{0xDE, 0xAD}})
-
 	scanner, err := NewScanner(&Options{})
 	if err != nil {
 		t.Fatalf("NewScanner: %v", err)
 	}
+	t.Cleanup(func() { _ = scanner.Close() })
+	scanner.SetUDPProbeProvider(stubProvider{wantPort: dnsPort, payload: []byte{0xDE, 0xAD}})
 	open, err := scanner.ConnectPort("127.0.0.1", string(dnsProbe),
 		&port.Port{Port: dnsPort, Protocol: protocol.UDP}, 2*time.Second)
 	if err != nil {


### PR DESCRIPTION
Closes #1633.

Opt-in `-uP/--udp-probes` flag that reuses the nmap-service-probes data already required by `-sV`: when a UDP port is scanned, the highest-priority known probe for that port is sent as the datagram payload instead of an empty packet. The parsed probe DB is memoised so `-sV` and `-uP` don't pay the parse cost twice. Default behavior is unchanged when the flag is not set, and `-cp` still wins over the provider when present.

No embedded probes shipped; protocol coverage comes from the host's installed nmap-service-probes (same locate logic as `-sV`). Runtime degrades gracefully (warn + disable) when the file isn't found.

Tests use the host's real nmap-service-probes against in-process DNS (miekg/dns) and NTPv4 responders to confirm the actual probe bytes elicit real protocol replies through ConnectPort. Tests skip cleanly on hosts without nmap installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in UDP service probes (--udp-probes / -uP) to send protocol-specific payloads during UDP scans; probe DB loads lazily and is disabled with a warning if missing.
  * Scanner/listener now support a pluggable UDP probe provider so per-port payloads can be supplied.

* **Behavior Changes**
  * When enabled, empty UDP sends use selected probe payloads; legacy empty-payload behavior remains when disabled. 

* **Tests**
  * Extensive unit and integration tests for probe selection, ordering, nil-safety, provider propagation, and end-to-end UDP scan behavior.

* **Documentation**
  * README updated with usage, examples, and behaviors for UDP Service Probes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/naabu/pull/1689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->