### PR TITLE
Clarify -passive and -ss flag descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ CONFIGURATION:
    -sr, -system-resolver            use system DNS as fallback resolver
    -resume                          resume scan using resume.cfg
    -stream                          stream mode (disables resume, nmap, verify, retries, shuffling, etc)
-   -passive                         display passive open ports using shodan internetdb api
+   -passive                         display passive open ports using shodan internetdb api (automatically enables stream mode)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -no-stdin                        Disable Stdin processing
 
@@ -137,7 +137,7 @@ OPTIMIZATION:
    -warm-up-time int               time in seconds between scan phases (default 2)
    -ping                           ping probes for verification of host
    -verify                         validate the ports again with TCP verification
-   -ss, -smart-scan                predictive port scanning using port correlation model
+   -ss, -smart-scan                predictive port scanning using port correlation model (not compatible with stream mode)
    -pt, -prediction-threshold int  minimum confidence for port predictions (0-100%) (default 20)
 
 DEBUG:

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -220,7 +220,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.SystemResolver, "system-resolver", "sr", false, "use system DNS as fallback resolver"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "resume scan using resume.cfg"),
 		flagSet.BoolVar(&options.Stream, "stream", false, "stream mode (disables resume, nmap, verify, retries, shuffling, etc)"),
-		flagSet.BoolVar(&options.Passive, "passive", false, "display passive open ports using shodan internetdb api"),
+		flagSet.BoolVar(&options.Passive, "passive", false, "display passive open ports using shodan internetdb api (automatically enables stream mode)"),
 		flagSet.DurationVarP(&options.InputReadTimeout, "input-read-timeout", "irt", time.Duration(3*time.Minute), "timeout on input read"),
 		flagSet.BoolVar(&options.DisableStdin, "no-stdin", false, "Disable Stdin processing"),
 	)
@@ -261,7 +261,7 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.WarmUpTime, "warm-up-time", 2, "time in seconds between scan phases"),
 		flagSet.BoolVar(&options.Ping, "ping", false, "ping probes for verification of host"),
 		flagSet.BoolVar(&options.Verify, "verify", false, "validate the ports again with TCP verification"),
-		flagSet.BoolVarP(&options.SmartScan, "smart-scan", "ss", false, "predictive port scanning using port correlation model"),
+		flagSet.BoolVarP(&options.SmartScan, "smart-scan", "ss", false, "predictive port scanning using port correlation model (not compatible with stream mode)"),
 		flagSet.IntVarP(&options.PredictionThreshold, "prediction-threshold", "pt", 20, "minimum confidence for port predictions (0-100%)"),
 	)
 


### PR DESCRIPTION
Updated README to clarify the behavior of the -passive and -ss flags. This change documents the existing behavior and helps explain the following error:

`[FTL] Program exiting: smart scan is not supported in stream mode`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README Usage text for the `-passive` flag to clarify that it automatically enables stream mode.
  * Added/expanded README documentation for the `-ss, -smart-scan` flag, including that it performs predictive port scanning and is incompatible with stream mode.
  * Refreshed the in-app CLI flag help text to match the updated `-passive` and `-smart-scan` behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->