### PR TITLE
faster scanning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+**/*_test.go
+**/.DS_Store
+**/node_modules
+**/.cursor
+dist
+bin
+*.md
+!README.md

--- a/_dockertest/Dockerfile
+++ b/_dockertest/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.24-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends libpcap-dev iproute2 ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+RUN go build -o /usr/local/bin/naabu ./cmd/naabu
+ENTRYPOINT []

--- a/_dockertest/Dockerfile
+++ b/_dockertest/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.24-bookworm
-RUN apt-get update && apt-get install -y --no-install-recommends libpcap-dev iproute2 ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM golang:1.25-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends libpcap-dev iproute2 ca-certificates python3 && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY . .
 RUN go build -o /usr/local/bin/naabu ./cmd/naabu

--- a/_dockertest/run.sh
+++ b/_dockertest/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image="${NAABU_DOCKERTEST_IMAGE:-naabu-dockertest}"
+
+docker build -f "${repo_root}/_dockertest/Dockerfile" -t "${image}" "${repo_root}"
+docker run --rm --privileged "${image}" bash -c '
+set -euo pipefail
+
+python3 /src/_dockertest/server.py 18080 18443 &
+fixture_pid=$!
+trap "kill ${fixture_pid} 2>/dev/null || true" EXIT
+
+ready=false
+for _ in $(seq 1 50); do
+	if (echo >/dev/tcp/127.0.0.1/18080) 2>/dev/null; then
+		ready=true
+		break
+	fi
+	sleep 0.1
+done
+if [[ "${ready}" != true ]]; then
+	echo "fixture did not become ready" >&2
+	exit 1
+fi
+
+actual="$(
+	/usr/local/bin/naabu \
+		-host 127.0.0.1 \
+		-p 18080,18443,19999 \
+		-s s \
+		-tw 4 \
+		-silent \
+		-no-stdin |
+	sort
+)"
+expected="$(printf "127.0.0.1:18080\n127.0.0.1:18443")"
+
+if [[ "${actual}" != "${expected}" ]]; then
+	printf "unexpected SYN results\nexpected:\n%s\nactual:\n%s\n" "${expected}" "${actual}" >&2
+	exit 1
+fi
+printf "%s\n" "${actual}"
+'

--- a/_dockertest/server.py
+++ b/_dockertest/server.py
@@ -1,0 +1,21 @@
+import socket, sys, threading, time
+
+
+def serve(p):
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", p))
+    s.listen(128)
+    while True:
+        try:
+            c, _ = s.accept()
+            c.close()
+        except Exception:
+            pass
+
+
+for a in sys.argv[1:]:
+    threading.Thread(target=serve, args=(int(a),), daemon=True).start()
+
+while True:
+    time.sleep(3600)

--- a/_dockertest/server.py
+++ b/_dockertest/server.py
@@ -1,10 +1,12 @@
 import socket, sys, threading, time
 
 
-def serve(p):
-    s = socket.socket()
+def serve(family, addr, p):
+    s = socket.socket(family, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(("0.0.0.0", p))
+    if family == socket.AF_INET6:
+        s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+    s.bind((addr, p))
     s.listen(128)
     while True:
         try:
@@ -15,7 +17,12 @@ def serve(p):
 
 
 for a in sys.argv[1:]:
-    threading.Thread(target=serve, args=(int(a),), daemon=True).start()
+    p = int(a)
+    threading.Thread(target=serve, args=(socket.AF_INET, "0.0.0.0", p), daemon=True).start()
+    try:
+        threading.Thread(target=serve, args=(socket.AF_INET6, "::", p), daemon=True).start()
+    except Exception:
+        pass
 
 while True:
     time.sleep(3600)

--- a/_dockertest/server.py
+++ b/_dockertest/server.py
@@ -2,27 +2,29 @@ import socket, sys, threading, time
 
 
 def serve(family, addr, p):
-    s = socket.socket(family, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    if family == socket.AF_INET6:
-        s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
-    s.bind((addr, p))
-    s.listen(128)
+    try:
+        s = socket.socket(family, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if family == socket.AF_INET6:
+            s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        s.bind((addr, p))
+        s.listen(128)
+    except OSError as e:
+        print(f"listen setup failed on {addr}:{p}: {e}", file=sys.stderr)
+        return
     while True:
         try:
             c, _ = s.accept()
             c.close()
-        except Exception:
-            pass
+        except OSError as e:
+            print(f"accept failed on {addr}:{p}: {e}", file=sys.stderr)
+            time.sleep(0.1)
 
 
 for a in sys.argv[1:]:
     p = int(a)
     threading.Thread(target=serve, args=(socket.AF_INET, "0.0.0.0", p), daemon=True).start()
-    try:
-        threading.Thread(target=serve, args=(socket.AF_INET6, "::", p), daemon=True).start()
-    except Exception:
-        pass
+    threading.Thread(target=serve, args=(socket.AF_INET6, "::", p), daemon=True).start()
 
 while True:
     time.sleep(3600)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057
-	github.com/Mzack9999/gopacket v0.0.0-20260327212258-d211b432c22b
+	github.com/Mzack9999/gopacket v0.0.0-20260720123648-429cac97ac7a
 	github.com/Ullaakut/nmap/v3 v3.0.6
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057 h1:KFac3SiGbId8ub
 github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057/go.mod h1:iLB2pivrPICvLOuROKmlqURtFIEsoJZaMidQfCG1+D4=
 github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 h1:ZbFL+BDfBqegi+/Ssh7im5+aQfBRx6it+kHnC7jaDU8=
 github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809/go.mod h1:upgc3Zs45jBDnBT4tVRgRcgm26ABpaP7MoTSdgysca4=
-github.com/Mzack9999/gopacket v0.0.0-20260327212258-d211b432c22b h1:lEa6Fj9C2E+qKp0x57q7k8WmOnANjoTsqmTHNQt49e8=
-github.com/Mzack9999/gopacket v0.0.0-20260327212258-d211b432c22b/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
+github.com/Mzack9999/gopacket v0.0.0-20260720123648-429cac97ac7a h1:OBKwMHHXblmDDPVhSlaxuhXdpqi1jq2MAKaQ3E+LKA8=
+github.com/Mzack9999/gopacket v0.0.0-20260720123648-429cac97ac7a/go.mod h1:S0ayp27mCeOCUQqlGBOfPzWzDRDiE9MfaC4nn0UL9Kw=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/Ullaakut/nmap/v3 v3.0.6 h1:ZCQ70TQp97f/YqIFhlzFMDi5xVDeA0CwMbNeJZGA//A=
 github.com/Ullaakut/nmap/v3 v3.0.6/go.mod h1:dd5K68P7LHc5nKrFwQx6EdTt61O9UN5x3zn1R4SLcco=

--- a/pkg/runner/default.go
+++ b/pkg/runner/default.go
@@ -24,4 +24,11 @@ const (
 	// DefaultThreadsNum is the default number of threads to use for the scan
 	// the default value of 25 is a good balance between performance and resource usage
 	DefaultThreadsNum = 25
+
+	// defaultWarmUpTime is the default seconds between scan phases.
+	defaultWarmUpTime = 2
+
+	// DefaultTimingTemplate is the default nmap-style timing level (T3, normal),
+	// which maps to naabu's historical defaults.
+	DefaultTimingTemplate = 3
 )

--- a/pkg/runner/fast_default_test.go
+++ b/pkg/runner/fast_default_test.go
@@ -1,0 +1,32 @@
+package runner
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFastSenderIPMatchesPickIP guards the invariant the default SYN scan loop
+// relies on: the zero-alloc fast IP generator must produce the same address as
+// the big.Int-based PickIP for every index, so swapping it into the default
+// path does not change which hosts get scanned.
+func TestFastSenderIPMatchesPickIP(t *testing.T) {
+	var targets []*net.IPNet
+	for _, c := range []string{"10.0.0.0/30", "192.168.1.0/29", "172.16.5.0/28"} {
+		_, ipnet, err := net.ParseCIDR(c)
+		require.NoError(t, err)
+		targets = append(targets, ipnet)
+	}
+
+	r := &Runner{}
+	idx := buildTargetIndex(targets)
+	require.Greater(t, idx.total, int64(0))
+
+	for i := int64(0); i < idx.total; i++ {
+		dstIP, fastIP, isV4 := idx.pickIPv4(i)
+		require.True(t, isV4, "index %d should be IPv4", i)
+		require.Equal(t, r.PickIP(targets, i), fastIP, "string IP mismatch at index %d", i)
+		require.Equal(t, fastIP, net.IPv4(dstIP[0], dstIP[1], dstIP[2], dstIP[3]).To4().String(), "byte IP mismatch at index %d", i)
+	}
+}

--- a/pkg/runner/fast_default_test.go
+++ b/pkg/runner/fast_default_test.go
@@ -24,7 +24,7 @@ func TestFastSenderIPMatchesPickIP(t *testing.T) {
 	require.Greater(t, idx.total, int64(0))
 
 	for i := int64(0); i < idx.total; i++ {
-		dstIP, fastIP, isV4 := idx.pickIPv4(i)
+		dstIP, fastIP, _, isV4 := idx.pickIPv4(i)
 		require.True(t, isV4, "index %d should be IPv4", i)
 		require.Equal(t, r.PickIP(targets, i), fastIP, "string IP mismatch at index %d", i)
 		require.Equal(t, fastIP, net.IPv4(dstIP[0], dstIP[1], dstIP[2], dstIP[3]).To4().String(), "byte IP mismatch at index %d", i)

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -23,7 +23,11 @@ type SYNSender struct {
 	batch   *rawsend.Batch
 	srcPort uint16
 	baseSum uint32
-	pkt     [24]byte
+	// defaultSrcSum is the checksum contribution of the default-route source
+	// IP, used as a fallback when a destination has no resolvable per-route
+	// source (see send).
+	defaultSrcSum uint32
+	pkt           [24]byte
 }
 
 const (
@@ -78,8 +82,9 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 		// Batch up to UIO_MAXIOV (1024) packets per sendmmsg call. At high
 		// packet rates this is the dominant syscall-amortisation lever: a 32
 		// packet batch issued ~32x more sendmmsg calls for the same throughput.
-		batch:   rawsend.NewBatch(sender.FD(), synBatchSize, synPacketLen),
-		srcPort: uint16(handler.Port),
+		batch:         rawsend.NewBatch(sender.FD(), synBatchSize, synPacketLen),
+		srcPort:       uint16(handler.Port),
+		defaultSrcSum: ipChecksumSum(src4),
 	}
 
 	binary.BigEndian.PutUint16(s.pkt[0:2], s.srcPort)
@@ -90,9 +95,11 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	s.pkt[21] = 4 // MSS option length
 	binary.BigEndian.PutUint16(s.pkt[22:24], 1460)
 
+	// The source IP is intentionally NOT folded into baseSum here: the kernel
+	// picks the source address per destination route (e.g. 127.0.0.1 for a
+	// loopback target, a different NIC for another subnet), so the pseudo-header
+	// source term is added per packet in send() from the destination's route.
 	var sum uint32
-	sum += uint32(binary.BigEndian.Uint16(src4[0:2]))
-	sum += uint32(binary.BigEndian.Uint16(src4[2:4]))
 	sum += 6  // zero + protocol (TCP)
 	sum += 24 // TCP segment length
 	sum += uint32(s.srcPort)
@@ -105,7 +112,23 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	return s, nil
 }
 
-func (s *SYNSender) send(dstIP [4]byte, dstPort uint16) error {
+// ipChecksumSum returns the two 16-bit words of an IPv4 address added together,
+// i.e. its contribution to a TCP pseudo-header checksum (not yet folded).
+func ipChecksumSum(ip4 net.IP) uint32 {
+	if len(ip4) != 4 {
+		return 0
+	}
+	return uint32(binary.BigEndian.Uint16(ip4[0:2])) + uint32(binary.BigEndian.Uint16(ip4[2:4]))
+}
+
+// send transmits a SYN to dstIP:dstPort. srcSum is the pseudo-header checksum
+// contribution of the source IP the kernel will use for this destination (as
+// returned by targetIndex.pickIPv4); a zero srcSum falls back to the default
+// route source so the checksum still matches a single-homed setup.
+func (s *SYNSender) send(dstIP [4]byte, srcSum uint32, dstPort uint16) error {
+	if srcSum == 0 {
+		srcSum = s.defaultSrcSum
+	}
 	// Encode a SYN cookie into the sequence number so the receive path can
 	// verify the returning SYN-ACK (Ack == seq+1) is genuinely ours.
 	seq := scan.SynCookie4(dstIP, dstPort, s.srcPort)
@@ -113,7 +136,19 @@ func (s *SYNSender) send(dstIP [4]byte, dstPort uint16) error {
 	binary.BigEndian.PutUint16(s.pkt[2:4], dstPort)
 	binary.BigEndian.PutUint32(s.pkt[4:8], seq)
 
-	sum := s.baseSum +
+	binary.BigEndian.PutUint16(s.pkt[16:18], synTCPChecksum(s.baseSum, srcSum, dstIP, dstPort, seq))
+
+	if s.batch != nil {
+		return s.batch.Add(s.pkt[:], dstIP)
+	}
+	return s.sender.SendTo(s.pkt[:], dstIP)
+}
+
+// synTCPChecksum folds the precomputed constant terms (baseSum) with the
+// per-packet source pseudo-header term (srcSum), destination IP, destination
+// port and sequence number into the final TCP checksum for the SYN template.
+func synTCPChecksum(baseSum, srcSum uint32, dstIP [4]byte, dstPort uint16, seq uint32) uint16 {
+	sum := baseSum + srcSum +
 		uint32(binary.BigEndian.Uint16(dstIP[0:2])) +
 		uint32(binary.BigEndian.Uint16(dstIP[2:4])) +
 		uint32(dstPort) +
@@ -121,12 +156,7 @@ func (s *SYNSender) send(dstIP [4]byte, dstPort uint16) error {
 		uint32(seq&0xffff)
 	sum = (sum >> 16) + (sum & 0xffff)
 	sum += sum >> 16
-	binary.BigEndian.PutUint16(s.pkt[16:18], ^uint16(sum))
-
-	if s.batch != nil {
-		return s.batch.Add(s.pkt[:], dstIP)
-	}
-	return s.sender.SendTo(s.pkt[:], dstIP)
+	return ^uint16(sum)
 }
 
 func (s *SYNSender) flush() error {
@@ -177,6 +207,11 @@ type indexEntry struct {
 	baseIPv4 uint32     // network base as uint32 (IPv4 only)
 	count    int64      // number of addresses in this CIDR
 	network  *net.IPNet // original, kept for IPv6 fallback
+	// srcSum is the pseudo-header checksum contribution of the source IP the
+	// kernel uses to reach this CIDR (resolved once at build time). Targets on
+	// different routes (loopback, other NICs) need different source IPs for a
+	// correct TCP checksum.
+	srcSum uint32
 }
 
 // targetIndex is a pre-computed lookup table that converts a linear
@@ -189,6 +224,7 @@ type targetIndex struct {
 
 func buildTargetIndex(targets []*net.IPNet) *targetIndex {
 	idx := &targetIndex{}
+	defaultSrcSum := routeSrcSum(net.IPv4(1, 1, 1, 1))
 	for _, t := range targets {
 		count := int64(mapcidr.AddressCountIpnet(t))
 		e := indexEntry{
@@ -198,11 +234,31 @@ func buildTargetIndex(targets []*net.IPNet) *targetIndex {
 		if ip4 := t.IP.To4(); ip4 != nil {
 			e.isV4 = true
 			e.baseIPv4 = binary.BigEndian.Uint32(ip4)
+			// Resolve the source IP for this CIDR's route so the fast sender's
+			// TCP checksum matches the source the kernel actually emits with.
+			e.srcSum = routeSrcSum(t.IP)
+			if e.srcSum == 0 {
+				e.srcSum = defaultSrcSum
+			}
 		}
 		idx.entries = append(idx.entries, e)
 		idx.total += count
 	}
 	return idx
+}
+
+// routeSrcSum resolves the source IP the kernel would use to reach dst and
+// returns its pseudo-header checksum contribution, or 0 if it cannot be
+// resolved (no router, route error, or IPv6 source).
+func routeSrcSum(dst net.IP) uint32 {
+	if scan.PkgRouter == nil {
+		return 0
+	}
+	_, _, src, err := scan.PkgRouter.Route(dst)
+	if err != nil || src == nil {
+		return 0
+	}
+	return ipChecksumSum(src.To4())
 }
 
 // pickIPv4 converts a global index to an IPv4 address. Returns the
@@ -214,12 +270,12 @@ func buildTargetIndex(targets []*net.IPNet) *targetIndex {
 //
 // Cost: ~10ns + ~25ns string format = ~35ns total, zero heap allocs
 // for the [4]byte path. (The string return does one small alloc.)
-func (t *targetIndex) pickIPv4(index int64) (ip [4]byte, ipStr string, isV4 bool) {
+func (t *targetIndex) pickIPv4(index int64) (ip [4]byte, ipStr string, srcSum uint32, isV4 bool) {
 	for i := range t.entries {
 		e := &t.entries[i]
 		if index < e.count {
 			if !e.isV4 {
-				return ip, "", false
+				return ip, "", 0, false
 			}
 			val := e.baseIPv4 + uint32(index)
 			ip[0] = byte(val >> 24)
@@ -227,11 +283,11 @@ func (t *targetIndex) pickIPv4(index int64) (ip [4]byte, ipStr string, isV4 bool
 			ip[2] = byte(val >> 8)
 			ip[3] = byte(val)
 			ipStr = formatIPv4(ip)
-			return ip, ipStr, true
+			return ip, ipStr, e.srcSum, true
 		}
 		index -= e.count
 	}
-	return ip, "", false
+	return ip, "", 0, false
 }
 
 // formatIPv4 converts a [4]byte IPv4 address to its dotted-decimal

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -27,6 +27,16 @@ type SYNSender struct {
 	pkt     [24]byte
 }
 
+const (
+	// synPacketLen is the fixed size of the SYN template (20 byte TCP header +
+	// 4 byte MSS option).
+	synPacketLen = 24
+	// synBatchSize is the number of packets accumulated before a sendmmsg call.
+	// Capped at the kernel's UIO_MAXIOV (1024); partial sends are retried by
+	// rawsend.Batch.Flush.
+	synBatchSize = 1024
+)
+
 var (
 	errNoRawConn    = errors.New("no raw IPv4 connection")
 	errEthernetPath = errors.New("ethernet framing path requires standard sender")
@@ -65,8 +75,11 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	}
 
 	s := &SYNSender{
-		sender:  sender,
-		batch:   rawsend.NewBatch(sender.FD(), 32, 24),
+		sender: sender,
+		// Batch up to UIO_MAXIOV (1024) packets per sendmmsg call. At high
+		// packet rates this is the dominant syscall-amortisation lever: a 32
+		// packet batch issued ~32x more sendmmsg calls for the same throughput.
+		batch:   rawsend.NewBatch(sender.FD(), synBatchSize, synPacketLen),
 		srcPort: uint16(handler.Port),
 	}
 

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -246,6 +246,12 @@ type indexEntry struct {
 	// different routes (loopback, other NICs) need different source IPs for a
 	// correct TCP checksum.
 	srcSum uint32
+	// routeVaries is set when a single CIDR spans destinations the kernel would
+	// emit from different sources (e.g. a broad range covering both default-route
+	// hosts and 127.0.0.0/8). The cached srcSum is then only a fallback and the
+	// source is resolved per destination in pickIPv4 so each packet checksums
+	// against the source it is actually sent with.
+	routeVaries bool
 }
 
 // targetIndex is a pre-computed lookup table that converts a linear
@@ -274,6 +280,10 @@ func buildTargetIndex(targets []*net.IPNet) *targetIndex {
 			if e.srcSum == 0 {
 				e.srcSum = defaultSrcSum
 			}
+			// A broad CIDR can straddle multiple source routes; sampling a few
+			// addresses catches that cheaply so pickIPv4 can resolve the source
+			// per destination instead of mis-checksumming part of the range.
+			e.routeVaries = cidrRouteVaries(e.baseIPv4, count)
 		}
 		idx.entries = append(idx.entries, e)
 		idx.total += count
@@ -281,18 +291,67 @@ func buildTargetIndex(targets []*net.IPNet) *targetIndex {
 	return idx
 }
 
+// routeSrc resolves the source IP the kernel would use to reach dst, or nil if
+// it cannot be resolved (no router or route error).
+func routeSrc(dst net.IP) net.IP {
+	if scan.PkgRouter == nil {
+		return nil
+	}
+	_, _, src, err := scan.PkgRouter.Route(dst)
+	if err != nil {
+		return nil
+	}
+	return src
+}
+
 // routeSrcSum resolves the source IP the kernel would use to reach dst and
 // returns its pseudo-header checksum contribution, or 0 if it cannot be
 // resolved (no router, route error, or IPv6 source).
 func routeSrcSum(dst net.IP) uint32 {
-	if scan.PkgRouter == nil {
-		return 0
-	}
-	_, _, src, err := scan.PkgRouter.Route(dst)
-	if err != nil || src == nil {
+	src := routeSrc(dst)
+	if src == nil {
 		return 0
 	}
 	return ipChecksumSum(src.To4())
+}
+
+// uint32ToIPv4 turns a uint32 host-order address into a net.IP.
+func uint32ToIPv4(v uint32) net.IP {
+	return net.IPv4(byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// sameRouteSrc reports whether two resolved route sources are equivalent,
+// treating two unresolved (nil) sources as the same (both fall back to default).
+func sameRouteSrc(a, b net.IP) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Equal(b)
+}
+
+// cidrRouteVaries samples a handful of addresses across a CIDR and reports
+// whether the kernel-selected source differs between them. A single-address
+// block (count <= 1) never varies. Sampling rather than scanning keeps build
+// time O(1) per CIDR while still catching the common straddle cases.
+func cidrRouteVaries(base uint32, count int64) bool {
+	if count <= 1 {
+		return false
+	}
+	last := base + uint32(count-1)
+	samples := [...]uint32{
+		base,
+		base + uint32(count/4),
+		base + uint32(count/2),
+		base + uint32((count*3)/4),
+		last,
+	}
+	baseSrc := routeSrc(uint32ToIPv4(samples[0]))
+	for _, s := range samples[1:] {
+		if !sameRouteSrc(baseSrc, routeSrc(uint32ToIPv4(s))) {
+			return true
+		}
+	}
+	return false
 }
 
 // pickIPv4 converts a global index to an IPv4 address. Returns the
@@ -317,7 +376,16 @@ func (t *targetIndex) pickIPv4(index int64) (ip [4]byte, ipStr string, srcSum ui
 			ip[2] = byte(val >> 8)
 			ip[3] = byte(val)
 			ipStr = formatIPv4(ip)
-			return ip, ipStr, e.srcSum, true
+			ss := e.srcSum
+			if e.routeVaries {
+				// This CIDR straddles multiple source routes; resolve the source
+				// for this exact destination so the checksum matches the source
+				// the kernel emits with, falling back to the cached term.
+				if perDst := routeSrcSum(uint32ToIPv4(val)); perDst != 0 {
+					ss = perDst
+				}
+			}
+			return ip, ipStr, ss, true
 		}
 		index -= e.count
 	}

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -27,7 +27,11 @@ type SYNSender struct {
 	// IP, used as a fallback when a destination has no resolvable per-route
 	// source (see send).
 	defaultSrcSum uint32
-	pkt           [24]byte
+	// pinnedSrcSum, when non-zero, overrides the per-target source checksum
+	// term: the socket is bound to a fixed -source-ip, so every packet is
+	// emitted with that source and must checksum against it.
+	pinnedSrcSum uint32
+	pkt          [24]byte
 }
 
 const (
@@ -46,11 +50,24 @@ var (
 	errNoSourceIP   = errors.New("cannot determine source IP")
 )
 
+// wantsEthernetPath reports whether a scan must use the L2 (ethernet) send path
+// instead of the fast sender: only when a source IP is pinned (with an interface
+// MAC) but the raw socket could not be bound to it, i.e. a spoofed/non-owned
+// source. A successfully bound source is emitted by the kernel directly, so the
+// fast path stays in use.
+func wantsEthernetPath(handler *scan.ListenHandler) bool {
+	return handler.SourceIp4 != nil && handler.SourceHW != nil && !handler.SourceBound
+}
+
 func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	if handler == nil || handler.TcpConn4 == nil {
 		return nil, errNoRawConn
 	}
-	if handler.SourceIp4 != nil && handler.SourceHW != nil {
+	// Hand off to the L2 (ethernet) path only when a source IP is pinned but the
+	// socket could not be bound to it (e.g. spoofed/non-owned source). When the
+	// bind succeeded the kernel already emits the chosen source, so the fast
+	// path is both correct and preferred over the fragile L2 path.
+	if wantsEthernetPath(handler) {
 		return nil, errEthernetPath
 	}
 
@@ -85,6 +102,12 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 		batch:         rawsend.NewBatch(sender.FD(), synBatchSize, synPacketLen),
 		srcPort:       uint16(handler.Port),
 		defaultSrcSum: ipChecksumSum(src4),
+	}
+	// When the socket is bound to an explicit -source-ip the kernel emits every
+	// packet with it, so pin the checksum's source term to that address instead
+	// of the per-target route source.
+	if handler.SourceBound && handler.SourceIp4 != nil {
+		s.pinnedSrcSum = ipChecksumSum(src4)
 	}
 
 	binary.BigEndian.PutUint16(s.pkt[0:2], s.srcPort)
@@ -126,9 +149,7 @@ func ipChecksumSum(ip4 net.IP) uint32 {
 // returned by targetIndex.pickIPv4); a zero srcSum falls back to the default
 // route source so the checksum still matches a single-homed setup.
 func (s *SYNSender) send(dstIP [4]byte, srcSum uint32, dstPort uint16) error {
-	if srcSum == 0 {
-		srcSum = s.defaultSrcSum
-	}
+	srcSum = s.effectiveSrcSum(srcSum)
 	// Encode a SYN cookie into the sequence number so the receive path can
 	// verify the returning SYN-ACK (Ack == seq+1) is genuinely ours.
 	seq := scan.SynCookie4(dstIP, dstPort, s.srcPort)
@@ -142,6 +163,19 @@ func (s *SYNSender) send(dstIP [4]byte, srcSum uint32, dstPort uint16) error {
 		return s.batch.Add(s.pkt[:], dstIP)
 	}
 	return s.sender.SendTo(s.pkt[:], dstIP)
+}
+
+// effectiveSrcSum resolves the source pseudo-header checksum term for a packet:
+// a pinned bound source wins over the per-target route source, which in turn
+// wins over the default-route fallback.
+func (s *SYNSender) effectiveSrcSum(srcSum uint32) uint32 {
+	if s.pinnedSrcSum != 0 {
+		return s.pinnedSrcSum
+	}
+	if srcSum == 0 {
+		return s.defaultSrcSum
+	}
+	return srcSum
 }
 
 // synTCPChecksum folds the precomputed constant terms (baseSum) with the

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -23,7 +23,6 @@ type SYNSender struct {
 	batch   *rawsend.Batch
 	srcPort uint16
 	baseSum uint32
-	seq     uint32
 	pkt     [24]byte
 }
 
@@ -107,8 +106,9 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 }
 
 func (s *SYNSender) send(dstIP [4]byte, dstPort uint16) error {
-	s.seq++
-	seq := s.seq
+	// Encode a SYN cookie into the sequence number so the receive path can
+	// verify the returning SYN-ACK (Ack == seq+1) is genuinely ours.
+	seq := scan.SynCookie4(dstIP, dstPort, s.srcPort)
 
 	binary.BigEndian.PutUint16(s.pkt[2:4], dstPort)
 	binary.BigEndian.PutUint32(s.pkt[4:8], seq)

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -57,7 +57,7 @@ var (
 // source. A successfully bound source is emitted by the kernel directly, so the
 // fast path stays in use.
 func wantsEthernetPath(handler *scan.ListenHandler) bool {
-	return handler.SourceIp4 != nil && handler.SourceHW != nil && !handler.SourceBound
+	return handler.SourceIp4 != nil && handler.SourceHW != nil && !handler.SourceBound4
 }
 
 func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
@@ -107,7 +107,7 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	// When the socket is bound to an explicit -source-ip the kernel emits every
 	// packet with it, so pin the checksum's source term to that address instead
 	// of the per-target route source.
-	if handler.SourceBound && handler.SourceIp4 != nil {
+	if handler.SourceBound4 && handler.SourceIp4 != nil {
 		s.pinnedSrcSum = ipChecksumSum(src4)
 	}
 
@@ -148,7 +148,7 @@ func newWorkerSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	}
 
 	bindIP := net.IPv4zero
-	if handler.SourceBound && handler.SourceIp4 != nil {
+	if handler.SourceBound4 && handler.SourceIp4 != nil {
 		bindIP = handler.SourceIp4
 	}
 	conn, err := net.ListenIP("ip4:tcp", &net.IPAddr{IP: bindIP})

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -156,6 +156,13 @@ func newWorkerSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 		return nil, fmt.Errorf("open worker raw socket: %w", err)
 	}
 
+	// This socket is transmit-only, but a raw ip4:tcp socket still receives a copy
+	// of every inbound TCP packet on the host. Shrink its receive buffer to the
+	// minimum so it fills almost immediately and the kernel then drops further
+	// copies, instead of spawning a drain goroutine that wakes on every packet
+	// (which, with N workers on a busy host, duplicates the whole TCP stream N times).
+	_ = conn.SetReadBuffer(1)
+
 	workerHandler := *handler
 	workerHandler.TcpConn4 = conn
 	s, err := newSYNSender(&workerHandler)
@@ -164,17 +171,7 @@ func newWorkerSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 		return nil, err
 	}
 	s.ownedConn = conn
-	go drainWorkerRawConn(conn)
 	return s, nil
-}
-
-func drainWorkerRawConn(conn *net.IPConn) {
-	var buf [4096]byte
-	for {
-		if _, _, err := conn.ReadFrom(buf[:]); err != nil {
-			return
-		}
-	}
 }
 
 // ipChecksumSum returns the two 16-bit words of an IPv4 address added together,
@@ -377,27 +374,42 @@ func sameRouteSrc(a, b net.IP) bool {
 	return a.Equal(b)
 }
 
-// cidrRouteVaries samples a handful of addresses across a CIDR and reports
-// whether the kernel-selected source differs between them. A single-address
-// block (count <= 1) never varies. Sampling rather than scanning keeps build
-// time O(1) per CIDR while still catching the common straddle cases.
+// routeSampleCap bounds the number of route lookups cidrRouteVaries performs so
+// building the target index stays cheap even for very large CIDRs.
+const routeSampleCap = 256
+
+// cidrRouteVaries samples addresses across a CIDR and reports whether the
+// kernel-selected source differs between them. A single-address block never
+// varies. The kernel picks a source per route, and routes split on prefix
+// boundaries, so the finest granularity a source can change at (short of host
+// routes) is a connected subnet - commonly a /24. We therefore probe one address
+// per /24 up to routeSampleCap, and stride evenly for CIDRs wider than that cap.
+// This catches the realistic straddle cases (e.g. a range covering two /24s on
+// different interfaces, or one spanning 127.0.0.0/8) that a handful of fixed
+// fractional samples would miss. When it does report variation, pickIPv4 resolves
+// the source per destination so each packet checksums against its actual source.
 func cidrRouteVaries(base uint32, count int64) bool {
 	if count <= 1 {
 		return false
 	}
 	last := base + uint32(count-1)
-	samples := [...]uint32{
-		base,
-		base + uint32(count/4),
-		base + uint32(count/2),
-		base + uint32((count*3)/4),
-		last,
+
+	// Step by one /24 (256 addresses) so every /24 boundary is probed; widen the
+	// step when that would exceed the lookup cap.
+	step := int64(256)
+	if n := (count + step - 1) / step; n > routeSampleCap {
+		step = (count + routeSampleCap - 1) / routeSampleCap
 	}
-	baseSrc := routeSrc(uint32ToIPv4(samples[0]))
-	for _, s := range samples[1:] {
-		if !sameRouteSrc(baseSrc, routeSrc(uint32ToIPv4(s))) {
+
+	baseSrc := routeSrc(uint32ToIPv4(base))
+	for off := int64(0); off < count; off += step {
+		if !sameRouteSrc(baseSrc, routeSrc(uint32ToIPv4(base+uint32(off)))) {
 			return true
 		}
+	}
+	// Always include the final address; the strided walk can stop short of it.
+	if !sameRouteSrc(baseSrc, routeSrc(uint32ToIPv4(last))) {
+		return true
 	}
 	return false
 }

--- a/pkg/runner/fastsend.go
+++ b/pkg/runner/fastsend.go
@@ -19,10 +19,11 @@ import (
 //
 // NOT safe for concurrent use, reuses internal buffers.
 type SYNSender struct {
-	sender  *rawsend.Sender
-	batch   *rawsend.Batch
-	srcPort uint16
-	baseSum uint32
+	sender    *rawsend.Sender
+	batch     *rawsend.Batch
+	ownedConn *net.IPConn
+	srcPort   uint16
+	baseSum   uint32
 	// defaultSrcSum is the checksum contribution of the default-route source
 	// IP, used as a fallback when a destination has no resolvable per-route
 	// source (see send).
@@ -135,6 +136,47 @@ func newSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
 	return s, nil
 }
 
+// newWorkerSYNSender gives a transmit worker its own raw socket. Reusing the
+// handler socket would leave all workers contending on one kernel socket lock,
+// which serializes sendmmsg and defeats multi-core transmit at high rates.
+func newWorkerSYNSender(handler *scan.ListenHandler) (*SYNSender, error) {
+	if handler == nil {
+		return nil, errNoRawConn
+	}
+	if wantsEthernetPath(handler) {
+		return nil, errEthernetPath
+	}
+
+	bindIP := net.IPv4zero
+	if handler.SourceBound && handler.SourceIp4 != nil {
+		bindIP = handler.SourceIp4
+	}
+	conn, err := net.ListenIP("ip4:tcp", &net.IPAddr{IP: bindIP})
+	if err != nil {
+		return nil, fmt.Errorf("open worker raw socket: %w", err)
+	}
+
+	workerHandler := *handler
+	workerHandler.TcpConn4 = conn
+	s, err := newSYNSender(&workerHandler)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	s.ownedConn = conn
+	go drainWorkerRawConn(conn)
+	return s, nil
+}
+
+func drainWorkerRawConn(conn *net.IPConn) {
+	var buf [4096]byte
+	for {
+		if _, _, err := conn.ReadFrom(buf[:]); err != nil {
+			return
+		}
+	}
+}
+
 // ipChecksumSum returns the two 16-bit words of an IPv4 address added together,
 // i.e. its contribution to a TCP pseudo-header checksum (not yet folded).
 func ipChecksumSum(ip4 net.IP) uint32 {
@@ -198,6 +240,12 @@ func (s *SYNSender) flush() error {
 		return s.batch.Flush()
 	}
 	return nil
+}
+
+func (s *SYNSender) close() {
+	if s != nil && s.ownedConn != nil {
+		_ = s.ownedConn.Close()
+	}
 }
 
 // parseIPv4Fast parses an IPv4 dotted-decimal string directly into a

--- a/pkg/runner/fastsend_test.go
+++ b/pkg/runner/fastsend_test.go
@@ -5,8 +5,56 @@ import (
 	"net"
 	"testing"
 
+	"github.com/projectdiscovery/naabu/v2/pkg/scan"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWantsEthernetPath(t *testing.T) {
+	ip := net.IPv4(10, 0, 0, 5)
+	hw := net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}
+
+	// source ip + interface MAC but not bound: must go L2 (spoof/non-owned).
+	require.True(t, wantsEthernetPath(&scan.ListenHandler{SourceIp4: ip, SourceHW: hw}))
+	// bound source: kernel emits it, stay on the fast path.
+	require.False(t, wantsEthernetPath(&scan.ListenHandler{SourceIp4: ip, SourceHW: hw, SourceBound: true}))
+	// source ip alone (no interface MAC): fast path with the bound socket.
+	require.False(t, wantsEthernetPath(&scan.ListenHandler{SourceIp4: ip}))
+	// interface alone: no source to force, fast path.
+	require.False(t, wantsEthernetPath(&scan.ListenHandler{SourceHW: hw}))
+	// nothing pinned.
+	require.False(t, wantsEthernetPath(&scan.ListenHandler{}))
+}
+
+// TestSYNSenderPinnedSrcSumOverrides verifies the pinned source checksum term is
+// used regardless of the per-target srcSum passed to send.
+func TestSYNSenderPinnedSrcSumOverrides(t *testing.T) {
+	src := net.IPv4(192, 0, 2, 50).To4()
+	pinned := ipChecksumSum(src)
+
+	s := &SYNSender{srcPort: 40000, pinnedSrcSum: pinned}
+	// baseSum mirrors the constant terms set in newSYNSender.
+	var base uint32
+	base += 6
+	base += 24
+	base += uint32(s.srcPort)
+	base += 0x6002
+	base += 0x0400
+	base += 0x0204
+	base += 0x05B4
+	s.baseSum = base
+
+	dst := [4]byte{198, 51, 100, 9}
+	const dstPort = 443
+	seq := scan.SynCookie4(dst, dstPort, s.srcPort)
+
+	// Effective source term when sending: pinned wins over any per-target value.
+	got := s.effectiveSrcSum(12345)
+	require.Equal(t, pinned, got)
+
+	// And the resulting checksum matches a hand-computed one using the pinned src.
+	want := synTCPChecksum(s.baseSum, pinned, dst, dstPort, seq)
+	require.Equal(t, want, synTCPChecksum(s.baseSum, got, dst, dstPort, seq))
+}
 
 func TestParseIPv4Fast(t *testing.T) {
 	tests := []struct {

--- a/pkg/runner/fastsend_test.go
+++ b/pkg/runner/fastsend_test.go
@@ -9,6 +9,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUint32ToIPv4(t *testing.T) {
+	require.Equal(t, net.IPv4(127, 0, 0, 1).To4(), uint32ToIPv4(0x7f000001).To4())
+	require.Equal(t, net.IPv4(255, 255, 255, 255).To4(), uint32ToIPv4(0xffffffff).To4())
+	require.Equal(t, net.IPv4(0, 0, 0, 0).To4(), uint32ToIPv4(0).To4())
+}
+
+func TestSameRouteSrc(t *testing.T) {
+	a := net.IPv4(10, 0, 0, 1)
+	b := net.IPv4(10, 0, 0, 2)
+	require.True(t, sameRouteSrc(nil, nil))
+	require.True(t, sameRouteSrc(a, net.IPv4(10, 0, 0, 1)))
+	require.False(t, sameRouteSrc(a, b))
+	require.False(t, sameRouteSrc(a, nil))
+	require.False(t, sameRouteSrc(nil, b))
+}
+
+// TestCidrRouteVariesSingleAddr ensures a single-address block is never treated
+// as route-varying (no per-destination resolution, no router calls needed).
+func TestCidrRouteVariesSingleAddr(t *testing.T) {
+	require.False(t, cidrRouteVaries(0x0a000001, 1))
+	require.False(t, cidrRouteVaries(0x0a000001, 0))
+}
+
 func TestWantsEthernetPath(t *testing.T) {
 	ip := net.IPv4(10, 0, 0, 5)
 	hw := net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}

--- a/pkg/runner/fastsend_test.go
+++ b/pkg/runner/fastsend_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseIPv4Fast(t *testing.T) {
@@ -126,32 +128,100 @@ func TestTargetIndex(t *testing.T) {
 	idx := buildTargetIndex([]*net.IPNet{cidr24, cidr16})
 
 	// First CIDR: 192.168.1.0/24 -> 256 addresses
-	ip, ipStr, ok := idx.pickIPv4(0)
+	ip, ipStr, _, ok := idx.pickIPv4(0)
 	if !ok || ip != [4]byte{192, 168, 1, 0} || ipStr != "192.168.1.0" {
 		t.Errorf("index 0: got ip=%v str=%q ok=%v", ip, ipStr, ok)
 	}
 
-	ip, ipStr, ok = idx.pickIPv4(255)
+	ip, ipStr, _, ok = idx.pickIPv4(255)
 	if !ok || ip != [4]byte{192, 168, 1, 255} || ipStr != "192.168.1.255" {
 		t.Errorf("index 255: got ip=%v str=%q ok=%v", ip, ipStr, ok)
 	}
 
 	// Second CIDR starts at index 256: 10.0.0.0/16
-	ip, ipStr, ok = idx.pickIPv4(256)
+	ip, ipStr, _, ok = idx.pickIPv4(256)
 	if !ok || ip != [4]byte{10, 0, 0, 0} || ipStr != "10.0.0.0" {
 		t.Errorf("index 256: got ip=%v str=%q ok=%v", ip, ipStr, ok)
 	}
 
-	ip, ipStr, ok = idx.pickIPv4(256 + 65535)
+	ip, ipStr, _, ok = idx.pickIPv4(256 + 65535)
 	if !ok || ip != [4]byte{10, 0, 255, 255} || ipStr != "10.0.255.255" {
 		t.Errorf("index 256+65535: got ip=%v str=%q ok=%v", ip, ipStr, ok)
 	}
 
 	// Out of range
-	_, _, ok = idx.pickIPv4(256 + 65536)
+	_, _, _, ok = idx.pickIPv4(256 + 65536)
 	if ok {
 		t.Error("expected ok=false for out-of-range index")
 	}
+}
+
+// referenceTCPChecksum independently computes the TCP checksum over the
+// pseudo-header + segment using the textbook one's-complement sum, so we can
+// assert synTCPChecksum (which folds precomputed terms) produces the same value
+// for the source IP the kernel will actually use.
+func referenceTCPChecksum(src, dst [4]byte, seg []byte) uint16 {
+	pseudo := []byte{
+		src[0], src[1], src[2], src[3],
+		dst[0], dst[1], dst[2], dst[3],
+		0, 6,
+		byte(len(seg) >> 8), byte(len(seg)),
+	}
+	var sum uint32
+	add := func(b []byte) {
+		for i := 0; i+1 < len(b); i += 2 {
+			sum += uint32(b[i])<<8 | uint32(b[i+1])
+		}
+		if len(b)%2 == 1 {
+			sum += uint32(b[len(b)-1]) << 8
+		}
+	}
+	add(pseudo)
+	add(seg)
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}
+
+func TestSynTCPChecksumUsesPerTargetSource(t *testing.T) {
+	const srcPort = uint16(54321)
+	srcIP := [4]byte{10, 0, 0, 5}
+	dstIP := [4]byte{93, 184, 216, 34}
+	const dstPort = uint16(443)
+	const seq = uint32(0xDEADBEEF)
+
+	// Build the 24-byte SYN segment exactly as newSYNSender/send do (checksum
+	// field left zero for the reference computation).
+	var pkt [24]byte
+	binary.BigEndian.PutUint16(pkt[0:2], srcPort)
+	binary.BigEndian.PutUint16(pkt[2:4], dstPort)
+	binary.BigEndian.PutUint32(pkt[4:8], seq)
+	pkt[12] = 0x60
+	pkt[13] = 0x02
+	binary.BigEndian.PutUint16(pkt[14:16], 1024)
+	pkt[20] = 2
+	pkt[21] = 4
+	binary.BigEndian.PutUint16(pkt[22:24], 1460)
+
+	// baseSum mirrors newSYNSender (constant terms, no source IP).
+	var baseSum uint32
+	baseSum += 6
+	baseSum += 24
+	baseSum += uint32(srcPort)
+	baseSum += 0x6002
+	baseSum += 0x0400
+	baseSum += 0x0204
+	baseSum += 0x05B4
+
+	want := referenceTCPChecksum(srcIP, dstIP, pkt[:])
+	got := synTCPChecksum(baseSum, ipChecksumSum(net.IP(srcIP[:])), dstIP, dstPort, seq)
+	require.Equal(t, want, got, "checksum must match a real packet from %v", srcIP)
+
+	// Using the wrong source IP (the old always-default-route bug) yields a
+	// checksum the target stack would reject.
+	wrong := synTCPChecksum(baseSum, ipChecksumSum(net.IPv4(127, 0, 0, 1).To4()), dstIP, dstPort, seq)
+	require.NotEqual(t, want, wrong, "a mismatched source must change the checksum")
 }
 
 func TestFormatIPv4RoundTrip(t *testing.T) {

--- a/pkg/runner/fastsend_test.go
+++ b/pkg/runner/fastsend_test.go
@@ -60,7 +60,7 @@ func TestWantsEthernetPath(t *testing.T) {
 	// source ip + interface MAC but not bound: must go L2 (spoof/non-owned).
 	require.True(t, wantsEthernetPath(&scan.ListenHandler{SourceIp4: ip, SourceHW: hw}))
 	// bound source: kernel emits it, stay on the fast path.
-	require.False(t, wantsEthernetPath(&scan.ListenHandler{SourceIp4: ip, SourceHW: hw, SourceBound: true}))
+	require.False(t, wantsEthernetPath(&scan.ListenHandler{SourceIp4: ip, SourceHW: hw, SourceBound4: true}))
 	// source ip alone (no interface MAC): fast path with the bound socket.
 	require.False(t, wantsEthernetPath(&scan.ListenHandler{SourceIp4: ip}))
 	// interface alone: no source to force, fast path.

--- a/pkg/runner/fastsend_test.go
+++ b/pkg/runner/fastsend_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWorkerSYNSenderUsesIndependentRawSocket(t *testing.T) {
+	if scan.PkgRouter == nil {
+		t.Skip("routing is unavailable")
+	}
+	conn, err := net.ListenIP("ip4:tcp", &net.IPAddr{IP: net.IPv4zero})
+	if err != nil {
+		t.Skipf("raw sockets are unavailable: %v", err)
+	}
+	defer conn.Close()
+
+	handler := &scan.ListenHandler{TcpConn4: conn}
+	base, err := newSYNSender(handler)
+	require.NoError(t, err)
+	worker, err := newWorkerSYNSender(handler)
+	require.NoError(t, err)
+	defer worker.close()
+
+	require.NotEqual(t, base.sender.FD(), worker.sender.FD(),
+		"workers sharing one fd serialize in the kernel")
+}
+
 func TestUint32ToIPv4(t *testing.T) {
 	require.Equal(t, net.IPv4(127, 0, 0, 1).To4(), uint32ToIPv4(0x7f000001).To4())
 	require.Equal(t, net.IPv4(255, 255, 255, 255).To4(), uint32ToIPv4(0xffffffff).To4())

--- a/pkg/runner/fastsend_test.go
+++ b/pkg/runner/fastsend_test.go
@@ -17,7 +17,7 @@ func TestWorkerSYNSenderUsesIndependentRawSocket(t *testing.T) {
 	if err != nil {
 		t.Skipf("raw sockets are unavailable: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	handler := &scan.ListenHandler{TcpConn4: conn}
 	base, err := newSYNSender(handler)

--- a/pkg/runner/fdlimit.go
+++ b/pkg/runner/fdlimit.go
@@ -1,0 +1,30 @@
+package runner
+
+// fdLimitReserve is the number of file descriptors kept aside for everything
+// that is not an in-flight connect probe: stdio, pcap handles, output files,
+// DNS sockets, the metrics server and service-version workers.
+const fdLimitReserve = 128
+
+// connectConcurrency returns how many concurrent connect probes are safe given
+// the process open-file soft limit. Connect scan opens one socket per in-flight
+// probe, so running rate goroutines with rate > ulimit yields "too many open
+// files". A soft of 0 means the limit is unknown (or unlimited) and rate is
+// used unchanged.
+func connectConcurrency(rate int, soft uint64) int {
+	if rate < 1 {
+		rate = 1
+	}
+	if soft == 0 {
+		return rate
+	}
+	if soft <= fdLimitReserve {
+		return 1
+	}
+	avail := soft - fdLimitReserve
+	// avail is only narrowed to int when it is smaller than rate, so the
+	// conversion can never overflow regardless of how large the limit is.
+	if avail >= uint64(rate) {
+		return rate
+	}
+	return int(avail)
+}

--- a/pkg/runner/fdlimit_test.go
+++ b/pkg/runner/fdlimit_test.go
@@ -1,0 +1,44 @@
+package runner
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectConcurrency(t *testing.T) {
+	tests := []struct {
+		name string
+		rate int
+		soft uint64
+		want int
+	}{
+		{"unknown limit keeps rate", 1500, 0, 1500},
+		{"limit well above rate keeps rate", 1500, 1048576, 1500},
+		{"typical 1024 ulimit caps below rate", 1500, 1024, 1024 - fdLimitReserve},
+		{"rate below available keeps rate", 200, 1024, 200},
+		{"tiny limit floors at one", 1500, fdLimitReserve, 1},
+		{"limit smaller than reserve floors at one", 1500, 16, 1},
+		{"rate equal to available keeps rate", 1024 - fdLimitReserve, 1024, 1024 - fdLimitReserve},
+		{"zero rate normalised to one", 0, 0, 1},
+		{"huge limit never overflows", 1000, 1 << 62, 1000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, connectConcurrency(tt.rate, tt.soft))
+		})
+	}
+}
+
+func TestRaiseOpenFileLimitDoesNotLower(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		require.Equal(t, uint64(0), raiseOpenFileLimit())
+		return
+	}
+	before := raiseOpenFileLimit()
+	require.Greater(t, before, uint64(0), "soft limit should be readable on unix")
+	// Idempotent: a second call must not reduce the limit.
+	after := raiseOpenFileLimit()
+	require.GreaterOrEqual(t, after, before)
+}

--- a/pkg/runner/fdlimit_unix.go
+++ b/pkg/runner/fdlimit_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package runner
+
+import "golang.org/x/sys/unix"
+
+// raiseOpenFileLimit best-effort raises the RLIMIT_NOFILE soft limit to the
+// hard limit and returns the resulting soft limit (0 if it cannot be read).
+// This lets high-rate connect scans use the FDs the kernel already permits
+// without the user having to run `ulimit -n` manually.
+func raiseOpenFileLimit() uint64 {
+	var lim unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &lim); err != nil {
+		return 0
+	}
+	if lim.Cur >= lim.Max {
+		return lim.Cur
+	}
+	target := lim
+	target.Cur = lim.Max
+	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &target); err == nil {
+		return lim.Max
+	}
+	// Darwin rejects a soft limit above OPEN_MAX even when the hard limit is
+	// higher, so retry with a conservative ceiling.
+	const darwinCeil = 24576
+	if lim.Cur < darwinCeil {
+		target.Cur = darwinCeil
+		if lim.Max < darwinCeil {
+			target.Cur = lim.Max
+		}
+		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &target); err == nil {
+			return target.Cur
+		}
+	}
+	return lim.Cur
+}

--- a/pkg/runner/fdlimit_windows.go
+++ b/pkg/runner/fdlimit_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package runner
+
+// raiseOpenFileLimit is a no-op on Windows, which does not expose a per-process
+// file-descriptor rlimit. Returning 0 leaves connect concurrency at the
+// configured rate.
+func raiseOpenFileLimit() uint64 { return 0 }

--- a/pkg/runner/fpqueue.go
+++ b/pkg/runner/fpqueue.go
@@ -6,44 +6,60 @@ import (
 	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
 )
 
-// fpQueue is an unbounded, drop-free hand-off between the scan hot path and the
+// fpQueueMaxItems caps the in-memory backlog of pending service-detection
+// targets. At ~hundreds of bytes per target this bounds the queue to a few tens
+// of MB even on huge, high-yield scans. push applies backpressure at this
+// ceiling instead of growing without limit.
+const fpQueueMaxItems = 100_000
+
+// fpQueue is a bounded, drop-free hand-off between the scan hot path and the
 // (slower) service-detection workers.
 //
-// The previous design fed a fixed buffered channel with a non-blocking send and
+// The original design fed a fixed buffered channel with a non-blocking send and
 // a default: drop, so when discovery outpaced the fingerprint workers - exactly
 // what the fast SYN path causes - open ports were silently dropped and -sV
-// missed them. push never blocks the scan and never drops; a single forwarder
-// goroutine drains into the engine, blocking only itself.
+// missed them. This queue never drops: a single forwarder goroutine drains into
+// the engine. To avoid an unbounded backlog (and eventual OOM) when discovery
+// sustainably outruns detection, push blocks once the backlog reaches
+// maxItems and resumes as the forwarder drains, propagating backpressure to the
+// scan instead of buffering everything in memory.
 type fpQueue struct {
-	mu     sync.Mutex
-	cond   *sync.Cond
-	items  []fingerprint.Target
-	closed bool
+	mu       sync.Mutex
+	notEmpty *sync.Cond
+	notFull  *sync.Cond
+	items    []fingerprint.Target
+	maxItems int
+	closed   bool
 }
 
 func newFpQueue() *fpQueue {
-	q := &fpQueue{}
-	q.cond = sync.NewCond(&q.mu)
+	q := &fpQueue{maxItems: fpQueueMaxItems}
+	q.notEmpty = sync.NewCond(&q.mu)
+	q.notFull = sync.NewCond(&q.mu)
 	return q
 }
 
-// push appends a target. It returns immediately and is safe to call from the
-// scan hot path. Pushes after close are ignored.
+// push appends a target, blocking only while the backlog is at the memory
+// ceiling so nothing is ever dropped. Pushes after close are ignored.
 func (q *fpQueue) push(t fingerprint.Target) {
 	q.mu.Lock()
+	for !q.closed && q.maxItems > 0 && len(q.items) >= q.maxItems {
+		q.notFull.Wait()
+	}
 	if !q.closed {
 		q.items = append(q.items, t)
-		q.cond.Signal()
+		q.notEmpty.Signal()
 	}
 	q.mu.Unlock()
 }
 
 // close marks the queue done. pop will return the remaining items and then
-// report ok=false once drained.
+// report ok=false once drained. Any pusher blocked on backpressure is released.
 func (q *fpQueue) close() {
 	q.mu.Lock()
 	q.closed = true
-	q.cond.Broadcast()
+	q.notEmpty.Broadcast()
+	q.notFull.Broadcast()
 	q.mu.Unlock()
 }
 
@@ -53,7 +69,7 @@ func (q *fpQueue) pop() (fingerprint.Target, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	for len(q.items) == 0 && !q.closed {
-		q.cond.Wait()
+		q.notEmpty.Wait()
 	}
 	if len(q.items) == 0 {
 		return fingerprint.Target{}, false
@@ -61,5 +77,6 @@ func (q *fpQueue) pop() (fingerprint.Target, bool) {
 	t := q.items[0]
 	q.items[0] = fingerprint.Target{}
 	q.items = q.items[1:]
+	q.notFull.Signal()
 	return t, true
 }

--- a/pkg/runner/fpqueue.go
+++ b/pkg/runner/fpqueue.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"sync"
+
+	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
+)
+
+// fpQueue is an unbounded, drop-free hand-off between the scan hot path and the
+// (slower) service-detection workers.
+//
+// The previous design fed a fixed buffered channel with a non-blocking send and
+// a default: drop, so when discovery outpaced the fingerprint workers - exactly
+// what the fast SYN path causes - open ports were silently dropped and -sV
+// missed them. push never blocks the scan and never drops; a single forwarder
+// goroutine drains into the engine, blocking only itself.
+type fpQueue struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	items  []fingerprint.Target
+	closed bool
+}
+
+func newFpQueue() *fpQueue {
+	q := &fpQueue{}
+	q.cond = sync.NewCond(&q.mu)
+	return q
+}
+
+// push appends a target. It returns immediately and is safe to call from the
+// scan hot path. Pushes after close are ignored.
+func (q *fpQueue) push(t fingerprint.Target) {
+	q.mu.Lock()
+	if !q.closed {
+		q.items = append(q.items, t)
+		q.cond.Signal()
+	}
+	q.mu.Unlock()
+}
+
+// close marks the queue done. pop will return the remaining items and then
+// report ok=false once drained.
+func (q *fpQueue) close() {
+	q.mu.Lock()
+	q.closed = true
+	q.cond.Broadcast()
+	q.mu.Unlock()
+}
+
+// pop blocks until an item is available, or returns ok=false when the queue is
+// closed and fully drained.
+func (q *fpQueue) pop() (fingerprint.Target, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for len(q.items) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+	if len(q.items) == 0 {
+		return fingerprint.Target{}, false
+	}
+	t := q.items[0]
+	q.items[0] = fingerprint.Target{}
+	q.items = q.items[1:]
+	return t, true
+}

--- a/pkg/runner/fpqueue.go
+++ b/pkg/runner/fpqueue.go
@@ -12,7 +12,7 @@ import (
 // ceiling instead of growing without limit.
 const fpQueueMaxItems = 100_000
 
-// fpQueue is a bounded, drop-free hand-off between the scan hot path and the
+// fpQueue is a bounded, drop-free hand-off between the scan result path and the
 // (slower) service-detection workers.
 //
 // The original design fed a fixed buffered channel with a non-blocking send and
@@ -22,12 +22,14 @@ const fpQueueMaxItems = 100_000
 // the engine. To avoid an unbounded backlog (and eventual OOM) when discovery
 // sustainably outruns detection, push blocks once the backlog reaches
 // maxItems and resumes as the forwarder drains, propagating backpressure to the
-// scan instead of buffering everything in memory.
+// caller (typically TCPResultWorker via onReceive) instead of buffering
+// everything in memory.
 type fpQueue struct {
 	mu       sync.Mutex
 	notEmpty *sync.Cond
 	notFull  *sync.Cond
 	items    []fingerprint.Target
+	head     int
 	maxItems int
 	closed   bool
 }
@@ -39,11 +41,15 @@ func newFpQueue() *fpQueue {
 	return q
 }
 
+func (q *fpQueue) lenLocked() int {
+	return len(q.items) - q.head
+}
+
 // push appends a target, blocking only while the backlog is at the memory
 // ceiling so nothing is ever dropped. Pushes after close are ignored.
 func (q *fpQueue) push(t fingerprint.Target) {
 	q.mu.Lock()
-	for !q.closed && q.maxItems > 0 && len(q.items) >= q.maxItems {
+	for !q.closed && q.maxItems > 0 && q.lenLocked() >= q.maxItems {
 		q.notFull.Wait()
 	}
 	if !q.closed {
@@ -64,19 +70,24 @@ func (q *fpQueue) close() {
 }
 
 // pop blocks until an item is available, or returns ok=false when the queue is
-// closed and fully drained.
+// closed and fully drained. Uses a head offset so pops are O(1); the underlying
+// slice is compacted when half of it is drained.
 func (q *fpQueue) pop() (fingerprint.Target, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	for len(q.items) == 0 && !q.closed {
+	for q.lenLocked() == 0 && !q.closed {
 		q.notEmpty.Wait()
 	}
-	if len(q.items) == 0 {
+	if q.lenLocked() == 0 {
 		return fingerprint.Target{}, false
 	}
-	t := q.items[0]
-	q.items[0] = fingerprint.Target{}
-	q.items = q.items[1:]
+	t := q.items[q.head]
+	q.items[q.head] = fingerprint.Target{}
+	q.head++
+	if q.head > 1024 && q.head*2 >= len(q.items) {
+		q.items = append([]fingerprint.Target(nil), q.items[q.head:]...)
+		q.head = 0
+	}
 	q.notFull.Signal()
 	return t, true
 }

--- a/pkg/runner/fpqueue_test.go
+++ b/pkg/runner/fpqueue_test.go
@@ -1,0 +1,87 @@
+package runner
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFpQueueNoDropPreservesOrder is the regression guard for the silent -sV
+// drop: every pushed target must come back out, in FIFO order, even though the
+// previous design dropped under load.
+func TestFpQueueNoDropPreservesOrder(t *testing.T) {
+	q := newFpQueue()
+	const n = 10000
+
+	var got []int
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			tgt, ok := q.pop()
+			if !ok {
+				return
+			}
+			got = append(got, tgt.Port)
+		}
+	}()
+
+	for i := 0; i < n; i++ {
+		q.push(fingerprint.Target{Port: i})
+	}
+	q.close()
+	<-done
+
+	require.Len(t, got, n, "no target may be dropped")
+	for i := 0; i < n; i++ {
+		require.Equal(t, i, got[i], "FIFO order must be preserved")
+	}
+}
+
+// TestFpQueueConcurrentPushNoDrop mirrors real usage: onReceive can be called
+// from many scan goroutines at once. Run with -race.
+func TestFpQueueConcurrentPushNoDrop(t *testing.T) {
+	q := newFpQueue()
+	const producers = 8
+	const perProducer = 2000
+
+	total := 0
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, ok := q.pop(); !ok {
+				return
+			}
+			total++
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for p := 0; p < producers; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perProducer; i++ {
+				q.push(fingerprint.Target{Port: i})
+			}
+		}()
+	}
+	wg.Wait()
+	q.close()
+	<-done
+
+	require.Equal(t, producers*perProducer, total, "all concurrent pushes must be delivered")
+}
+
+// TestFpQueuePushAfterCloseIgnored ensures a late push cannot panic or wake a
+// finished consumer.
+func TestFpQueuePushAfterCloseIgnored(t *testing.T) {
+	q := newFpQueue()
+	q.close()
+	q.push(fingerprint.Target{Port: 1})
+	_, ok := q.pop()
+	require.False(t, ok, "closed-and-empty queue must report drained")
+}

--- a/pkg/runner/fpqueue_test.go
+++ b/pkg/runner/fpqueue_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
 	"github.com/stretchr/testify/require"
@@ -84,4 +85,42 @@ func TestFpQueuePushAfterCloseIgnored(t *testing.T) {
 	q.push(fingerprint.Target{Port: 1})
 	_, ok := q.pop()
 	require.False(t, ok, "closed-and-empty queue must report drained")
+}
+
+// TestFpQueueBackpressureBounded verifies the backlog never exceeds the cap
+// while a slow consumer drains, yet every item is still delivered (no drop).
+func TestFpQueueBackpressureBounded(t *testing.T) {
+	q := newFpQueue()
+	q.maxItems = 8
+	const n = 200
+
+	var maxLen int
+	got := 0
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			q.mu.Lock()
+			if l := len(q.items); l > maxLen {
+				maxLen = l
+			}
+			q.mu.Unlock()
+			tgt, ok := q.pop()
+			if !ok {
+				return
+			}
+			_ = tgt
+			got++
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < n; i++ {
+		q.push(fingerprint.Target{Port: i})
+	}
+	q.close()
+	<-done
+
+	require.Equal(t, n, got, "every pushed target must be delivered")
+	require.LessOrEqual(t, maxLen, q.maxItems, "backlog must stay within the cap")
 }

--- a/pkg/runner/fpqueue_test.go
+++ b/pkg/runner/fpqueue_test.go
@@ -101,7 +101,7 @@ func TestFpQueueBackpressureBounded(t *testing.T) {
 		defer close(done)
 		for {
 			q.mu.Lock()
-			if l := len(q.items); l > maxLen {
+			if l := q.lenLocked(); l > maxLen {
 				maxLen = l
 			}
 			q.mu.Unlock()

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -97,9 +97,10 @@ func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, inde
 		dstIP4 [4]byte
 		isV4   bool
 		ip     string
+		srcSum uint32
 	)
 	if sender != nil {
-		dstIP4, ip, isV4 = tgtIdx.pickIPv4(ipIndex)
+		dstIP4, ip, srcSum, isV4 = tgtIdx.pickIPv4(ipIndex)
 	}
 	if ip == "" {
 		ip = r.PickIP(targets, ipIndex)
@@ -130,7 +131,7 @@ func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, inde
 				return
 			}
 			pace.wait()
-			if err := sender.send(dstIP4, uint16(port.Port)); err != nil {
+			if err := sender.send(dstIP4, srcSum, uint16(port.Port)); err != nil {
 				gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
 			}
 		} else {

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -132,6 +132,9 @@ func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, inde
 			}
 			pace.wait()
 			if err := sender.send(dstIP4, srcSum, uint16(port.Port)); err != nil {
+				if isCongestion(err) {
+					pace.onCongestion()
+				}
 				gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
 			}
 		} else {

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -67,9 +67,19 @@ func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int6
 			defer wg.Done()
 			pace := newPacer(perWorkerRate)
 			forEachWorkerIndex(worker, n, rng, func(index int64) {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 				r.fastScanIndex(ctx, b, index, portsCount, targets, tgtIdx, sender, pace, payload, raw)
 			})
-			_ = sender.flush()
+			if err := sender.flush(); err != nil {
+				if isCongestion(err) {
+					pace.onCongestion()
+				}
+				gologger.Debug().Msgf("tx worker %d final flush failed: %s\n", worker, err)
+			}
 		}(w, senders[w])
 	}
 	wg.Wait()

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"github.com/projectdiscovery/blackrock"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
+)
+
+// forEachWorkerIndex walks the strided slice of [0,rng) owned by a given worker.
+// Workers 0..workers-1 partition the index space by residue (index % workers),
+// so every index is visited by exactly one worker.
+func forEachWorkerIndex(worker, workers int, rng int64, fn func(int64)) {
+	if workers < 1 {
+		workers = 1
+	}
+	for index := int64(worker); index < rng; index += int64(workers) {
+		fn(index)
+	}
+}
+
+// runFastTx fans the fast SYN send loop across r.options.TxWorkers goroutines,
+// each with its own raw sender, batch buffer and rate pacer, to overcome the
+// single-core transmit ceiling. The global rate is split evenly across workers.
+//
+// Note: per-index resume bookkeeping is intentionally skipped on this path - it
+// is inherently serial and meaningless once sends are fanned out; resume falls
+// back to the standard single-worker loop.
+func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int64, portsCount uint64,
+	targets []*net.IPNet, tgtIdx *targetIndex, base *SYNSender, payload string, raw bool) {
+
+	n := r.options.TxWorkers
+	if n < 1 {
+		n = 1
+	}
+
+	// One sender per worker; the first reuses the already-created base sender.
+	// Additional senders share the same raw fd but keep independent batch
+	// buffers, so userspace batching does not contend.
+	senders := make([]*SYNSender, 1, n)
+	senders[0] = base
+	for i := 1; i < n; i++ {
+		s, err := newSYNSender(r.scanner.ListenHandler)
+		if err != nil {
+			gologger.Debug().Msgf("tx worker %d sender unavailable (%s), reducing fan-out to %d\n", i, err, i)
+			break
+		}
+		senders = append(senders, s)
+	}
+	n = len(senders)
+
+	perWorkerRate := r.options.Rate
+	if perWorkerRate > 0 {
+		perWorkerRate /= n
+		if perWorkerRate < 1 {
+			perWorkerRate = 1
+		}
+	}
+
+	var wg sync.WaitGroup
+	for w := 0; w < n; w++ {
+		wg.Add(1)
+		go func(worker int, sender *SYNSender) {
+			defer wg.Done()
+			pace := newPacer(perWorkerRate)
+			forEachWorkerIndex(worker, n, rng, func(index int64) {
+				r.fastScanIndex(ctx, b, index, portsCount, targets, tgtIdx, sender, pace, payload, raw)
+			})
+			_ = sender.flush()
+		}(w, senders[w])
+	}
+	wg.Wait()
+
+	// Drain any fallback (IPv6/connect) probes handed off to handleHostPort.
+	r.wgscan.Wait()
+}
+
+// fastScanIndex processes a single Blackrock index on the fast SYN path. It is
+// safe for concurrent use: the result store is mutex-protected, Blackrock.Shuffle
+// is pure, and each caller supplies its own sender and pacer.
+func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, index int64, portsCount uint64,
+	targets []*net.IPNet, tgtIdx *targetIndex, sender *SYNSender, pace *pacer, payload string, raw bool) {
+
+	// Distributed sharding: only handle this node's slice.
+	if !r.options.inShard(index) {
+		return
+	}
+
+	xxx := b.Shuffle(index)
+	ipIndex := xxx / int64(portsCount)
+	portIndex := int(xxx % int64(portsCount))
+
+	var (
+		dstIP4 [4]byte
+		isV4   bool
+		ip     string
+	)
+	if sender != nil {
+		dstIP4, ip, isV4 = tgtIdx.pickIPv4(ipIndex)
+	}
+	if ip == "" {
+		ip = r.PickIP(targets, ipIndex)
+	}
+
+	if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
+		return
+	}
+
+	port := r.PickPort(portIndex)
+
+	if r.scanner.ScanResults.HasSkipped(ip) {
+		return
+	}
+	if r.options.PortThreshold > 0 && r.scanner.ScanResults.GetPortCount(ip) >= r.options.PortThreshold {
+		hosts, _ := r.scanner.IPRanger.GetHostsByIP(ip)
+		gologger.Info().Msgf("Skipping %s %v, Threshold reached \n", ip, hosts)
+		r.scanner.ScanResults.AddSkipped(ip)
+		return
+	}
+
+	if raw {
+		if sender != nil && isV4 && port.Protocol == protocol.TCP {
+			if r.scanner.ScanResults.IPHasPort(ip, port) {
+				return
+			}
+			if !r.canIScanIfCDN(ip, port) {
+				return
+			}
+			pace.wait()
+			if err := sender.send(dstIP4, uint16(port.Port)); err != nil {
+				gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
+			}
+		} else {
+			r.RawSocketEnumeration(ctx, ip, port)
+		}
+	} else {
+		r.wgscan.Add()
+		go r.handleHostPort(ctx, ip, payload, port)
+	}
+
+	if r.options.EnableProgressBar {
+		r.stats.IncrementCounter("packets", 1)
+	}
+}

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -12,13 +12,16 @@ import (
 
 // forEachWorkerIndex walks the strided slice of [0,rng) owned by a given worker.
 // Workers 0..workers-1 partition the index space by residue (index % workers),
-// so every index is visited by exactly one worker.
-func forEachWorkerIndex(worker, workers int, rng int64, fn func(int64)) {
+// so every index is visited by exactly one worker. fn returning false stops the
+// walk early (used for context cancellation).
+func forEachWorkerIndex(worker, workers int, rng int64, fn func(int64) bool) {
 	if workers < 1 {
 		workers = 1
 	}
 	for index := int64(worker); index < rng; index += int64(workers) {
-		fn(index)
+		if !fn(index) {
+			return
+		}
 	}
 }
 
@@ -52,6 +55,13 @@ func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int6
 	}
 	n = len(senders)
 
+	// Cap fan-out by the configured rate so each worker can still send at least
+	// 1 pps without inflating the aggregate rate above -rate.
+	if r.options.Rate > 0 && n > r.options.Rate {
+		n = r.options.Rate
+		senders = senders[:n]
+	}
+
 	perWorkerRate := r.options.Rate
 	if perWorkerRate > 0 {
 		perWorkerRate /= n
@@ -66,13 +76,14 @@ func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int6
 		go func(worker int, sender *SYNSender) {
 			defer wg.Done()
 			pace := newPacer(perWorkerRate)
-			forEachWorkerIndex(worker, n, rng, func(index int64) {
+			forEachWorkerIndex(worker, n, rng, func(index int64) bool {
 				select {
 				case <-ctx.Done():
-					return
+					return false
 				default:
 				}
 				r.fastScanIndex(ctx, b, index, portsCount, targets, tgtIdx, sender, pace, payload, raw)
+				return true
 			})
 			if err := sender.flush(); err != nil {
 				if isCongestion(err) {
@@ -115,13 +126,11 @@ func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, inde
 	if ip == "" {
 		ip = r.PickIP(targets, ipIndex)
 	}
-
 	if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
 		return
 	}
 
 	port := r.PickPort(portIndex)
-
 	if r.scanner.ScanResults.HasSkipped(ip) {
 		return
 	}
@@ -154,7 +163,6 @@ func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, inde
 		r.wgscan.Add()
 		go r.handleHostPort(ctx, ip, payload, port)
 	}
-
 	if r.options.EnableProgressBar {
 		r.stats.IncrementCounter("packets", 1)
 	}

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -35,18 +35,15 @@ func forEachWorkerIndex(worker, workers int, rng int64, fn func(int64) bool) {
 func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int64, portsCount uint64,
 	targets []*net.IPNet, tgtIdx *targetIndex, base *SYNSender, payload string, raw bool) {
 
-	n := r.options.TxWorkers
-	if n < 1 {
-		n = 1
-	}
+	n := effectiveTxWorkers(r.options.TxWorkers, r.options.Rate, rng, base != nil && base.batch != nil)
 
 	// One sender per worker; the first reuses the already-created base sender.
-	// Additional senders share the same raw fd but keep independent batch
-	// buffers, so userspace batching does not contend.
+	// Additional senders own independent raw sockets and batch buffers so both
+	// userspace batching and the kernel transmit path can run concurrently.
 	senders := make([]*SYNSender, 1, n)
 	senders[0] = base
 	for i := 1; i < n; i++ {
-		s, err := newSYNSender(r.scanner.ListenHandler)
+		s, err := newWorkerSYNSender(r.scanner.ListenHandler)
 		if err != nil {
 			gologger.Debug().Msgf("tx worker %d sender unavailable (%s), reducing fan-out to %d\n", i, err, i)
 			break
@@ -55,27 +52,15 @@ func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int6
 	}
 	n = len(senders)
 
-	// Cap fan-out by the configured rate so each worker can still send at least
-	// 1 pps without inflating the aggregate rate above -rate.
-	if r.options.Rate > 0 && n > r.options.Rate {
-		n = r.options.Rate
-		senders = senders[:n]
-	}
-
-	perWorkerRate := r.options.Rate
-	if perWorkerRate > 0 {
-		perWorkerRate /= n
-		if perWorkerRate < 1 {
-			perWorkerRate = 1
-		}
-	}
-
 	var wg sync.WaitGroup
 	for w := 0; w < n; w++ {
 		wg.Add(1)
 		go func(worker int, sender *SYNSender) {
 			defer wg.Done()
-			pace := newPacer(perWorkerRate)
+			if worker > 0 {
+				defer sender.close()
+			}
+			pace := newPacer(rateForWorker(r.options.Rate, n, worker))
 			forEachWorkerIndex(worker, n, rng, func(index int64) bool {
 				select {
 				case <-ctx.Done():
@@ -97,6 +82,40 @@ func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int6
 
 	// Drain any fallback (IPv6/connect) probes handed off to handleHostPort.
 	r.wgscan.Wait()
+}
+
+// rateForWorker splits the configured global rate without dropping the
+// remainder, while keeping the sum of all worker rates exactly equal to rate.
+func rateForWorker(rate, workers, worker int) int {
+	if rate <= 0 {
+		return rate
+	}
+	base := rate / workers
+	if worker < rate%workers {
+		base++
+	}
+	return base
+}
+
+// effectiveTxWorkers avoids opening sockets and scheduling goroutines that
+// cannot do useful work. On Linux, one sender can batch synBatchSize probes
+// into a single sendmmsg call, so fan-out below that boundary only adds partial
+// flushes. Non-batched platforms are capped by probe count instead.
+func effectiveTxWorkers(requested, rate int, rng int64, batched bool) int {
+	if requested < 1 {
+		requested = 1
+	}
+	if rate > 0 && requested > rate {
+		requested = rate
+	}
+	usefulWork := rng
+	if batched && rng > 0 {
+		usefulWork = (rng + synBatchSize - 1) / synBatchSize
+	}
+	if usefulWork > 0 && int64(requested) > usefulWork {
+		requested = int(usefulWork)
+	}
+	return requested
 }
 
 // fastScanIndex processes a single Blackrock index on the fast SYN path. It is

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -25,21 +25,14 @@ func forEachWorkerIndex(worker, workers int, rng int64, fn func(int64) bool) {
 	}
 }
 
-// runFastTx fans the fast SYN send loop across r.options.TxWorkers goroutines,
-// each with its own raw sender, batch buffer and rate pacer, to overcome the
-// single-core transmit ceiling. The global rate is split evenly across workers.
-//
-// Note: per-index resume bookkeeping is intentionally skipped on this path - it
-// is inherently serial and meaningless once sends are fanned out; resume falls
-// back to the standard single-worker loop.
-func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int64, portsCount uint64,
-	targets []*net.IPNet, tgtIdx *targetIndex, base *SYNSender, payload string, raw bool) {
-
+// buildTxSenders creates the fan-out senders for the multi-core transmit path.
+// The first slot reuses the already-created base sender; additional workers own
+// independent raw sockets and batch buffers so both userspace batching and the
+// kernel transmit path can run concurrently. Sockets are opened once and reused
+// across retries (closeTxSenders frees the extra ones), avoiding a fresh
+// open/close of every worker socket on each retry pass.
+func (r *Runner) buildTxSenders(base *SYNSender, rng int64) []*SYNSender {
 	n := effectiveTxWorkers(r.options.TxWorkers, r.options.Rate, rng, base != nil && base.batch != nil)
-
-	// One sender per worker; the first reuses the already-created base sender.
-	// Additional senders own independent raw sockets and batch buffers so both
-	// userspace batching and the kernel transmit path can run concurrently.
 	senders := make([]*SYNSender, 1, n)
 	senders[0] = base
 	for i := 1; i < n; i++ {
@@ -50,16 +43,38 @@ func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int6
 		}
 		senders = append(senders, s)
 	}
-	n = len(senders)
+	return senders
+}
+
+// closeTxSenders releases the extra worker sockets built by buildTxSenders. The
+// base sender (index 0) wraps the shared listen handler and is closed elsewhere.
+func closeTxSenders(senders []*SYNSender) {
+	for i := 1; i < len(senders); i++ {
+		senders[i].close()
+	}
+}
+
+// runFastTx fans the fast SYN send loop across the pre-built senders, each with
+// its own raw sender, batch buffer and rate pacer, to overcome the single-core
+// transmit ceiling. The global rate is split evenly across workers. Senders are
+// owned by the caller and reused across retries, so this does not close them.
+//
+// Note: per-index resume bookkeeping is intentionally skipped on this path - it
+// is inherently serial and meaningless once sends are fanned out; resume falls
+// back to the standard single-worker loop.
+func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int64, portsCount uint64,
+	targets []*net.IPNet, tgtIdx *targetIndex, senders []*SYNSender, payload string, raw bool) {
+
+	n := len(senders)
+	if n == 0 {
+		return
+	}
 
 	var wg sync.WaitGroup
 	for w := 0; w < n; w++ {
 		wg.Add(1)
 		go func(worker int, sender *SYNSender) {
 			defer wg.Done()
-			if worker > 0 {
-				defer sender.close()
-			}
 			pace := newPacer(rateForWorker(r.options.Rate, n, worker))
 			forEachWorkerIndex(worker, n, rng, func(index int64) bool {
 				select {

--- a/pkg/runner/multitx.go
+++ b/pkg/runner/multitx.go
@@ -62,7 +62,10 @@ func closeTxSenders(senders []*SYNSender) {
 // Note: per-index resume bookkeeping is intentionally skipped on this path - it
 // is inherently serial and meaningless once sends are fanned out; resume falls
 // back to the standard single-worker loop.
-func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int64, portsCount uint64,
+// tierPortIdx maps a within-tier port position to an index into scanner.Ports;
+// indexBase offsets this tier's local indices into the global index space so
+// shard slicing stays disjoint across tiers. See porttiers.go.
+func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng, indexBase int64, tierPortIdx []int,
 	targets []*net.IPNet, tgtIdx *targetIndex, senders []*SYNSender, payload string, raw bool) {
 
 	n := len(senders)
@@ -82,7 +85,7 @@ func (r *Runner) runFastTx(ctx context.Context, b *blackrock.BlackRock, rng int6
 					return false
 				default:
 				}
-				r.fastScanIndex(ctx, b, index, portsCount, targets, tgtIdx, sender, pace, payload, raw)
+				r.fastScanIndex(ctx, b, index, indexBase, tierPortIdx, targets, tgtIdx, sender, pace, payload, raw)
 				return true
 			})
 			if err := sender.flush(); err != nil {
@@ -136,17 +139,22 @@ func effectiveTxWorkers(requested, rate int, rng int64, batched bool) int {
 // fastScanIndex processes a single Blackrock index on the fast SYN path. It is
 // safe for concurrent use: the result store is mutex-protected, Blackrock.Shuffle
 // is pure, and each caller supplies its own sender and pacer.
-func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, index int64, portsCount uint64,
+func (r *Runner) fastScanIndex(ctx context.Context, b *blackrock.BlackRock, index, indexBase int64, tierPortIdx []int,
 	targets []*net.IPNet, tgtIdx *targetIndex, sender *SYNSender, pace *pacer, payload string, raw bool) {
 
-	// Distributed sharding: only handle this node's slice.
-	if !r.options.inShard(index) {
+	// Distributed sharding: only handle this node's slice. Shard membership is
+	// decided on the global index so slices stay disjoint across tiers.
+	if !r.options.inShard(indexBase + index) {
 		return
 	}
 
+	tierPortsCount := int64(len(tierPortIdx))
+	if tierPortsCount == 0 {
+		return
+	}
 	xxx := b.Shuffle(index)
-	ipIndex := xxx / int64(portsCount)
-	portIndex := int(xxx % int64(portsCount))
+	ipIndex := xxx / tierPortsCount
+	portIndex := tierPortIdx[int(xxx%tierPortsCount)]
 
 	var (
 		dstIP4 [4]byte

--- a/pkg/runner/multitx_test.go
+++ b/pkg/runner/multitx_test.go
@@ -1,0 +1,56 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestForEachWorkerIndexCoversSpaceOnce verifies the strided worker partition
+// visits every index in [0,rng) exactly once across all workers.
+func TestForEachWorkerIndexCoversSpaceOnce(t *testing.T) {
+	for _, workers := range []int{1, 2, 3, 4, 7} {
+		for _, rng := range []int64{0, 1, 5, 100, 1001} {
+			seen := make([]int, rng)
+			for w := 0; w < workers; w++ {
+				forEachWorkerIndex(w, workers, rng, func(i int64) {
+					seen[i]++
+				})
+			}
+			for i := int64(0); i < rng; i++ {
+				require.Equalf(t, 1, seen[i], "workers=%d rng=%d index=%d", workers, rng, i)
+			}
+		}
+	}
+}
+
+func TestForEachWorkerIndexClampsWorkers(t *testing.T) {
+	var count int
+	forEachWorkerIndex(0, 0, 10, func(int64) { count++ })
+	require.Equal(t, 10, count, "workers<1 must be treated as a single worker")
+}
+
+// TestTxWorkersShardComposition confirms multi-worker striping composes with
+// distributed sharding: union of (worker stripe ∩ shard) equals the shard slice,
+// disjointly.
+func TestTxWorkersShardComposition(t *testing.T) {
+	const workers, total, shard = 3, 2, 1
+	const rng = int64(600)
+
+	o := &Options{Shard: shard, ShardTotal: total}
+	seen := make([]int, rng)
+	for w := 0; w < workers; w++ {
+		forEachWorkerIndex(w, workers, rng, func(i int64) {
+			if o.inShard(i) {
+				seen[i]++
+			}
+		})
+	}
+	for i := int64(0); i < rng; i++ {
+		want := 0
+		if o.inShard(i) {
+			want = 1
+		}
+		require.Equalf(t, want, seen[i], "index %d", i)
+	}
+}

--- a/pkg/runner/multitx_test.go
+++ b/pkg/runner/multitx_test.go
@@ -43,6 +43,34 @@ func TestForEachWorkerIndexEarlyStop(t *testing.T) {
 	require.Equal(t, 5, count, "returning false must stop the walk")
 }
 
+func TestRateForWorkerPreservesGlobalRate(t *testing.T) {
+	for _, tc := range []struct {
+		rate, workers int
+	}{
+		{1, 1},
+		{10, 3},
+		{10001, 4},
+	} {
+		total := 0
+		for worker := 0; worker < tc.workers; worker++ {
+			workerRate := rateForWorker(tc.rate, tc.workers, worker)
+			require.GreaterOrEqual(t, workerRate, 1)
+			total += workerRate
+		}
+		require.Equal(t, tc.rate, total)
+	}
+	require.Zero(t, rateForWorker(0, 4, 0), "unlimited rate must remain unlimited")
+}
+
+func TestEffectiveTxWorkers(t *testing.T) {
+	require.Equal(t, 1, effectiveTxWorkers(0, 100, 10000, true))
+	require.Equal(t, 2, effectiveTxWorkers(8, 2, 10000, true), "rate must cap workers")
+	require.Equal(t, 1, effectiveTxWorkers(8, 10000, synBatchSize, true), "one batch needs one worker")
+	require.Equal(t, 2, effectiveTxWorkers(8, 10000, synBatchSize+1, true))
+	require.Equal(t, 3, effectiveTxWorkers(8, 10000, 3, false), "non-batched workers are capped by probes")
+	require.Equal(t, 8, effectiveTxWorkers(8, 10000, 0, true), "empty range preserves validated configuration")
+}
+
 // TestTxWorkersShardComposition confirms multi-worker striping composes with
 // distributed sharding: union of (worker stripe ∩ shard) equals the shard slice,
 // disjointly.

--- a/pkg/runner/multitx_test.go
+++ b/pkg/runner/multitx_test.go
@@ -13,8 +13,9 @@ func TestForEachWorkerIndexCoversSpaceOnce(t *testing.T) {
 		for _, rng := range []int64{0, 1, 5, 100, 1001} {
 			seen := make([]int, rng)
 			for w := 0; w < workers; w++ {
-				forEachWorkerIndex(w, workers, rng, func(i int64) {
+				forEachWorkerIndex(w, workers, rng, func(i int64) bool {
 					seen[i]++
+					return true
 				})
 			}
 			for i := int64(0); i < rng; i++ {
@@ -26,8 +27,20 @@ func TestForEachWorkerIndexCoversSpaceOnce(t *testing.T) {
 
 func TestForEachWorkerIndexClampsWorkers(t *testing.T) {
 	var count int
-	forEachWorkerIndex(0, 0, 10, func(int64) { count++ })
+	forEachWorkerIndex(0, 0, 10, func(int64) bool {
+		count++
+		return true
+	})
 	require.Equal(t, 10, count, "workers<1 must be treated as a single worker")
+}
+
+func TestForEachWorkerIndexEarlyStop(t *testing.T) {
+	var count int
+	forEachWorkerIndex(0, 1, 100, func(int64) bool {
+		count++
+		return count < 5
+	})
+	require.Equal(t, 5, count, "returning false must stop the walk")
 }
 
 // TestTxWorkersShardComposition confirms multi-worker striping composes with
@@ -40,10 +53,11 @@ func TestTxWorkersShardComposition(t *testing.T) {
 	o := &Options{Shard: shard, ShardTotal: total}
 	seen := make([]int, rng)
 	for w := 0; w < workers; w++ {
-		forEachWorkerIndex(w, workers, rng, func(i int64) {
+		forEachWorkerIndex(w, workers, rng, func(i int64) bool {
 			if o.inShard(i) {
 				seen[i]++
 			}
+			return true
 		})
 	}
 	for i := int64(0); i < rng; i++ {

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -87,7 +87,9 @@ type Options struct {
 	// XMLOutput is an optional file path for nmap-compatible XML output ("-" for stdout)
 	XMLOutput string
 	// GrepOutput is an optional file path for nmap-compatible greppable output ("-" for stdout)
-	GrepOutput        string
+	GrepOutput string
+	// OutputAll is a base name that expands to <base>.json, <base>.xml and <base>.gnmap
+	OutputAll         string
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool
@@ -231,6 +233,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.CSV, "csv", false, "write output in csv format"),
 		flagSet.StringVarP(&options.XMLOutput, "xml-output", "oX", "", "write nmap-compatible XML output to file (- for stdout)"),
 		flagSet.StringVarP(&options.GrepOutput, "grep-output", "oG", "", "write nmap-compatible greppable output to file (- for stdout)"),
+		flagSet.StringVarP(&options.OutputAll, "output-all", "oA", "", "write json, xml and greppable output to <basename>.{json,xml,gnmap}"),
 	)
 
 	flagSet.CreateGroup("config", "Configuration",
@@ -382,6 +385,7 @@ func ParseOptions() *Options {
 			gologger.Fatal().Msgf("%s\n", err)
 		}
 	}
+	options.expandOutputAll()
 	options.configureOutput()
 	// Show the user the banner
 	showBanner()

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -167,12 +167,25 @@ type Options struct {
 	// that presets rate/retries/timeout/warm-up/threads. T3 is the default and
 	// matches naabu's historical behaviour.
 	TimingTemplate int
+
+	// Shard / ShardTotal split the scan space across distributed nodes
+	// (masscan-style "X/Y", 1-based): node Shard of ShardTotal scans only its
+	// slice of the (host, port) space. ShardTotal == 0 disables sharding.
+	Shard      int
+	ShardTotal int
+
+	// Seed fixes the blackrock shuffle seed for reproducible scans. It must be
+	// identical across nodes when sharding so the slices are disjoint and
+	// complete. 0 means a random per-run seed.
+	Seed int64
 }
 
 // ParseOptions parses the command line flags provided by a user
 func ParseOptions() *Options {
 	options := &Options{}
 	var cfgFile string
+	var shardArg string
+	var seedArg int
 
 	flagSet := goflags.NewFlagSet()
 	flagSet.SetDescription(`Naabu is a port scanning tool written in Go that allows you to enumerate open ports for hosts in a fast and reliable manner.`)
@@ -277,6 +290,8 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.Verify, "verify", false, "validate the ports again with TCP verification"),
 		flagSet.BoolVarP(&options.SmartScan, "smart-scan", "ss", false, "predictive port scanning using port correlation model (not compatible with stream mode)"),
 		flagSet.IntVarP(&options.PredictionThreshold, "prediction-threshold", "pt", 20, "minimum confidence for port predictions (0-100%)"),
+		flagSet.StringVar(&shardArg, "shard", "", "distributed scan slice as index/total, 1-based (e.g. 1/4)"),
+		flagSet.IntVar(&seedArg, "seed", 0, "seed for scan randomization, must match across shards (default random)"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",
@@ -386,6 +401,15 @@ func ParseOptions() *Options {
 			gologger.Error().Msgf("Could not get network interfaces: %s\n", err)
 		}
 		os.Exit(0)
+	}
+
+	options.Seed = int64(seedArg)
+	if shardArg != "" {
+		idx, total, err := parseShard(shardArg)
+		if err != nil {
+			gologger.Fatal().Msgf("Program exiting: %s\n", err)
+		}
+		options.Shard, options.ShardTotal = idx, total
 	}
 
 	// Apply the timing template before validation so the connect-scan rate

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -70,20 +70,20 @@ type Options struct {
 	// Deprecated: stats are automatically available through local endpoint
 	EnableProgressBar bool // Enable progress bar
 	// Deprecated: stats are automatically available through local endpoint (maybe used on cloud?)
-	StatsInterval     int                 // StatsInterval is the number of seconds to display stats after
-	ScanAllIPS        bool                // Scan all the ips
-	IPVersion         goflags.StringSlice // IP Version to use while resolving hostnames
-	ScanType          string              // Scan Type
-	ConnectPayload    string              // Payload to use with CONNECT scan types
-	Proxy             string              // Socks5 proxy
-	ProxyAuth         string              // Socks5 proxy authentication (username:password)
-	Resolvers         string              // Resolvers (comma separated or file)
-	baseResolvers     []string
-	DnsOrder          string          // DNS resolution order (p/l/lp/pl)
-	SystemResolver    bool            // Use system DNS resolver as fallback
-	OnResult          result.ResultFn // callback on final host result
-	OnReceive         result.ResultFn // callback on response receive
-	CSV               bool
+	StatsInterval  int                 // StatsInterval is the number of seconds to display stats after
+	ScanAllIPS     bool                // Scan all the ips
+	IPVersion      goflags.StringSlice // IP Version to use while resolving hostnames
+	ScanType       string              // Scan Type
+	ConnectPayload string              // Payload to use with CONNECT scan types
+	Proxy          string              // Socks5 proxy
+	ProxyAuth      string              // Socks5 proxy authentication (username:password)
+	Resolvers      string              // Resolvers (comma separated or file)
+	baseResolvers  []string
+	DnsOrder       string          // DNS resolution order (p/l/lp/pl)
+	SystemResolver bool            // Use system DNS resolver as fallback
+	OnResult       result.ResultFn // callback on final host result
+	OnReceive      result.ResultFn // callback on response receive
+	CSV            bool
 	// XMLOutput is an optional file path for nmap-compatible XML output ("-" for stdout)
 	XMLOutput string
 	// GrepOutput is an optional file path for nmap-compatible greppable output ("-" for stdout)
@@ -178,6 +178,11 @@ type Options struct {
 	// identical across nodes when sharding so the slices are disjoint and
 	// complete. 0 means a random per-run seed.
 	Seed int64
+
+	// TxWorkers is the number of parallel transmit goroutines (each with its
+	// own raw socket, batch buffer and rate slice) used by the fast SYN sender.
+	// >1 overcomes the single-core send ceiling. Default 1 (unchanged behaviour).
+	TxWorkers int
 }
 
 // ParseOptions parses the command line flags provided by a user
@@ -210,6 +215,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("rate-limit", "Rate-limit",
 		flagSet.IntVar(&options.Threads, "c", DefaultThreadsNum, "general internal worker threads"),
 		flagSet.IntVar(&options.Rate, "rate", DefaultRateSynScan, "packets to send per second"),
+		flagSet.IntVarP(&options.TxWorkers, "tx-workers", "tw", 1, "parallel transmit workers for the fast SYN sender"),
 	)
 
 	flagSet.CreateGroup("update", "Update",

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -84,6 +84,10 @@ type Options struct {
 	OnResult          result.ResultFn // callback on final host result
 	OnReceive         result.ResultFn // callback on response receive
 	CSV               bool
+	// XMLOutput is an optional file path for nmap-compatible XML output ("-" for stdout)
+	XMLOutput string
+	// GrepOutput is an optional file path for nmap-compatible greppable output ("-" for stdout)
+	GrepOutput        string
 	Resume            bool
 	ResumeCfg         *ResumeCfg
 	Stream            bool
@@ -206,6 +210,8 @@ func ParseOptions() *Options {
 		flagSet.StringSliceVarP(&options.ExcludeOutputFields, "exclude-output-fields", "eof", nil, "exclude output fields output based on a condition", goflags.NormalizedOriginalStringSliceOptions),
 		flagSet.BoolVarP(&options.JSON, "json", "j", false, "write output in JSON lines format"),
 		flagSet.BoolVar(&options.CSV, "csv", false, "write output in csv format"),
+		flagSet.StringVarP(&options.XMLOutput, "xml-output", "oX", "", "write nmap-compatible XML output to file (- for stdout)"),
+		flagSet.StringVarP(&options.GrepOutput, "grep-output", "oG", "", "write nmap-compatible greppable output to file (- for stdout)"),
 	)
 
 	flagSet.CreateGroup("config", "Configuration",

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -158,6 +158,11 @@ type Options struct {
 	// PredictionThreshold is the minimum confidence percentage (0–100) to
 	// act on a port prediction (default 20, meaning 20%).
 	PredictionThreshold int
+
+	// TimingTemplate is an nmap-style timing level (0 paranoid .. 5 insane)
+	// that presets rate/retries/timeout/warm-up/threads. T3 is the default and
+	// matches naabu's historical behaviour.
+	TimingTemplate int
 }
 
 // ParseOptions parses the command line flags provided by a user
@@ -260,7 +265,8 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("optimization", "Optimization",
 		flagSet.IntVar(&options.Retries, "retries", DefaultRetriesSynScan, "number of retries for the port scan"),
 		flagSet.DurationVar(&options.Timeout, "timeout", DefaultPortTimeoutSynScan, "millisecond to wait before timing out"),
-		flagSet.IntVar(&options.WarmUpTime, "warm-up-time", 2, "time in seconds between scan phases"),
+		flagSet.IntVar(&options.WarmUpTime, "warm-up-time", defaultWarmUpTime, "time in seconds between scan phases"),
+		flagSet.IntVarP(&options.TimingTemplate, "timing", "T", DefaultTimingTemplate, "timing template, higher is faster (0-5)"),
 		flagSet.BoolVar(&options.Ping, "ping", false, "ping probes for verification of host"),
 		flagSet.BoolVar(&options.Verify, "verify", false, "validate the ports again with TCP verification"),
 		flagSet.BoolVarP(&options.SmartScan, "smart-scan", "ss", false, "predictive port scanning using port correlation model (not compatible with stream mode)"),
@@ -375,6 +381,10 @@ func ParseOptions() *Options {
 		}
 		os.Exit(0)
 	}
+
+	// Apply the timing template before validation so the connect-scan rate
+	// adjustments in ValidateOptions see the resolved values.
+	options.applyTimingTemplate()
 
 	// Validate the options passed by the user and if any
 	// invalid options have been used, exit.

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -178,8 +179,10 @@ type Options struct {
 
 	// Seed fixes the blackrock shuffle seed for reproducible scans. It must be
 	// identical across nodes when sharding so the slices are disjoint and
-	// complete. 0 means a random per-run seed.
-	Seed int64
+	// complete. SeedSet distinguishes an explicit -seed (including 0) from an unset
+	// flag, so 0 is a usable reproducible seed rather than "random".
+	Seed    int64
+	SeedSet bool
 
 	// TxWorkers is the number of parallel transmit goroutines (each with its
 	// own raw socket, batch buffer and rate slice) used by the fast SYN sender.
@@ -423,8 +426,15 @@ func ParseOptions() *Options {
 	}
 
 	// Apply the timing template before validation so the connect-scan rate
-	// adjustments in ValidateOptions see the resolved values.
-	options.applyTimingTemplate()
+	// adjustments in ValidateOptions see the resolved values. Collect the flags the
+	// user actually set so the template only fills the ones left untouched, even
+	// when an explicit value coincides with the compile-time default.
+	setFlags := make(map[string]struct{})
+	flagSet.CommandLine.Visit(func(f *flag.Flag) { setFlags[f.Name] = struct{}{} })
+	options.applyTimingTemplate(setFlags)
+	if _, ok := setFlags["seed"]; ok {
+		options.SeedSet = true
+	}
 
 	// Validate the options passed by the user and if any
 	// invalid options have been used, exit.

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -162,6 +162,15 @@ type Options struct {
 	// SmartScan enables predictive port scanning: after the initial scan,
 	// a correlation model predicts additional likely-open ports per host.
 	SmartScan bool
+	// NoPortPriority disables tiered scan ordering, restoring a single uniform
+	// Blackrock permutation over the whole (host, port) space.
+	//
+	// Tiered ordering scans the nmap top-100, then the rest of the top-1000,
+	// then everything else, randomising within each tier. That keeps the most
+	// likely open ports early regardless of how wide the range is, which a single
+	// uniform permutation cannot do. Disable it to get a completely uniform probe
+	// distribution across the range.
+	NoPortPriority bool
 	// PredictionThreshold is the minimum confidence percentage (0–100) to
 	// act on a port prediction (default 20, meaning 20%).
 	PredictionThreshold int
@@ -302,6 +311,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.Verify, "verify", false, "validate the ports again with TCP verification"),
 		flagSet.BoolVarP(&options.SmartScan, "smart-scan", "ss", false, "predictive port scanning using port correlation model (not compatible with stream mode)"),
 		flagSet.IntVarP(&options.PredictionThreshold, "prediction-threshold", "pt", 20, "minimum confidence for port predictions (0-100%)"),
+		flagSet.BoolVarP(&options.NoPortPriority, "no-port-priority", "npp", false, "disable tiered port ordering (scan the whole range in one uniform random order)"),
 		flagSet.StringVar(&shardArg, "shard", "", "distributed scan slice as index/total, 1-based (e.g. 1/4)"),
 		flagSet.IntVar(&seedArg, "seed", 0, "seed for scan randomization, must match across shards (default random)"),
 	)

--- a/pkg/runner/output.go
+++ b/pkg/runner/output.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/naabu/v2/pkg/port"
@@ -144,12 +142,21 @@ var (
 	headers              = []string{}
 )
 
+func stringSliceContains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Result) CSVHeaders(excludedFields []string) ([]string, error) {
 	ty := reflect.TypeOf(*r)
 	for i := 0; i < ty.NumField(); i++ {
 		field := ty.Field(i)
 		csvTag := field.Tag.Get("csv")
-		if !slices.Contains(headers, csvTag) && !slices.Contains(excludedFields, csvTag) {
+		if !stringSliceContains(headers, csvTag) && !stringSliceContains(excludedFields, csvTag) {
 			headers = append(headers, csvTag)
 		}
 	}
@@ -170,7 +177,7 @@ func (r *Result) CSVFields(excludedFields []string) ([]string, error) {
 	for i := 0; i < vl.NumField(); i++ {
 		field := vl.Field(i)
 		csvTag := ty.Field(i).Tag.Get("csv")
-		if slices.Contains(headers, csvTag) {
+		if stringSliceContains(headers, csvTag) {
 			var fieldStr string
 			if ty.Field(i).Name == "CPEs" {
 				fieldStr = strings.Join(data.CPEs, ";")

--- a/pkg/runner/output_nmap.go
+++ b/pkg/runner/output_nmap.go
@@ -1,0 +1,339 @@
+package runner
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/naabu/v2/pkg/port"
+	"github.com/projectdiscovery/naabu/v2/pkg/result"
+	iputil "github.com/projectdiscovery/utils/ip"
+)
+
+// nmapHostData is the flattened per-host view used to render the nmap-compatible
+// XML and greppable outputs.
+type nmapHostData struct {
+	ip       string
+	hostname string
+	mac      string
+	macVnd   string
+	ports    []*port.Port
+}
+
+// --- XML schema (subset of nmap's DTD, enough for common consumers) ---
+
+type xmlRun struct {
+	XMLName          xml.Name    `xml:"nmaprun"`
+	Scanner          string      `xml:"scanner,attr"`
+	Args             string      `xml:"args,attr,omitempty"`
+	Start            int64       `xml:"start,attr"`
+	StartStr         string      `xml:"startstr,attr"`
+	Version          string      `xml:"version,attr"`
+	XMLOutputVersion string      `xml:"xmloutputversion,attr"`
+	ScanInfo         xmlScanInfo `xml:"scaninfo"`
+	Hosts            []xmlHost   `xml:"host"`
+	RunStats         xmlRunStats `xml:"runstats"`
+}
+
+type xmlScanInfo struct {
+	Type     string `xml:"type,attr"`
+	Protocol string `xml:"protocol,attr"`
+}
+
+type xmlHost struct {
+	Status    xmlStatus     `xml:"status"`
+	Addresses []xmlAddress  `xml:"address"`
+	Hostnames *xmlHostnames `xml:"hostnames,omitempty"`
+	Ports     *xmlPorts     `xml:"ports,omitempty"`
+}
+
+type xmlStatus struct {
+	State  string `xml:"state,attr"`
+	Reason string `xml:"reason,attr,omitempty"`
+}
+
+type xmlAddress struct {
+	Addr     string `xml:"addr,attr"`
+	AddrType string `xml:"addrtype,attr"`
+	Vendor   string `xml:"vendor,attr,omitempty"`
+}
+
+type xmlHostnames struct {
+	Hostnames []xmlHostname `xml:"hostname"`
+}
+
+type xmlHostname struct {
+	Name string `xml:"name,attr"`
+	Type string `xml:"type,attr"`
+}
+
+type xmlPorts struct {
+	Ports []xmlPort `xml:"port"`
+}
+
+type xmlPort struct {
+	Protocol string       `xml:"protocol,attr"`
+	PortID   int          `xml:"portid,attr"`
+	State    xmlPortState `xml:"state"`
+	Service  *xmlService  `xml:"service,omitempty"`
+}
+
+type xmlPortState struct {
+	State  string `xml:"state,attr"`
+	Reason string `xml:"reason,attr,omitempty"`
+}
+
+type xmlService struct {
+	Name      string   `xml:"name,attr,omitempty"`
+	Product   string   `xml:"product,attr,omitempty"`
+	Version   string   `xml:"version,attr,omitempty"`
+	ExtraInfo string   `xml:"extrainfo,attr,omitempty"`
+	Method    string   `xml:"method,attr,omitempty"`
+	Conf      int      `xml:"conf,attr,omitempty"`
+	CPEs      []string `xml:"cpe,omitempty"`
+}
+
+type xmlRunStats struct {
+	Finished xmlFinished  `xml:"finished"`
+	Hosts    xmlHostsStat `xml:"hosts"`
+}
+
+type xmlFinished struct {
+	Time    int64  `xml:"time,attr"`
+	TimeStr string `xml:"timestr,attr"`
+	Elapsed string `xml:"elapsed,attr"`
+	Exit    string `xml:"exit,attr"`
+}
+
+type xmlHostsStat struct {
+	Up    int `xml:"up,attr"`
+	Down  int `xml:"down,attr"`
+	Total int `xml:"total,attr"`
+}
+
+const nmapTimeLayout = "Mon Jan 2 15:04:05 2006"
+
+func addrType(ip string) string {
+	if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() == nil {
+		return "ipv6"
+	}
+	return "ipv4"
+}
+
+// scanInfoType maps naabu scan types to nmap scaninfo "type" values.
+func scanInfoType(scanType string) string {
+	if scanType == SynScan {
+		return "syn"
+	}
+	return "connect"
+}
+
+func newXMLService(svc *port.Service) *xmlService {
+	if svc == nil || svc.Name == "" {
+		return nil
+	}
+	return &xmlService{
+		Name:      svc.Name,
+		Product:   svc.Product,
+		Version:   svc.Version,
+		ExtraInfo: svc.ExtraInfo,
+		Method:    svc.Method,
+		Conf:      svc.Confidence,
+		CPEs:      svc.CPEs,
+	}
+}
+
+// writeNmapXML renders hosts as an nmap-compatible XML document.
+func writeNmapXML(w io.Writer, hosts []nmapHostData, scanType string, start, end time.Time) error {
+	run := xmlRun{
+		Scanner:          "naabu",
+		Start:            start.Unix(),
+		StartStr:         start.Format(nmapTimeLayout),
+		Version:          Version,
+		XMLOutputVersion: "1.05",
+		ScanInfo:         xmlScanInfo{Type: scanInfoType(scanType), Protocol: "tcp"},
+	}
+
+	for _, h := range hosts {
+		xh := xmlHost{
+			Status:    xmlStatus{State: "up", Reason: "syn-ack"},
+			Addresses: []xmlAddress{{Addr: h.ip, AddrType: addrType(h.ip)}},
+		}
+		if h.mac != "" {
+			xh.Addresses = append(xh.Addresses, xmlAddress{Addr: h.mac, AddrType: "mac", Vendor: h.macVnd})
+		}
+		if h.hostname != "" && h.hostname != h.ip {
+			xh.Hostnames = &xmlHostnames{Hostnames: []xmlHostname{{Name: h.hostname, Type: "user"}}}
+		}
+		if len(h.ports) > 0 {
+			xp := &xmlPorts{}
+			for _, p := range h.ports {
+				xp.Ports = append(xp.Ports, xmlPort{
+					Protocol: p.Protocol.String(),
+					PortID:   p.Port,
+					State:    xmlPortState{State: "open", Reason: "syn-ack"},
+					Service:  newXMLService(p.Service),
+				})
+			}
+			xh.Ports = xp
+		}
+		run.Hosts = append(run.Hosts, xh)
+	}
+
+	run.RunStats = xmlRunStats{
+		Finished: xmlFinished{
+			Time:    end.Unix(),
+			TimeStr: end.Format(nmapTimeLayout),
+			Elapsed: fmt.Sprintf("%.2f", end.Sub(start).Seconds()),
+			Exit:    "success",
+		},
+		Hosts: xmlHostsStat{Up: len(hosts), Down: 0, Total: len(hosts)},
+	}
+
+	if _, err := io.WriteString(w, xml.Header+"<!DOCTYPE nmaprun>\n"); err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(run); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\n")
+	return err
+}
+
+// grepSanitize strips the field separators greppable output relies on.
+func grepSanitize(s string) string {
+	return strings.NewReplacer("/", "|", ",", ";", "\n", " ", "\t", " ").Replace(s)
+}
+
+// writeGreppable renders hosts in nmap's greppable (-oG) format.
+func writeGreppable(w io.Writer, hosts []nmapHostData, start, end time.Time) error {
+	if _, err := fmt.Fprintf(w, "# Naabu %s scan initiated %s\n", Version, start.Format(nmapTimeLayout)); err != nil {
+		return err
+	}
+	for _, h := range hosts {
+		name := h.hostname
+		if name == "" {
+			name = h.ip
+		}
+		if len(h.ports) == 0 {
+			if _, err := fmt.Fprintf(w, "Host: %s (%s)\tStatus: Up\n", h.ip, name); err != nil {
+				return err
+			}
+			continue
+		}
+		var parts []string
+		for _, p := range h.ports {
+			svcName := ""
+			version := ""
+			if p.Service != nil {
+				svcName = grepSanitize(p.Service.Name)
+				version = grepSanitize(strings.TrimSpace(p.Service.Product + " " + p.Service.Version))
+			}
+			// portid/state/protocol/owner/service/rpc/version
+			parts = append(parts, fmt.Sprintf("%d/open/%s//%s//%s/", p.Port, p.Protocol.String(), svcName, version))
+		}
+		if _, err := fmt.Fprintf(w, "Host: %s (%s)\tPorts: %s\n", h.ip, name, strings.Join(parts, ", ")); err != nil {
+			return err
+		}
+	}
+	upHosts := len(hosts)
+	if _, err := fmt.Fprintf(w, "# Naabu done at %s -- %d IP addresses (%d hosts up) scanned\n",
+		end.Format(nmapTimeLayout), upHosts, upHosts); err != nil {
+		return err
+	}
+	return nil
+}
+
+// collectNmapHosts flattens the scan result set into the per-host view used by
+// the nmap-compatible writers, resolving hostnames the same way handleOutput does.
+func (r *Runner) collectNmapHosts(scanResults *result.Result) []nmapHostData {
+	var hosts []nmapHostData
+	switch {
+	case scanResults.HasIPsPorts():
+		for hostResult := range scanResults.GetIPsPorts() {
+			if !ipMatchesIpVersions(hostResult.IP, r.options.IPVersion...) {
+				continue
+			}
+			hosts = append(hosts, nmapHostData{
+				ip:       hostResult.IP,
+				hostname: r.primaryHostname(hostResult.IP),
+				mac:      hostResult.MacAddress,
+				macVnd:   vendorFromMAC(hostResult.MacAddress),
+				ports:    hostResult.Ports,
+			})
+		}
+	case scanResults.HasIPS():
+		for hostIP := range scanResults.GetIPs() {
+			if !ipMatchesIpVersions(hostIP, r.options.IPVersion...) {
+				continue
+			}
+			hosts = append(hosts, nmapHostData{
+				ip:       hostIP,
+				hostname: r.primaryHostname(hostIP),
+			})
+		}
+	}
+	return hosts
+}
+
+// primaryHostname returns the first non-IP hostname recorded for an IP, or "".
+func (r *Runner) primaryHostname(ip string) string {
+	dt, err := r.hostsForIP(ip)
+	if err != nil {
+		return ""
+	}
+	for _, h := range dt {
+		if h != "" && h != "ip" && !iputil.IsIP(h) {
+			return h
+		}
+	}
+	return ""
+}
+
+// writeNmapFormats emits the nmap-compatible XML and greppable outputs when the
+// corresponding -oX / -oG flags are set.
+func (r *Runner) writeNmapFormats(scanResults *result.Result) {
+	if r.options.XMLOutput == "" && r.options.GrepOutput == "" {
+		return
+	}
+	if r.scanStartTime.IsZero() {
+		r.scanStartTime = time.Now()
+	}
+	hosts := r.collectNmapHosts(scanResults)
+
+	if r.options.XMLOutput != "" {
+		r.emitNmapFile(r.options.XMLOutput, func(w io.Writer) error {
+			return writeNmapXML(w, hosts, r.options.ScanType, r.scanStartTime, time.Now())
+		})
+	}
+	if r.options.GrepOutput != "" {
+		r.emitNmapFile(r.options.GrepOutput, func(w io.Writer) error {
+			return writeGreppable(w, hosts, r.scanStartTime, time.Now())
+		})
+	}
+}
+
+func (r *Runner) emitNmapFile(path string, write func(io.Writer) error) {
+	if path == "-" {
+		if err := write(os.Stdout); err != nil {
+			gologger.Error().Msgf("could not write nmap output: %s\n", err)
+		}
+		return
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		gologger.Error().Msgf("could not create output file %s: %s\n", path, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	if err := write(f); err != nil {
+		gologger.Error().Msgf("could not write output file %s: %s\n", path, err)
+	}
+}

--- a/pkg/runner/output_nmap.go
+++ b/pkg/runner/output_nmap.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -326,6 +327,12 @@ func (r *Runner) emitNmapFile(path string, write func(io.Writer) error) {
 			gologger.Error().Msgf("could not write nmap output: %s\n", err)
 		}
 		return
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			gologger.Error().Msgf("could not create output dir %s: %s\n", dir, err)
+			return
+		}
 	}
 	f, err := os.Create(path)
 	if err != nil {

--- a/pkg/runner/output_nmap.go
+++ b/pkg/runner/output_nmap.go
@@ -1,12 +1,14 @@
 package runner
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -283,7 +285,7 @@ func (r *Runner) collectNmapHosts(scanResults *result.Result) []nmapHostData {
 				hostname: r.primaryHostname(hostResult.IP),
 				mac:      hostResult.MacAddress,
 				macVnd:   vendorFromMAC(hostResult.MacAddress),
-				ports:    hostResult.Ports,
+				ports:    sortedPorts(hostResult.Ports),
 			})
 		}
 	case scanResults.HasIPS():
@@ -297,7 +299,39 @@ func (r *Runner) collectNmapHosts(scanResults *result.Result) []nmapHostData {
 			})
 		}
 	}
+	// The result store is map-backed, so host and port order is otherwise random
+	// per run; sort for reproducible output (and to match nmap's ordering).
+	sort.Slice(hosts, func(i, j int) bool {
+		return compareIPStrings(hosts[i].ip, hosts[j].ip) < 0
+	})
 	return hosts
+}
+
+// sortedPorts returns a copy of ports ordered by (port, protocol) so the output
+// is deterministic without mutating the shared result store.
+func sortedPorts(ports []*port.Port) []*port.Port {
+	if len(ports) == 0 {
+		return ports
+	}
+	out := make([]*port.Port, len(ports))
+	copy(out, ports)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Port != out[j].Port {
+			return out[i].Port < out[j].Port
+		}
+		return out[i].Protocol.String() < out[j].Protocol.String()
+	})
+	return out
+}
+
+// compareIPStrings orders two IP strings numerically (by parsed bytes) so 9 < 10
+// and IPv4 sorts before IPv6; unparseable values fall back to lexical order.
+func compareIPStrings(a, b string) int {
+	ia, ib := net.ParseIP(a), net.ParseIP(b)
+	if ia == nil || ib == nil {
+		return strings.Compare(a, b)
+	}
+	return bytes.Compare(ia.To16(), ib.To16())
 }
 
 // primaryHostname returns the first non-IP hostname recorded for an IP, or "".

--- a/pkg/runner/output_nmap.go
+++ b/pkg/runner/output_nmap.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/naabu/v2/pkg/port"
+	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
 	"github.com/projectdiscovery/naabu/v2/pkg/result"
 	iputil "github.com/projectdiscovery/utils/ip"
 )
@@ -181,10 +182,16 @@ func writeNmapXML(w io.Writer, hosts []nmapHostData, scanType string, start, end
 		if len(h.ports) > 0 {
 			xp := &xmlPorts{}
 			for _, p := range h.ports {
+				// nmap reports the probe that elicited the reply; a UDP open port
+				// is confirmed by a udp-response, not a syn-ack.
+				reason := "syn-ack"
+				if p.Protocol == protocol.UDP {
+					reason = "udp-response"
+				}
 				xp.Ports = append(xp.Ports, xmlPort{
 					Protocol: p.Protocol.String(),
 					PortID:   p.Port,
-					State:    xmlPortState{State: "open", Reason: "syn-ack"},
+					State:    xmlPortState{State: "open", Reason: reason},
 					Service:  newXMLService(p.Service),
 				})
 			}

--- a/pkg/runner/output_nmap.go
+++ b/pkg/runner/output_nmap.go
@@ -161,8 +161,15 @@ func writeNmapXML(w io.Writer, hosts []nmapHostData, scanType string, start, end
 	}
 
 	for _, h := range hosts {
+		// A host with open ports genuinely produced a syn-ack; a host from
+		// discovery-only (no ports) has no probe-based reason, so report it the way
+		// nmap marks assumed-up hosts rather than fabricating syn-ack.
+		hostReason := "user-set"
+		if len(h.ports) > 0 {
+			hostReason = "syn-ack"
+		}
 		xh := xmlHost{
-			Status:    xmlStatus{State: "up", Reason: "syn-ack"},
+			Status:    xmlStatus{State: "up", Reason: hostReason},
 			Addresses: []xmlAddress{{Addr: h.ip, AddrType: addrType(h.ip)}},
 		}
 		if h.mac != "" {
@@ -219,7 +226,9 @@ func writeGreppable(w io.Writer, hosts []nmapHostData, start, end time.Time) err
 		return err
 	}
 	for _, h := range hosts {
-		name := h.hostname
+		// Sanitize the hostname: greppable output is line-oriented, and a PTR record
+		// carrying an embedded newline/tab would otherwise inject spurious lines.
+		name := grepSanitize(h.hostname)
 		if name == "" {
 			name = h.ip
 		}

--- a/pkg/runner/output_nmap_test.go
+++ b/pkg/runner/output_nmap_test.go
@@ -3,12 +3,15 @@ package runner
 import (
 	"bytes"
 	"encoding/xml"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/port"
 	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
+	"github.com/projectdiscovery/naabu/v2/pkg/result"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,4 +83,89 @@ func TestGrepSanitizeStripsSeparators(t *testing.T) {
 func TestAddrType(t *testing.T) {
 	require.Equal(t, "ipv4", addrType("1.2.3.4"))
 	require.Equal(t, "ipv6", addrType("2606:2800:220:1:248:1893:25c8:1946"))
+}
+
+func newConnectRunner(t *testing.T) *Runner {
+	t.Helper()
+	options := &Options{
+		Host:      []string{"192.168.1.0/24"},
+		Ports:     "80",
+		ScanType:  ConnectScan,
+		IPVersion: []string{"4"},
+	}
+	runner, err := NewRunner(options)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = runner.Close() })
+	require.NoError(t, runner.Load())
+	return runner
+}
+
+func TestCollectNmapHostsPortsBranch(t *testing.T) {
+	runner := newConnectRunner(t)
+
+	res := result.NewResult()
+	res.AddPort("203.0.113.7", &port.Port{Port: 80, Protocol: protocol.TCP})
+	res.AddPort("203.0.113.7", &port.Port{Port: 443, Protocol: protocol.TCP})
+	// out-of-version host must be filtered (IPVersion is 4 only).
+	res.AddPort("2606:2800:220:1::1", &port.Port{Port: 80, Protocol: protocol.TCP})
+
+	hosts := runner.collectNmapHosts(res)
+	require.Len(t, hosts, 1, "ipv6 host must be filtered out")
+	require.Equal(t, "203.0.113.7", hosts[0].ip)
+	require.Empty(t, hosts[0].hostname, "pure IP scan resolves no hostname")
+	require.Len(t, hosts[0].ports, 2)
+}
+
+func TestCollectNmapHostsIPsOnlyBranch(t *testing.T) {
+	runner := newConnectRunner(t)
+
+	res := result.NewResult()
+	res.AddIp("203.0.113.9")
+
+	hosts := runner.collectNmapHosts(res)
+	require.Len(t, hosts, 1)
+	require.Equal(t, "203.0.113.9", hosts[0].ip)
+	require.Empty(t, hosts[0].ports)
+}
+
+func TestPrimaryHostname(t *testing.T) {
+	runner := newConnectRunner(t)
+	// pure IP scan: no hostname store consulted.
+	require.Empty(t, runner.primaryHostname("203.0.113.7"))
+
+	runner.hasHostnames.Store(true)
+	require.NoError(t, runner.scanner.IPRanger.AddHostWithMetadata("203.0.113.7", "example.com"))
+	require.Equal(t, "example.com", runner.primaryHostname("203.0.113.7"))
+}
+
+func TestWriteNmapFormatsToFiles(t *testing.T) {
+	runner := newConnectRunner(t)
+	dir := t.TempDir()
+	runner.options.XMLOutput = filepath.Join(dir, "out.xml")
+	runner.options.GrepOutput = filepath.Join(dir, "out.grep")
+
+	res := result.NewResult()
+	res.AddPort("203.0.113.7", &port.Port{Port: 80, Protocol: protocol.TCP})
+
+	runner.writeNmapFormats(res)
+
+	xmlData, err := os.ReadFile(runner.options.XMLOutput)
+	require.NoError(t, err)
+	require.Contains(t, string(xmlData), `scanner="naabu"`)
+	require.Contains(t, string(xmlData), `portid="80"`)
+	var run xmlRun
+	require.NoError(t, xml.Unmarshal(xmlData, &run), "written XML must be well-formed")
+
+	grepData, err := os.ReadFile(runner.options.GrepOutput)
+	require.NoError(t, err)
+	require.Contains(t, string(grepData), "Host: 203.0.113.7")
+	require.Contains(t, string(grepData), "80/open/tcp")
+}
+
+func TestWriteNmapFormatsNoOpWhenUnset(t *testing.T) {
+	runner := newConnectRunner(t)
+	res := result.NewResult()
+	res.AddPort("203.0.113.7", &port.Port{Port: 80, Protocol: protocol.TCP})
+	// XMLOutput and GrepOutput are empty: must not panic or create files.
+	require.NotPanics(t, func() { runner.writeNmapFormats(res) })
 }

--- a/pkg/runner/output_nmap_test.go
+++ b/pkg/runner/output_nmap_test.go
@@ -162,6 +162,33 @@ func TestWriteNmapFormatsToFiles(t *testing.T) {
 	require.Contains(t, string(grepData), "80/open/tcp")
 }
 
+func TestExpandOutputAll(t *testing.T) {
+	opts := &Options{OutputAll: "scan"}
+	opts.expandOutputAll()
+	require.Equal(t, "scan.json", opts.Output)
+	require.True(t, opts.JSON)
+	require.Equal(t, "scan.xml", opts.XMLOutput)
+	require.Equal(t, "scan.gnmap", opts.GrepOutput)
+}
+
+func TestExpandOutputAllRespectsExplicit(t *testing.T) {
+	opts := &Options{OutputAll: "scan", Output: "custom.txt", XMLOutput: "custom.xml"}
+	opts.expandOutputAll()
+	// explicit -o/-oX win, only the unset -oG is derived
+	require.Equal(t, "custom.txt", opts.Output)
+	require.False(t, opts.JSON)
+	require.Equal(t, "custom.xml", opts.XMLOutput)
+	require.Equal(t, "scan.gnmap", opts.GrepOutput)
+}
+
+func TestExpandOutputAllEmpty(t *testing.T) {
+	opts := &Options{}
+	opts.expandOutputAll()
+	require.Empty(t, opts.Output)
+	require.Empty(t, opts.XMLOutput)
+	require.Empty(t, opts.GrepOutput)
+}
+
 func TestHandleOutputCreatesNestedDir(t *testing.T) {
 	runner := newConnectRunner(t)
 	dir := t.TempDir()

--- a/pkg/runner/output_nmap_test.go
+++ b/pkg/runner/output_nmap_test.go
@@ -1,0 +1,83 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/naabu/v2/pkg/port"
+	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleHosts() []nmapHostData {
+	return []nmapHostData{
+		{
+			ip:       "93.184.216.34",
+			hostname: "example.com",
+			ports: []*port.Port{
+				{Port: 80, Protocol: protocol.TCP},
+				{Port: 443, Protocol: protocol.TCP, Service: &port.Service{Name: "https", Product: "nginx", Version: "1.25"}},
+			},
+		},
+		{ip: "10.0.0.1"}, // alive host, no ports (discovery)
+	}
+}
+
+func TestWriteNmapXMLIsValidAndComplete(t *testing.T) {
+	var buf bytes.Buffer
+	start := time.Unix(1_700_000_000, 0)
+	end := start.Add(2 * time.Second)
+	require.NoError(t, writeNmapXML(&buf, sampleHosts(), SynScan, start, end))
+
+	out := buf.String()
+	require.True(t, strings.HasPrefix(out, xml.Header), "must start with xml header")
+	require.Contains(t, out, "<!DOCTYPE nmaprun>")
+
+	// Round-trips back into the schema.
+	var run xmlRun
+	require.NoError(t, xml.Unmarshal([]byte(out), &run))
+	require.Equal(t, "naabu", run.Scanner)
+	require.Equal(t, "syn", run.ScanInfo.Type)
+	require.Len(t, run.Hosts, 2)
+	require.Equal(t, 2, run.RunStats.Hosts.Up)
+
+	// First host: hostname + two ports, second port has service.
+	h0 := run.Hosts[0]
+	require.Equal(t, "93.184.216.34", h0.Addresses[0].Addr)
+	require.Equal(t, "ipv4", h0.Addresses[0].AddrType)
+	require.NotNil(t, h0.Hostnames)
+	require.Equal(t, "example.com", h0.Hostnames.Hostnames[0].Name)
+	require.NotNil(t, h0.Ports)
+	require.Len(t, h0.Ports.Ports, 2)
+	require.Equal(t, "open", h0.Ports.Ports[0].State.State)
+	require.NotNil(t, h0.Ports.Ports[1].Service)
+	require.Equal(t, "https", h0.Ports.Ports[1].Service.Name)
+
+	// Second host: no ports element.
+	require.Nil(t, run.Hosts[1].Ports)
+}
+
+func TestWriteGreppable(t *testing.T) {
+	var buf bytes.Buffer
+	start := time.Unix(1_700_000_000, 0)
+	require.NoError(t, writeGreppable(&buf, sampleHosts(), start, start.Add(time.Second)))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.True(t, strings.HasPrefix(lines[0], "# Naabu"))
+	require.Contains(t, buf.String(), "Host: 93.184.216.34 (example.com)\tPorts: 80/open/tcp//", "ports line must be present")
+	require.Contains(t, buf.String(), "443/open/tcp//https//nginx 1.25/")
+	require.Contains(t, buf.String(), "Host: 10.0.0.1 (10.0.0.1)\tStatus: Up")
+	require.True(t, strings.HasPrefix(lines[len(lines)-1], "# Naabu done"))
+}
+
+func TestGrepSanitizeStripsSeparators(t *testing.T) {
+	require.Equal(t, "a|b;c d", grepSanitize("a/b,c\td"))
+}
+
+func TestAddrType(t *testing.T) {
+	require.Equal(t, "ipv4", addrType("1.2.3.4"))
+	require.Equal(t, "ipv6", addrType("2606:2800:220:1:248:1893:25c8:1946"))
+}

--- a/pkg/runner/output_nmap_test.go
+++ b/pkg/runner/output_nmap_test.go
@@ -162,6 +162,21 @@ func TestWriteNmapFormatsToFiles(t *testing.T) {
 	require.Contains(t, string(grepData), "80/open/tcp")
 }
 
+func TestHandleOutputCreatesNestedDir(t *testing.T) {
+	runner := newConnectRunner(t)
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b", "c", "out.txt")
+	runner.options.Output = nested
+	runner.options.DisableStdout = true
+
+	res := result.NewResult()
+	res.AddPort("203.0.113.7", &port.Port{Port: 80, Protocol: protocol.TCP})
+	runner.handleOutput(res)
+
+	_, err := os.Stat(nested)
+	require.NoError(t, err, "output to a non-existent nested path must create the directory")
+}
+
 func TestWriteNmapFormatsNoOpWhenUnset(t *testing.T) {
 	runner := newConnectRunner(t)
 	res := result.NewResult()

--- a/pkg/runner/pacer.go
+++ b/pkg/runner/pacer.go
@@ -1,0 +1,63 @@
+package runner
+
+import "time"
+
+// pacer is a low-overhead, single-goroutine rate limiter for the hot SYN send
+// path. The shared ratelimit.Limiter delivers one token per packet over a
+// channel served by a background goroutine, so every packet pays a goroutine
+// handoff and the budget is released in a burst on each interval tick. On the
+// fast sender that channel round-trip dominates once the rate climbs past a few
+// tens of thousands of packets per second.
+//
+// pacer instead hands out a local integer budget: the per-packet cost is a
+// single decrement, and the clock is consulted (and the goroutine possibly
+// parked) only once per window. Windows are ~10ms so bursts stay within ~1% of
+// the configured rate while keeping syscalls/sleeps rare.
+//
+// Not safe for concurrent use; it is owned by the single goroutine driving the
+// fast sender.
+type pacer struct {
+	rate   int64
+	batch  int64
+	window time.Duration
+	budget int64
+	next   time.Time
+}
+
+// newPacer returns a pacer limited to rate packets per second. A rate <= 0
+// produces an unlimited pacer whose wait is a no-op.
+func newPacer(rate int) *pacer {
+	if rate <= 0 {
+		return &pacer{}
+	}
+	// ~100 windows per second: batch*window == 1s/rate, so the average rate is
+	// exact regardless of the integer division below.
+	batch := int64(rate) / 100
+	if batch < 1 {
+		batch = 1
+	}
+	window := time.Duration(float64(batch) / float64(rate) * float64(time.Second))
+	return &pacer{rate: int64(rate), batch: batch, window: window}
+}
+
+// wait blocks as needed to keep the average send rate at or below the
+// configured packets per second.
+func (p *pacer) wait() {
+	if p.rate <= 0 {
+		return
+	}
+	if p.budget > 0 {
+		p.budget--
+		return
+	}
+	now := time.Now()
+	if p.next.IsZero() {
+		p.next = now
+	}
+	if now.Before(p.next) {
+		time.Sleep(p.next.Sub(now))
+		now = p.next
+	}
+	p.next = now.Add(p.window)
+	p.budget = p.batch - 1
+}

--- a/pkg/runner/pacer.go
+++ b/pkg/runner/pacer.go
@@ -1,6 +1,10 @@
 package runner
 
-import "time"
+import (
+	"errors"
+	"syscall"
+	"time"
+)
 
 // pacer is a low-overhead, single-goroutine rate limiter for the hot SYN send
 // path. The shared ratelimit.Limiter delivers one token per packet over a
@@ -14,15 +18,28 @@ import "time"
 // parked) only once per window. Windows are ~10ms so bursts stay within ~1% of
 // the configured rate while keeping syscalls/sleeps rare.
 //
+// pacer is also loss-aware. When the send path reports kernel TX-buffer
+// exhaustion (ENOBUFS/EAGAIN) the caller invokes onCongestion, which multiplicatively
+// halves the effective rate so we stop overflowing the qdisc and dropping probes
+// at the source. The rate then recovers additively back toward the configured
+// ceiling, an AIMD loop similar to masscan/zmap rate adaptation.
+//
 // Not safe for concurrent use; it is owned by the single goroutine driving the
 // fast sender.
 type pacer struct {
-	rate   int64
-	batch  int64
-	window time.Duration
-	budget int64
-	next   time.Time
+	maxRate    int64
+	minRate    int64
+	rate       int64
+	batch      int64
+	window     time.Duration
+	budget     int64
+	next       time.Time
+	lastAdjust time.Time
 }
+
+// pacerRecoverEvery is how long the pacer waits between additive-increase steps
+// while climbing back toward the configured rate after a backoff.
+const pacerRecoverEvery = 250 * time.Millisecond
 
 // newPacer returns a pacer limited to rate packets per second. A rate <= 0
 // produces an unlimited pacer whose wait is a no-op.
@@ -30,20 +47,37 @@ func newPacer(rate int) *pacer {
 	if rate <= 0 {
 		return &pacer{}
 	}
-	// ~100 windows per second: batch*window == 1s/rate, so the average rate is
-	// exact regardless of the integer division below.
-	batch := int64(rate) / 100
-	if batch < 1 {
-		batch = 1
+	p := &pacer{maxRate: int64(rate)}
+	p.minRate = p.maxRate / 100
+	if p.minRate < 1 {
+		p.minRate = 1
 	}
-	window := time.Duration(float64(batch) / float64(rate) * float64(time.Second))
-	return &pacer{rate: int64(rate), batch: batch, window: window}
+	p.setRate(p.maxRate)
+	return p
 }
 
-// wait blocks as needed to keep the average send rate at or below the
-// configured packets per second.
+// setRate recomputes the window/batch for a new effective rate and resets the
+// in-window budget so the next wait re-paces against the new schedule.
+func (p *pacer) setRate(rate int64) {
+	if rate < 1 {
+		rate = 1
+	}
+	p.rate = rate
+	// ~100 windows per second: batch*window == 1s/rate, so the average rate is
+	// exact regardless of the integer division below.
+	p.batch = rate / 100
+	if p.batch < 1 {
+		p.batch = 1
+	}
+	p.window = time.Duration(float64(p.batch) / float64(rate) * float64(time.Second))
+	p.budget = 0
+}
+
+// wait blocks as needed to keep the average send rate at or below the current
+// effective packets per second, nudging the rate back up toward the configured
+// ceiling once a recovery interval has elapsed since the last backoff.
 func (p *pacer) wait() {
-	if p.rate <= 0 {
+	if p.maxRate <= 0 {
 		return
 	}
 	if p.budget > 0 {
@@ -58,6 +92,44 @@ func (p *pacer) wait() {
 		time.Sleep(p.next.Sub(now))
 		now = p.next
 	}
+	if p.rate < p.maxRate && now.Sub(p.lastAdjust) >= pacerRecoverEvery {
+		step := p.maxRate / 10
+		if step < 1 {
+			step = 1
+		}
+		nr := p.rate + step
+		if nr > p.maxRate {
+			nr = p.maxRate
+		}
+		p.lastAdjust = now
+		p.setRate(nr)
+	}
 	p.next = now.Add(p.window)
 	p.budget = p.batch - 1
+}
+
+// onCongestion halves the effective rate after the kernel signals a full TX
+// buffer. Backoffs are debounced to one per window so a burst of ENOBUFS from a
+// single overfull batch does not collapse the rate to the floor.
+func (p *pacer) onCongestion() {
+	if p.maxRate <= 0 {
+		return
+	}
+	now := time.Now()
+	if !p.lastAdjust.IsZero() && now.Sub(p.lastAdjust) < p.window {
+		return
+	}
+	nr := p.rate / 2
+	if nr < p.minRate {
+		nr = p.minRate
+	}
+	p.lastAdjust = now
+	p.setRate(nr)
+}
+
+// isCongestion reports whether a send error means the kernel TX buffer/qdisc is
+// full, i.e. we are sending faster than the host can drain and probes are being
+// dropped at the source.
+func isCongestion(err error) bool {
+	return errors.Is(err, syscall.ENOBUFS) || errors.Is(err, syscall.EAGAIN)
 }

--- a/pkg/runner/pacer_test.go
+++ b/pkg/runner/pacer_test.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPacerUnlimited ensures a non-positive rate never blocks.
+func TestPacerUnlimited(t *testing.T) {
+	p := newPacer(0)
+	start := time.Now()
+	for i := 0; i < 100000; i++ {
+		p.wait()
+	}
+	require.Less(t, time.Since(start), 50*time.Millisecond, "unlimited pacer must not block")
+}
+
+// TestPacerHonorsRate ensures the average send rate tracks the configured pps:
+// sending rate/2 packets at rate pps should take roughly half a second, and not
+// finish near-instantly (which would mean the limiter is a no-op).
+func TestPacerHonorsRate(t *testing.T) {
+	const rate = 2000
+	p := newPacer(rate)
+
+	start := time.Now()
+	for i := 0; i < rate/2; i++ {
+		p.wait()
+	}
+	elapsed := time.Since(start)
+
+	require.GreaterOrEqual(t, elapsed, 400*time.Millisecond, "pacer must throttle to near the configured rate")
+	require.Less(t, elapsed, 900*time.Millisecond, "pacer must not be drastically slower than the configured rate")
+}
+
+// TestPacerExactRateViaWindow verifies the average rate is preserved even when
+// rate/100 truncates (the window compensates).
+func TestPacerExactRateViaWindow(t *testing.T) {
+	p := newPacer(199)
+	require.EqualValues(t, 1, p.batch)
+	// window == batch/rate seconds, so batch/window == rate exactly
+	got := float64(p.batch) / p.window.Seconds()
+	require.InDelta(t, 199, got, 1.0, "effective rate must match configured rate")
+}

--- a/pkg/runner/pacer_test.go
+++ b/pkg/runner/pacer_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"syscall"
 	"testing"
 	"time"
 
@@ -42,4 +43,74 @@ func TestPacerExactRateViaWindow(t *testing.T) {
 	// window == batch/rate seconds, so batch/window == rate exactly
 	got := float64(p.batch) / p.window.Seconds()
 	require.InDelta(t, 199, got, 1.0, "effective rate must match configured rate")
+}
+
+// TestPacerCongestionHalvesRate ensures a congestion signal multiplicatively
+// reduces the effective rate down to but not below the floor.
+func TestPacerCongestionHalvesRate(t *testing.T) {
+	p := newPacer(100000)
+	require.EqualValues(t, 100000, p.rate)
+
+	// Each backoff must wait out a window; force the debounce open between calls.
+	for want := int64(50000); want >= p.minRate; want /= 2 {
+		p.lastAdjust = time.Time{}
+		p.onCongestion()
+		require.EqualValues(t, want, p.rate)
+		if want == p.minRate {
+			break
+		}
+	}
+
+	// Further backoffs clamp at the floor, never zero/negative.
+	p.lastAdjust = time.Time{}
+	p.onCongestion()
+	require.GreaterOrEqual(t, p.rate, p.minRate)
+	require.Equal(t, p.minRate, p.rate)
+}
+
+// TestPacerCongestionDebounced ensures a burst of congestion signals inside one
+// window only backs off once.
+func TestPacerCongestionDebounced(t *testing.T) {
+	p := newPacer(100000)
+	p.onCongestion()
+	first := p.rate
+	require.EqualValues(t, 50000, first)
+	// Immediate repeats within the same window are ignored.
+	p.onCongestion()
+	p.onCongestion()
+	require.EqualValues(t, first, p.rate)
+}
+
+// TestPacerRecoversToCeiling ensures the rate climbs back to the configured
+// ceiling after backoff once recovery intervals elapse.
+func TestPacerRecoversToCeiling(t *testing.T) {
+	p := newPacer(10000)
+	p.setRate(1000)
+	require.EqualValues(t, 1000, p.rate)
+
+	// Drive many windows; each wait that crosses a recovery interval nudges the
+	// rate up by maxRate/10. Backdate lastAdjust so recovery is eligible.
+	for i := 0; i < 100 && p.rate < p.maxRate; i++ {
+		p.lastAdjust = time.Now().Add(-pacerRecoverEvery)
+		p.budget = 0
+		p.next = time.Time{}
+		p.wait()
+	}
+	require.EqualValues(t, p.maxRate, p.rate, "rate must recover to the configured ceiling")
+}
+
+// TestPacerCongestionNoopUnlimited ensures congestion handling is inert for an
+// unlimited pacer.
+func TestPacerCongestionNoopUnlimited(t *testing.T) {
+	p := newPacer(0)
+	p.onCongestion()
+	require.EqualValues(t, 0, p.rate)
+	p.wait() // must remain a no-op
+}
+
+func TestIsCongestion(t *testing.T) {
+	require.True(t, isCongestion(syscall.ENOBUFS))
+	require.True(t, isCongestion(syscall.EAGAIN))
+	require.False(t, isCongestion(syscall.ECONNREFUSED))
+	require.False(t, isCongestion(nil))
 }

--- a/pkg/runner/porttiers.go
+++ b/pkg/runner/porttiers.go
@@ -1,0 +1,101 @@
+package runner
+
+import (
+	"github.com/projectdiscovery/naabu/v2/pkg/port"
+)
+
+// Tiered scan ordering.
+//
+// The scan space is a permutation of (host, port) pairs produced by Blackrock.
+// A single permutation over the whole space is uniform by construction, so the
+// position of any given port scales with the size of the port range: scanning
+// 1-65535 pushes port 80 roughly 65x further into the scan than scanning
+// top-1000 does, even though it is the port most likely to be open.
+//
+// Splitting the space into priority tiers and permuting *within* each tier fixes
+// that without giving up what the permutation is for. Blackrock exists to spread
+// probes across hosts and ports rather than walking them in order, which keeps a
+// scan from hammering one host's sequential ports - the pattern rate limiters and
+// fail2ban-style blocking react to. Tiering preserves that: order inside a tier
+// is still fully randomised, only the tier boundaries are ordered.
+//
+// Tiers are membership-based, which is why intra-tier order does not matter:
+//
+//	tier 0 - nmap top-100 ports
+//	tier 1 - nmap top-1000 ports not already in tier 0
+//	tier 2 - everything else
+//
+// A scan whose ports all land in one tier (top-100, top-1000, an explicit -p
+// list of common ports) produces a single tier covering the whole range, and the
+// identity ordering below makes that byte-for-byte identical to the untiered
+// behaviour.
+
+// portTiers groups indices into Runner.scanner.Ports by scan priority, most
+// likely to be open first. Each element is a list of port indices forming one
+// tier; tiers are scanned in order and permuted independently.
+type portTiers [][]int
+
+// totalTiers reports how many non-empty tiers the plan has.
+func (t portTiers) totalTiers() int { return len(t) }
+
+// buildPortTiers produces the tier plan for the given port list.
+//
+// When priority ordering is disabled, or when every port falls in the same tier,
+// the result is a single tier holding the identity permutation - which makes the
+// scan loop behave exactly as it did before tiering existed.
+func buildPortTiers(ports []*port.Port, prioritize bool) portTiers {
+	identity := func() portTiers {
+		all := make([]int, len(ports))
+		for i := range ports {
+			all[i] = i
+		}
+		return portTiers{all}
+	}
+
+	if !prioritize || len(ports) == 0 {
+		return identity()
+	}
+
+	top100 := portSet(NmapTop100)
+	top1000 := portSet(NmapTop1000)
+
+	const tierCount = 3
+	buckets := make([][]int, tierCount)
+	for idx, p := range ports {
+		if p == nil {
+			continue
+		}
+		tier := 2
+		if _, ok := top100[p.Port]; ok {
+			tier = 0
+		} else if _, ok := top1000[p.Port]; ok {
+			tier = 1
+		}
+		buckets[tier] = append(buckets[tier], idx)
+	}
+
+	tiers := make(portTiers, 0, tierCount)
+	for _, bucket := range buckets {
+		if len(bucket) > 0 {
+			tiers = append(tiers, bucket)
+		}
+	}
+
+	// Nothing to gain from tiering a range that lands entirely in one tier, and
+	// falling back to identity keeps the ordering bit-identical to the untiered
+	// path for the common top-100 / top-1000 presets.
+	if len(tiers) <= 1 {
+		return identity()
+	}
+	return tiers
+}
+
+// portSet expands a comma/range port list into a membership set.
+func portSet(list string) map[int]struct{} {
+	expanded := expandPortListOrdered(list)
+	set := make(map[int]struct{}, len(expanded))
+	for _, p := range expanded {
+		set[p] = struct{}{}
+	}
+	return set
+}

--- a/pkg/runner/porttiers_test.go
+++ b/pkg/runner/porttiers_test.go
@@ -1,0 +1,236 @@
+package runner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/projectdiscovery/blackrock"
+	"github.com/projectdiscovery/naabu/v2/pkg/port"
+	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func portsFrom(numbers []int) []*port.Port {
+	out := make([]*port.Port, 0, len(numbers))
+	for _, n := range numbers {
+		out = append(out, &port.Port{Port: n, Protocol: protocol.TCP})
+	}
+	return out
+}
+
+func fullRangePorts(t *testing.T) []*port.Port {
+	t.Helper()
+	numbers := make([]int, 0, 65535)
+	for p := 1; p <= 65535; p++ {
+		numbers = append(numbers, p)
+	}
+	return portsFrom(numbers)
+}
+
+// simulateTierOrder walks the tier plan exactly as the scan loop does and
+// returns, for each (ipIndex, portNumber) probe, the order in which it was
+// issued. It mirrors runner.go: one Blackrock permutation per tier over
+// hosts*tierPorts, with a contiguous global index across tiers.
+func simulateTierOrder(ports []*port.Port, tiers portTiers, hosts int64, seed int64) []struct {
+	IPIndex int64
+	Port    int
+} {
+	var out []struct {
+		IPIndex int64
+		Port    int
+	}
+	for _, tierPortIdx := range tiers {
+		tierPortsCount := int64(len(tierPortIdx))
+		if tierPortsCount == 0 {
+			continue
+		}
+		tierRange := hosts * tierPortsCount
+		b := blackrock.New(tierRange, seed)
+		for local := int64(0); local < tierRange; local++ {
+			xxx := b.Shuffle(local)
+			ipIndex := xxx / tierPortsCount
+			portIndex := tierPortIdx[int(xxx%tierPortsCount)]
+			out = append(out, struct {
+				IPIndex int64
+				Port    int
+			}{ipIndex, ports[portIndex].Port})
+		}
+	}
+	return out
+}
+
+func TestBuildPortTiersPlan(t *testing.T) {
+	t.Run("disabled yields a single identity tier", func(t *testing.T) {
+		ports := fullRangePorts(t)
+		tiers := buildPortTiers(ports, false)
+		require.Equal(t, 1, tiers.totalTiers())
+		require.Len(t, tiers[0], len(ports))
+		for i := range ports {
+			require.Equal(t, i, tiers[0][i], "must be the identity permutation")
+		}
+	})
+
+	t.Run("top-100 collapses to a single tier", func(t *testing.T) {
+		ports := portsFrom(expandPortListOrdered(NmapTop100))
+		tiers := buildPortTiers(ports, true)
+		require.Equal(t, 1, tiers.totalTiers(),
+			"a range entirely inside one tier must not be split, keeping ordering identical to before")
+	})
+
+	t.Run("top-1000 splits into two tiers", func(t *testing.T) {
+		ports := portsFrom(expandPortListOrdered(NmapTop1000))
+		tiers := buildPortTiers(ports, true)
+		require.Equal(t, 2, tiers.totalTiers())
+		require.Len(t, tiers[0], len(expandPortListOrdered(NmapTop100)))
+	})
+
+	t.Run("full range splits into three tiers", func(t *testing.T) {
+		ports := fullRangePorts(t)
+		tiers := buildPortTiers(ports, true)
+		require.Equal(t, 3, tiers.totalTiers())
+		require.Len(t, tiers[0], 100, "tier 0 is the nmap top-100")
+		require.Len(t, tiers[1], 900, "tier 1 is the remaining top-1000")
+		require.Len(t, tiers[2], 65535-1000)
+	})
+
+	t.Run("tiers partition the port list exactly", func(t *testing.T) {
+		for _, spec := range []struct {
+			name  string
+			ports []*port.Port
+		}{
+			{"full", fullRangePorts(t)},
+			{"top1000", portsFrom(expandPortListOrdered(NmapTop1000))},
+			{"sparse", portsFrom([]int{22, 80, 443, 9999, 40000, 65535})},
+		} {
+			t.Run(spec.name, func(t *testing.T) {
+				tiers := buildPortTiers(spec.ports, true)
+				seen := make(map[int]int, len(spec.ports))
+				for _, tier := range tiers {
+					for _, idx := range tier {
+						seen[idx]++
+					}
+				}
+				require.Len(t, seen, len(spec.ports), "every port index must appear")
+				for idx, n := range seen {
+					require.Equal(t, 1, n, "port index %d appears %d times", idx, n)
+				}
+			})
+		}
+	})
+}
+
+// The scan must still probe every (host, port) pair exactly once. A tiering bug
+// here would silently drop ports, which is the failure mode this whole change is
+// meant to avoid.
+func TestTieredOrderCoversEveryHostPortExactlyOnce(t *testing.T) {
+	ports := portsFrom(expandPortListOrdered(NmapTop1000))
+	const hosts = int64(3)
+	tiers := buildPortTiers(ports, true)
+	require.Greater(t, tiers.totalTiers(), 1, "need a multi-tier plan to be meaningful")
+
+	order := simulateTierOrder(ports, tiers, hosts, 42)
+	require.Len(t, order, len(ports)*int(hosts), "probe count must equal hosts*ports")
+
+	seen := make(map[[2]int64]int, len(order))
+	for _, probe := range order {
+		seen[[2]int64{probe.IPIndex, int64(probe.Port)}]++
+	}
+	require.Len(t, seen, len(ports)*int(hosts), "every (host, port) pair must be probed")
+	for key, n := range seen {
+		require.Equal(t, 1, n, "pair host=%d port=%d probed %d times", key[0], key[1], n)
+	}
+}
+
+// Sharding decides membership on the global index, so shards must remain
+// disjoint and jointly complete across tier boundaries.
+func TestTieredShardingStaysDisjointAndComplete(t *testing.T) {
+	ports := portsFrom(expandPortListOrdered(NmapTop1000))
+	const hosts = int64(2)
+	tiers := buildPortTiers(ports, true)
+
+	total := int64(len(ports)) * hosts
+	const shardTotal = 4
+
+	covered := make(map[int64]int, total)
+	for shard := 1; shard <= shardTotal; shard++ {
+		opts := &Options{Shard: shard, ShardTotal: shardTotal}
+		var indexBase int64
+		for _, tierPortIdx := range tiers {
+			tierRange := hosts * int64(len(tierPortIdx))
+			for local := int64(0); local < tierRange; local++ {
+				if opts.inShard(indexBase + local) {
+					covered[indexBase+local]++
+				}
+			}
+			indexBase += tierRange
+		}
+	}
+
+	require.Equal(t, int(total), len(covered), "shards must jointly cover the whole index space")
+	for idx, n := range covered {
+		require.Equal(t, 1, n, "global index %d claimed by %d shards", idx, n)
+	}
+}
+
+// The point of the change: a wide range must no longer postpone likely-open
+// ports.
+func TestTieringKeepsCommonPortsEarlyOnWideRanges(t *testing.T) {
+	ports := fullRangePorts(t)
+	const hosts = int64(2)
+	const seed = int64(12345)
+
+	firstProbeOf := func(tiers portTiers, target int) int {
+		order := simulateTierOrder(ports, tiers, hosts, seed)
+		for i, probe := range order {
+			if probe.Port == target {
+				return i
+			}
+		}
+		return -1
+	}
+
+	untiered := buildPortTiers(ports, false)
+	tiered := buildPortTiers(ports, true)
+
+	total := len(ports) * int(hosts)
+	for _, target := range []int{80, 443, 22, 3389} {
+		before := firstProbeOf(untiered, target)
+		after := firstProbeOf(tiered, target)
+		require.Positive(t, before)
+		require.Positive(t, after)
+
+		// tier 0 is 100 ports * hosts probes, so anything in it must land inside
+		// that prefix rather than somewhere in the full 131k-probe space.
+		require.Less(t, after, 100*int(hosts),
+			"port %d should be probed within the first tier", target)
+		require.Less(t, after, before,
+			"port %d should be reached earlier when tiered (was %d, now %d)", target, before, after)
+
+		fmt.Printf("  port %-5d untiered=#%-7d tiered=#%-5d (%.0fx earlier, of %d probes)\n",
+			target, before, after, float64(before)/float64(max(after, 1)), total)
+	}
+}
+
+// Randomisation within a tier is what keeps the scan from walking a host's ports
+// in order, so it must survive tiering.
+func TestTierInternalOrderStaysRandomised(t *testing.T) {
+	ports := portsFrom(expandPortListOrdered(NmapTop1000))
+	tiers := buildPortTiers(ports, true)
+	order := simulateTierOrder(ports, tiers, 2, 7)
+
+	// Within the first tier, consecutive probes should not be ascending ports on
+	// the same host; an ordered walk would show a long ascending run.
+	ascending := 0
+	longest := 0
+	for i := 1; i < len(order) && i < 200; i++ {
+		if order[i].IPIndex == order[i-1].IPIndex && order[i].Port > order[i-1].Port {
+			ascending++
+			if ascending > longest {
+				longest = ascending
+			}
+		} else {
+			ascending = 0
+		}
+	}
+	require.Less(t, longest, 10, "probes within a tier must not walk ports in order")
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -623,6 +623,21 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 			// user's port list, reordered by the correlation model.
 			r.runPredictiveScan(ctx, targets, targetsWithPort, shouldUseRawPackets)
 		} else {
+			// Fast SYN sender: bypasses gopacket serialization, per-packet route
+			// lookups and the single-writer channel. Falls back to the standard
+			// path for connect scans, IPv6 targets and ethernet framing.
+			var synSender *SYNSender
+			var tgtIdx *targetIndex
+			if shouldUseRawPackets {
+				tgtIdx = buildTargetIndex(targets)
+				if s, err := newSYNSender(r.scanner.ListenHandler); err != nil {
+					gologger.Debug().Msgf("fast SYN sender unavailable (%s), using standard path\n", err)
+				} else {
+					synSender = s
+					gologger.Info().Msgf("fast SYN sender active (direct raw socket)")
+				}
+			}
+
 			Range := targetsCount * portsCount
 			if r.options.EnableProgressBar {
 				r.stats.AddStatic("ports", portsCount)
@@ -664,7 +679,20 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					xxx := b.Shuffle(index)
 					ipIndex := xxx / int64(portsCount)
 					portIndex := int(xxx % int64(portsCount))
-					ip := r.PickIP(targets, ipIndex)
+
+					// fast IPv4 generation (uint32 math) when the fast sender is
+					// active; otherwise fall back to the big.Int-based PickIP.
+					var (
+						dstIP4 [4]byte
+						isV4   bool
+						ip     string
+					)
+					if synSender != nil {
+						dstIP4, ip, isV4 = tgtIdx.pickIPv4(ipIndex)
+					}
+					if ip == "" {
+						ip = r.PickIP(targets, ipIndex)
+					}
 
 					if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
 						continue
@@ -695,9 +723,21 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 						continue
 					}
 
-					// connect scan
 					if shouldUseRawPackets {
-						r.RawSocketEnumeration(ctx, ip, port)
+						if synSender != nil && isV4 && port.Protocol == protocol.TCP {
+							if r.scanner.ScanResults.IPHasPort(ip, port) {
+								continue
+							}
+							if !r.canIScanIfCDN(ip, port) {
+								continue
+							}
+							r.limiter.Take()
+							if err := synSender.send(dstIP4, uint16(port.Port)); err != nil {
+								gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
+							}
+						} else {
+							r.RawSocketEnumeration(ctx, ip, port)
+						}
 					} else {
 						r.wgscan.Add()
 						go r.handleHostPort(ctx, ip, payload, port)
@@ -736,6 +776,11 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					if r.options.EnableProgressBar {
 						r.stats.IncrementCounter("packets", 1)
 					}
+				}
+
+				// flush any SYN packets still queued in the batch sender
+				if synSender != nil {
+					_ = synSender.flush()
 				}
 
 				r.wgscan.Wait()

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -628,12 +628,14 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 			// path for connect scans, IPv6 targets and ethernet framing.
 			var synSender *SYNSender
 			var tgtIdx *targetIndex
+			var synPacer *pacer
 			if shouldUseRawPackets {
 				tgtIdx = buildTargetIndex(targets)
 				if s, err := newSYNSender(r.scanner.ListenHandler); err != nil {
 					gologger.Debug().Msgf("fast SYN sender unavailable (%s), using standard path\n", err)
 				} else {
 					synSender = s
+					synPacer = newPacer(r.options.Rate)
 					gologger.Info().Msgf("fast SYN sender active (direct raw socket)")
 				}
 			}
@@ -731,7 +733,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 							if !r.canIScanIfCDN(ip, port) {
 								continue
 							}
-							r.limiter.Take()
+							synPacer.wait()
 							if err := synSender.send(dstIP4, uint16(port.Port)); err != nil {
 								gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
 							}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -475,12 +475,24 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 		r.options.Rate = limits.RateLimitWithProxy(r.options.Rate)
 	}
 
-	// Scan workers
-	r.wgscan = sizedwaitgroup.New(r.options.Rate)
-	r.limiter = ratelimit.New(context.Background(), uint(r.options.Rate), time.Second)
-
 	shouldDiscoverHosts := r.options.shouldDiscoverHosts()
 	shouldUseRawPackets := r.options.shouldUseRawPackets()
+
+	// Scan workers
+	scanConcurrency := r.options.Rate
+	if !shouldUseRawPackets {
+		// Connect scan opens one socket per in-flight probe. Raise the open
+		// file limit to the hard limit and cap concurrency to what it allows,
+		// so the default rate does not trip "too many open files".
+		if soft := raiseOpenFileLimit(); soft > 0 {
+			if capped := connectConcurrency(r.options.Rate, soft); capped < scanConcurrency {
+				gologger.Info().Msgf("Capping connect concurrency to %d (open file limit %d)\n", capped, soft)
+				scanConcurrency = capped
+			}
+		}
+	}
+	r.wgscan = sizedwaitgroup.New(scanConcurrency)
+	r.limiter = ratelimit.New(context.Background(), uint(r.options.Rate), time.Second)
 
 	if shouldDiscoverHosts && shouldUseRawPackets {
 		// perform host discovery

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -72,6 +72,10 @@ type Runner struct {
 	// skip the disk-backed IP->hostname lookups entirely and emit IPs directly.
 	hasHostnames atomic.Bool
 
+	// csvHeaderOnce guards the live CSV header so it is written exactly once per
+	// run rather than once per onReceive call (which is per result).
+	csvHeaderOnce sync.Once
+
 	fpTargetCh  chan fingerprint.Target
 	fpDone      chan struct{}
 	fpServices  map[string]*port.Service
@@ -244,6 +248,16 @@ func NewRunner(options *Options) (*Runner, error) {
 	return runner, nil
 }
 
+// finalJSONCSVToStdout reports whether handleOutput should print JSON/CSV
+// results to stdout. In the common case onReceive already streams them live
+// during the scan (and the Verify path replays through onReceive), so printing
+// again here would duplicate every line. It only falls to handleOutput when the
+// live path is intentionally suppressed: -sV emits enriched output after the
+// scan, and nmap CLI defers JSON/CSV until after nmap integration.
+func (r *Runner) finalJSONCSVToStdout() bool {
+	return r.options.ServiceVersion || (r.options.NmapCLI != "" && (r.options.JSON || r.options.CSV))
+}
+
 // hostsForIP returns the hostnames to print for an IP. For scans whose inputs
 // are pure IPs/CIDRs (no hostnames), it returns the IP directly and avoids the
 // disk-backed Hosts lookup entirely.
@@ -333,8 +347,6 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 		return
 	}
 
-	csvHeaderEnabled := true
-
 	buffer := bytes.Buffer{}
 	writer := csv.NewWriter(&buffer)
 	for _, host := range dt {
@@ -366,10 +378,9 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 					}
 					_, _ = fmt.Fprintf(&buffer, "%s\n", b)
 				} else if r.options.CSV {
-					if csvHeaderEnabled {
+					r.csvHeaderOnce.Do(func() {
 						writeCSVHeaders(data, writer, r.options.ExcludeOutputFields)
-						csvHeaderEnabled = false
-					}
+					})
 					writeCSVRow(data, writer, r.options.ExcludeOutputFields)
 				}
 			}
@@ -1457,7 +1468,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					}
 				}
 
-				if !r.options.DisableStdout {
+				if !r.options.DisableStdout && r.finalJSONCSVToStdout() {
 					if r.options.JSON {
 						gologger.Silent().Msgf("%s", buffer.String())
 					} else if r.options.CSV {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -81,6 +81,9 @@ type Runner struct {
 	scanStartTime time.Time
 
 	fpTargetCh chan fingerprint.Target
+	// fpQueue decouples the scan hot path from the fingerprint workers so fast
+	// discovery never blocks the scan nor silently drops -sV targets.
+	fpQueue    *fpQueue
 	fpDone     chan struct{}
 	fpServices map[string]*port.Service
 	fpMu       sync.Mutex
@@ -330,8 +333,10 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 		_ = r.unique.Set(ipPort, struct{}{})
 	}
 
-	// Feed on-the-fly service detection (non-blocking to avoid stalling the scan path).
-	if r.fpTargetCh != nil {
+	// Feed on-the-fly service detection. The queue never blocks the scan path and
+	// never drops targets, so -sV stays complete even when discovery outpaces the
+	// fingerprint workers.
+	if r.fpQueue != nil {
 		hostname := hostResult.IP
 		for _, h := range dt {
 			if h != "ip" && h != hostResult.IP {
@@ -340,17 +345,13 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 			}
 		}
 		for _, p := range hostResult.Ports {
-			t := fingerprint.Target{
+			r.fpQueue.push(fingerprint.Target{
 				Host:        hostname,
 				IP:          hostResult.IP,
 				Port:        p.Port,
 				TLSDetected: p.TLS, //nolint:staticcheck // deprecated but still set by scan layer
 				TLSChecked:  true,
-			}
-			select {
-			case r.fpTargetCh <- t:
-			default:
-			}
+			})
 		}
 	}
 
@@ -1349,10 +1350,25 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 	ctx, cancel := context.WithCancel(parentCtx)
 	r.fpCancel = cancel
 	r.fpTargetCh = make(chan fingerprint.Target, 1000)
+	r.fpQueue = newFpQueue()
 	r.fpDone = make(chan struct{})
 	r.fpServices = make(map[string]*port.Service)
 
 	resultCh := engine.FingerprintStream(ctx, r.fpTargetCh)
+
+	// Forward queued targets into the engine. The unbounded queue absorbs bursts
+	// from fast discovery; this goroutine blocks on the engine channel instead
+	// of dropping, and closes fpTargetCh once the queue is closed and drained.
+	go func() {
+		for {
+			t, ok := r.fpQueue.pop()
+			if !ok {
+				close(r.fpTargetCh)
+				return
+			}
+			r.fpTargetCh <- t
+		}
+	}()
 
 	gologger.Info().Msgf("Fingerprinting open port(s) with %d workers", r.options.ServiceVersionWorkers)
 
@@ -1369,12 +1385,15 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 }
 
 func (r *Runner) waitServiceDetection(scanResults *result.Result) {
-	if r.fpTargetCh == nil {
+	if r.fpQueue == nil {
 		return
 	}
-	// Close and nil out so the repeated call sites are idempotent within a run
-	// and a reused Runner (SDK) can start a fresh detection cycle next scan.
-	close(r.fpTargetCh)
+	// Close the queue (the forwarder drains the remaining targets and then closes
+	// fpTargetCh, which ends the engine) and nil out so the repeated call sites
+	// are idempotent within a run and a reused Runner (SDK) can start a fresh
+	// detection cycle next scan.
+	r.fpQueue.close()
+	r.fpQueue = nil
 	r.fpTargetCh = nil
 	<-r.fpDone
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -829,6 +829,9 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 								}
 								synPacer.wait()
 								if err := synSender.send(dstIP4, srcSum, uint16(port.Port)); err != nil {
+									if isCongestion(err) {
+										synPacer.onCongestion()
+									}
 									gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
 								}
 							} else {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -80,12 +80,11 @@ type Runner struct {
 	// XML/greppable output timestamps and elapsed time.
 	scanStartTime time.Time
 
-	fpTargetCh  chan fingerprint.Target
-	fpDone      chan struct{}
-	fpServices  map[string]*port.Service
-	fpMu        sync.Mutex
-	fpCancel    context.CancelFunc
-	fpCloseOnce sync.Once
+	fpTargetCh chan fingerprint.Target
+	fpDone     chan struct{}
+	fpServices map[string]*port.Service
+	fpMu       sync.Mutex
+	fpCancel   context.CancelFunc
 	// probeDB is the parsed nmap-service-probes database, shared
 	// between service version detection (-sV) and the UDP probe
 	// injection path (-uP). It is nil until one of those features
@@ -1360,7 +1359,10 @@ func (r *Runner) waitServiceDetection(scanResults *result.Result) {
 	if r.fpTargetCh == nil {
 		return
 	}
-	r.fpCloseOnce.Do(func() { close(r.fpTargetCh) })
+	// Close and nil out so the repeated call sites are idempotent within a run
+	// and a reused Runner (SDK) can start a fresh detection cycle next scan.
+	close(r.fpTargetCh)
+	r.fpTargetCh = nil
 	<-r.fpDone
 
 	for hostResult := range scanResults.GetIPsPorts() {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -127,6 +127,9 @@ func NewRunner(options *Options) (*Runner, error) {
 	if options.Threads == 0 {
 		options.Threads = DefaultThreadsNum
 	}
+	if options.TxWorkers == 0 {
+		options.TxWorkers = 1
+	}
 	if options.DnsOrder == "" {
 		options.DnsOrder = "l"
 	}
@@ -732,80 +735,86 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 				r.options.ResumeCfg.Unlock()
 
 				b := blackrock.New(int64(Range), currentSeed)
-				for index := int64(0); index < int64(Range); index++ {
-					// Distributed sharding: each node only handles its slice of
-					// the index space. The shared seed makes the slices disjoint.
-					if !r.options.inShard(index) {
-						continue
-					}
-					xxx := b.Shuffle(index)
-					ipIndex := xxx / int64(portsCount)
-					portIndex := int(xxx % int64(portsCount))
+				if synSender != nil && r.options.TxWorkers > 1 {
+					// Multi-core transmit: fan the fast SYN sends across N
+					// workers, each with its own socket, batch and rate slice.
+					r.runFastTx(ctx, b, int64(Range), portsCount, targets, tgtIdx, synSender, payload, shouldUseRawPackets)
+				} else {
+					for index := int64(0); index < int64(Range); index++ {
+						// Distributed sharding: each node only handles its slice of
+						// the index space. The shared seed makes the slices disjoint.
+						if !r.options.inShard(index) {
+							continue
+						}
+						xxx := b.Shuffle(index)
+						ipIndex := xxx / int64(portsCount)
+						portIndex := int(xxx % int64(portsCount))
 
-					// fast IPv4 generation (uint32 math) when the fast sender is
-					// active; otherwise fall back to the big.Int-based PickIP.
-					var (
-						dstIP4 [4]byte
-						isV4   bool
-						ip     string
-					)
-					if synSender != nil {
-						dstIP4, ip, isV4 = tgtIdx.pickIPv4(ipIndex)
-					}
-					if ip == "" {
-						ip = r.PickIP(targets, ipIndex)
-					}
+						// fast IPv4 generation (uint32 math) when the fast sender is
+						// active; otherwise fall back to the big.Int-based PickIP.
+						var (
+							dstIP4 [4]byte
+							isV4   bool
+							ip     string
+						)
+						if synSender != nil {
+							dstIP4, ip, isV4 = tgtIdx.pickIPv4(ipIndex)
+						}
+						if ip == "" {
+							ip = r.PickIP(targets, ipIndex)
+						}
 
-					if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
-						continue
-					}
+						if r.excludedIpsNP != nil && !r.excludedIpsNP.ValidateAddress(ip) {
+							continue
+						}
 
-					port := r.PickPort(portIndex)
+						port := r.PickPort(portIndex)
 
-					r.options.ResumeCfg.RLock()
-					resumeCfgIndex := r.options.ResumeCfg.Index
-					r.options.ResumeCfg.RUnlock()
-					if index < resumeCfgIndex {
-						gologger.Debug().Msgf("Skipping \"%s:%d\": Resume - Port scan already completed\n", ip, port.Port)
-						continue
-					}
+						r.options.ResumeCfg.RLock()
+						resumeCfgIndex := r.options.ResumeCfg.Index
+						r.options.ResumeCfg.RUnlock()
+						if index < resumeCfgIndex {
+							gologger.Debug().Msgf("Skipping \"%s:%d\": Resume - Port scan already completed\n", ip, port.Port)
+							continue
+						}
 
-					// resume cfg logic
-					r.options.ResumeCfg.Lock()
-					r.options.ResumeCfg.Index = index
-					r.options.ResumeCfg.Unlock()
+						// resume cfg logic
+						r.options.ResumeCfg.Lock()
+						r.options.ResumeCfg.Index = index
+						r.options.ResumeCfg.Unlock()
 
-					if r.scanner.ScanResults.HasSkipped(ip) {
-						continue
-					}
-					if r.options.PortThreshold > 0 && r.scanner.ScanResults.GetPortCount(ip) >= r.options.PortThreshold {
-						hosts, _ := r.scanner.IPRanger.GetHostsByIP(ip)
-						gologger.Info().Msgf("Skipping %s %v, Threshold reached \n", ip, hosts)
-						r.scanner.ScanResults.AddSkipped(ip)
-						continue
-					}
+						if r.scanner.ScanResults.HasSkipped(ip) {
+							continue
+						}
+						if r.options.PortThreshold > 0 && r.scanner.ScanResults.GetPortCount(ip) >= r.options.PortThreshold {
+							hosts, _ := r.scanner.IPRanger.GetHostsByIP(ip)
+							gologger.Info().Msgf("Skipping %s %v, Threshold reached \n", ip, hosts)
+							r.scanner.ScanResults.AddSkipped(ip)
+							continue
+						}
 
-					if shouldUseRawPackets {
-						if synSender != nil && isV4 && port.Protocol == protocol.TCP {
-							if r.scanner.ScanResults.IPHasPort(ip, port) {
-								continue
-							}
-							if !r.canIScanIfCDN(ip, port) {
-								continue
-							}
-							synPacer.wait()
-							if err := synSender.send(dstIP4, uint16(port.Port)); err != nil {
-								gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
+						if shouldUseRawPackets {
+							if synSender != nil && isV4 && port.Protocol == protocol.TCP {
+								if r.scanner.ScanResults.IPHasPort(ip, port) {
+									continue
+								}
+								if !r.canIScanIfCDN(ip, port) {
+									continue
+								}
+								synPacer.wait()
+								if err := synSender.send(dstIP4, uint16(port.Port)); err != nil {
+									gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
+								}
+							} else {
+								r.RawSocketEnumeration(ctx, ip, port)
 							}
 						} else {
-							r.RawSocketEnumeration(ctx, ip, port)
+							r.wgscan.Add()
+							go r.handleHostPort(ctx, ip, payload, port)
 						}
-					} else {
-						r.wgscan.Add()
-						go r.handleHostPort(ctx, ip, payload, port)
-					}
-					if r.options.EnableProgressBar {
-						r.stats.IncrementCounter("packets", 1)
+						if r.options.EnableProgressBar {
+							r.stats.IncrementCounter("packets", 1)
+						}
 					}
 				}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -768,9 +768,10 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 							dstIP4 [4]byte
 							isV4   bool
 							ip     string
+							srcSum uint32
 						)
 						if synSender != nil {
-							dstIP4, ip, isV4 = tgtIdx.pickIPv4(ipIndex)
+							dstIP4, ip, srcSum, isV4 = tgtIdx.pickIPv4(ipIndex)
 						}
 						if ip == "" {
 							ip = r.PickIP(targets, ipIndex)
@@ -814,7 +815,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 									continue
 								}
 								synPacer.wait()
-								if err := synSender.send(dstIP4, uint16(port.Port)); err != nil {
+								if err := synSender.send(dstIP4, srcSum, uint16(port.Port)); err != nil {
 									gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, port.Port, err)
 								}
 							} else {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -305,13 +305,24 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 		return
 	}
 
-	// receive event has only one port
+	// A receive event may carry multiple ports (e.g. --verify replays the
+	// full HostResult). Keep only the ports we have not emitted yet instead
+	// of dropping the whole host the moment its first port was already seen.
+	newPorts := make([]*port.Port, 0, len(hostResult.Ports))
 	for _, p := range hostResult.Ports {
 		ipPort := net.JoinHostPort(hostResult.IP, fmt.Sprint(p.Port))
 		if r.unique.Has(ipPort) {
-			return
+			continue
 		}
+		newPorts = append(newPorts, p)
 	}
+	if len(newPorts) == 0 {
+		return
+	}
+	// shallow-copy so we don't mutate the caller's HostResult slice
+	hr := *hostResult
+	hr.Ports = newPorts
+	hostResult = &hr
 
 	// recover hostnames from ip:port combination
 	r.recoverHostnames(hostResult.IP, hostResult.Ports, dt)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -76,6 +76,10 @@ type Runner struct {
 	// run rather than once per onReceive call (which is per result).
 	csvHeaderOnce sync.Once
 
+	// scanStartTime records when enumeration began, used for nmap-compatible
+	// XML/greppable output timestamps and elapsed time.
+	scanStartTime time.Time
+
 	fpTargetCh  chan fingerprint.Target
 	fpDone      chan struct{}
 	fpServices  map[string]*port.Service
@@ -415,6 +419,8 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 func (r *Runner) RunEnumeration(pctx context.Context) error {
 	ctx, cancel := context.WithCancel(pctx)
 	defer cancel()
+
+	r.scanStartTime = time.Now()
 
 	if privileges.IsPrivileged && r.options.ScanType == SynScan {
 		// Set values if those were specified via cli, errors are fatal
@@ -1584,6 +1590,8 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 	}
 
 	r.outputDeadHosts(file, &csvFileHeaderEnabled)
+
+	r.writeNmapFormats(scanResults)
 }
 
 // outputDeadHosts reports the hosts that were probed during host discovery but

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -716,8 +716,9 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					continue
 				}
 
-				// Use current time as seed
-				currentSeed := time.Now().UnixNano()
+				// Use current time as seed, unless an explicit/shard seed applies.
+				// Sharded nodes must share a seed so their slices are disjoint.
+				currentSeed := r.options.shardSeed(time.Now().UnixNano())
 				r.options.ResumeCfg.RLock()
 				if r.options.ResumeCfg.Seed > 0 {
 					currentSeed = r.options.ResumeCfg.Seed
@@ -732,6 +733,11 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 
 				b := blackrock.New(int64(Range), currentSeed)
 				for index := int64(0); index < int64(Range); index++ {
+					// Distributed sharding: each node only handles its slice of
+					// the index space. The shared seed makes the slices disjoint.
+					if !r.options.inShard(index) {
+						continue
+					}
 					xxx := b.Shuffle(index)
 					ipIndex := xxx / int64(portsCount)
 					portIndex := int(xxx % int64(portsCount))
@@ -804,7 +810,12 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 				}
 
 				// handle the ip:port combination
-				for _, targetWithPort := range targetsWithPort {
+				for twpIndex, targetWithPort := range targetsWithPort {
+					// shard the explicit ip:port targets the same way as the
+					// generated (host, port) space.
+					if !r.options.inShard(int64(twpIndex)) {
+						continue
+					}
 					ip, p, err := net.SplitHostPort(targetWithPort)
 					if err != nil {
 						gologger.Debug().Msgf("Skipping %s: %v\n", targetWithPort, err)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mzack9999/gcache"
@@ -45,6 +46,11 @@ import (
 	"golang.org/x/net/proxy"
 )
 
+// defaultUniqueCacheSize bounds the output de-duplication LRU. ~64K entries
+// keeps memory flat (a few MB) while comfortably covering retry/retransmit
+// duplicate windows on large scans.
+const defaultUniqueCacheSize = 65536
+
 // Runner is an instance of the port enumeration
 // client used to orchestrate the whole process.
 type Runner struct {
@@ -60,6 +66,11 @@ type Runner struct {
 	excludedIpsNP  *networkpolicy.NetworkPolicy
 
 	unique gcache.Cache[string, struct{}]
+
+	// hasHostnames is set when at least one target resolves from a hostname
+	// (as opposed to a literal IP/CIDR/ASN). When false the output path can
+	// skip the disk-backed IP->hostname lookups entirely and emit IPs directly.
+	hasHostnames atomic.Bool
 
 	fpTargetCh  chan fingerprint.Target
 	fpDone      chan struct{}
@@ -178,7 +189,12 @@ func NewRunner(options *Options) (*Runner, error) {
 	}
 	runner.streamChannel = make(chan Target)
 
-	uniqueCache := gcache.New[string, struct{}](1500).Build()
+	// Bounded LRU for output de-duplication of ip:port (and host:port) lines.
+	// Duplicates come from scan retries and target retransmissions; a generous
+	// LRU window absorbs them while keeping memory flat on huge scans. LRU is
+	// preferred over a bloom filter here because an eviction only risks a benign
+	// repeated line, whereas a bloom false-positive would drop a real result.
+	uniqueCache := gcache.New[string, struct{}](defaultUniqueCacheSize).LRU().Build()
 	runner.unique = uniqueCache
 
 	scanOpts := &scan.Options{
@@ -228,12 +244,42 @@ func NewRunner(options *Options) (*Runner, error) {
 	return runner, nil
 }
 
+// hostsForIP returns the hostnames to print for an IP. For scans whose inputs
+// are pure IPs/CIDRs (no hostnames), it returns the IP directly and avoids the
+// disk-backed Hosts lookup entirely.
+func (r *Runner) hostsForIP(ip string) ([]string, error) {
+	if !r.hasHostnames.Load() {
+		return []string{ip}, nil
+	}
+	return r.scanner.IPRanger.GetHostsByIP(ip)
+}
+
+// recoverHostnames rewrites bare IPs in dt with hostnames recorded against the
+// ip:port keys. It is a no-op for pure IP/CIDR scans (no hostname store).
+func (r *Runner) recoverHostnames(ip string, ports []*port.Port, dt []string) {
+	if !r.hasHostnames.Load() {
+		return
+	}
+	for _, p := range ports {
+		ipPort := net.JoinHostPort(ip, fmt.Sprint(p.Port))
+		if dtOthers, ok := r.scanner.IPRanger.Hosts.Get(ipPort); ok {
+			if otherName, _, err := net.SplitHostPort(string(dtOthers)); err == nil {
+				for idx, ipCandidate := range dt {
+					if iputil.IsIP(ipCandidate) {
+						dt[idx] = otherName
+					}
+				}
+			}
+		}
+	}
+}
+
 func (r *Runner) onReceive(hostResult *result.HostResult) {
 	if !ipMatchesIpVersions(hostResult.IP, r.options.IPVersion...) {
 		return
 	}
 
-	dt, err := r.scanner.IPRanger.GetHostsByIP(hostResult.IP)
+	dt, err := r.hostsForIP(hostResult.IP)
 	if err != nil {
 		return
 	}
@@ -247,18 +293,9 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 	}
 
 	// recover hostnames from ip:port combination
+	r.recoverHostnames(hostResult.IP, hostResult.Ports, dt)
 	for _, p := range hostResult.Ports {
 		ipPort := net.JoinHostPort(hostResult.IP, fmt.Sprint(p.Port))
-		if dtOthers, ok := r.scanner.IPRanger.Hosts.Get(ipPort); ok {
-			if otherName, _, err := net.SplitHostPort(string(dtOthers)); err == nil {
-				// replace bare ip:port with host
-				for idx, ipCandidate := range dt {
-					if iputil.IsIP(ipCandidate) {
-						dt[idx] = otherName
-					}
-				}
-			}
-		}
 		_ = r.unique.Set(ipPort, struct{}{})
 	}
 
@@ -1335,7 +1372,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 	switch {
 	case scanResults.HasIPsPorts():
 		for hostResult := range scanResults.GetIPsPorts() {
-			dt, err := r.scanner.IPRanger.GetHostsByIP(hostResult.IP)
+			dt, err := r.hostsForIP(hostResult.IP)
 			if err != nil {
 				continue
 			}
@@ -1345,19 +1382,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 			}
 
 			// recover hostnames from ip:port combination
-			for _, p := range hostResult.Ports {
-				ipPort := net.JoinHostPort(hostResult.IP, fmt.Sprint(p.Port))
-				if dtOthers, ok := r.scanner.IPRanger.Hosts.Get(ipPort); ok {
-					if otherName, _, err := net.SplitHostPort(string(dtOthers)); err == nil {
-						// replace bare ip:port with host
-						for idx, ipCandidate := range dt {
-							if iputil.IsIP(ipCandidate) {
-								dt[idx] = otherName
-							}
-						}
-					}
-				}
-			}
+			r.recoverHostnames(hostResult.IP, hostResult.Ports, dt)
 
 			buffer := bytes.Buffer{}
 			for _, host := range dt {
@@ -1464,7 +1489,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 		}
 	case scanResults.HasIPS():
 		for hostIP := range scanResults.GetIPs() {
-			dt, err := r.scanner.IPRanger.GetHostsByIP(hostIP)
+			dt, err := r.hostsForIP(hostIP)
 			if err != nil {
 				continue
 			}
@@ -1566,7 +1591,7 @@ func (r *Runner) outputDeadHosts(file *os.File, csvFileHeaderEnabled *bool) {
 			continue
 		}
 
-		hosts, _ := r.scanner.IPRanger.GetHostsByIP(deadIP)
+		hosts, _ := r.hostsForIP(deadIP)
 		if len(hosts) == 0 {
 			hosts = []string{deadIP}
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -735,9 +735,11 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 				r.options.ResumeCfg.Unlock()
 
 				b := blackrock.New(int64(Range), currentSeed)
-				if synSender != nil && r.options.TxWorkers > 1 {
+				if synSender != nil && r.options.TxWorkers > 1 && !r.options.Resume {
 					// Multi-core transmit: fan the fast SYN sends across N
 					// workers, each with its own socket, batch and rate slice.
+					// Resume relies on serial per-index bookkeeping, so it falls
+					// back to the single-worker loop below.
 					r.runFastTx(ctx, b, int64(Range), portsCount, targets, tgtIdx, synSender, payload, shouldUseRawPackets)
 				} else {
 					for index := int64(0); index < int64(Range); index++ {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -435,6 +435,9 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 	defer cancel()
 
 	r.scanStartTime = time.Now()
+	// Reset the CSV header guard so a reused Runner writes a fresh header on
+	// every enumeration instead of omitting it after the first run.
+	r.csvHeaderOnce = sync.Once{}
 
 	if privileges.IsPrivileged && r.options.ScanType == SynScan {
 		// Set values if those were specified via cli, errors are fatal
@@ -885,7 +888,12 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 
 				// flush any SYN packets still queued in the batch sender
 				if synSender != nil {
-					_ = synSender.flush()
+					if err := synSender.flush(); err != nil {
+						if isCongestion(err) {
+							synPacer.onCongestion()
+						}
+						gologger.Debug().Msgf("final flush failed: %s\n", err)
+					}
 				}
 
 				r.wgscan.Wait()

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1264,6 +1264,12 @@ func (r *Runner) SetSourceIP(sourceIP string) error {
 		return errors.New("invalid ip type")
 	}
 
+	// Bind the raw transport sockets to the source so the kernel actually emits
+	// packets with it; otherwise the fast/raw send path lets the kernel choose
+	// the source by route and the flag is silently ignored. A non-owned source
+	// (e.g. spoofing) leaves SourceBound false and falls back to the L2 path.
+	r.scanner.ListenHandler.BindSourceIP(r.scanner.ListenHandler.SourceIp4, r.scanner.ListenHandler.SourceIP6)
+
 	return nil
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1386,7 +1386,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 
 		// create path if not existing
 		outputFolder := filepath.Dir(output)
-		if fileutil.FolderExists(outputFolder) {
+		if !fileutil.FolderExists(outputFolder) {
 			mkdirErr := os.MkdirAll(outputFolder, 0700)
 			if mkdirErr != nil {
 				gologger.Error().Msgf("Could not create output folder %s: %s\n", outputFolder, mkdirErr)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -76,6 +76,11 @@ type Runner struct {
 	// run rather than once per onReceive call (which is per result).
 	csvHeaderOnce sync.Once
 
+	// verifyReplay is set only while handleOutput replays the post-verification
+	// result set through onReceive. In --verify mode live results are unverified,
+	// so onReceive suppresses them during the scan and emits only this replay.
+	verifyReplay atomic.Bool
+
 	// scanStartTime records when enumeration began, used for nmap-compatible
 	// XML/greppable output timestamps and elapsed time.
 	scanStartTime time.Time
@@ -298,6 +303,13 @@ func (r *Runner) recoverHostnames(ip string, ports []*port.Port, dt []string) {
 }
 
 func (r *Runner) onReceive(hostResult *result.HostResult) {
+	// In --verify mode the results streamed during the scan are unverified. Drop
+	// them here (this also covers the raw SYN path, whose TCPResultWorker calls
+	// OnReceive unconditionally) so only the verified replay reaches stdout and the
+	// unique cache, keeping stdout consistent with the file output.
+	if r.options.Verify && !r.verifyReplay.Load() {
+		return
+	}
 	if !ipMatchesIpVersions(hostResult.IP, r.options.IPVersion...) {
 		return
 	}
@@ -337,7 +349,10 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 	// stays complete even when discovery outpaces the fingerprint workers. When
 	// the backlog hits its memory ceiling, push blocks here and backpressure
 	// reaches TCPResultWorker (not the SYN TX path directly).
-	if r.fpQueue != nil {
+	r.fpMu.Lock()
+	fpq := r.fpQueue
+	r.fpMu.Unlock()
+	if fpq != nil {
 		hostname := hostResult.IP
 		for _, h := range dt {
 			if h != "ip" && h != hostResult.IP {
@@ -346,7 +361,7 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 			}
 		}
 		for _, p := range hostResult.Ports {
-			r.fpQueue.push(fingerprint.Target{
+			fpq.push(fingerprint.Target{
 				Host:        hostname,
 				IP:          hostResult.IP,
 				Port:        p.Port,
@@ -781,6 +796,13 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					// Resume relies on serial per-index bookkeeping, so it falls
 					// back to the single-worker loop below.
 					r.runFastTx(ctx, b, int64(Range), portsCount, targets, tgtIdx, synSender, payload, shouldUseRawPackets)
+					// runFastTx returns early on cancellation; propagate it so we do
+					// not re-open the worker sockets for every remaining retry.
+					select {
+					case <-ctx.Done():
+						scanCancelled = true
+					default:
+					}
 				} else {
 					for index := int64(0); index < int64(Range); index++ {
 						select {
@@ -1406,15 +1428,18 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 	// Forward queued targets into the engine. The bounded queue absorbs bursts
 	// from fast discovery (with backpressure at capacity); this goroutine blocks
 	// on the engine channel instead of dropping, and closes fpTargetCh once the
-	// queue is closed and drained.
+	// queue is closed and drained. It captures the queue and channel as locals so
+	// waitServiceDetection can clear the Runner fields without racing this loop.
+	q := r.fpQueue
+	ch := r.fpTargetCh
 	go func() {
 		for {
-			t, ok := r.fpQueue.pop()
+			t, ok := q.pop()
 			if !ok {
-				close(r.fpTargetCh)
+				close(ch)
 				return
 			}
-			r.fpTargetCh <- t
+			ch <- t
 		}
 	}()
 
@@ -1433,17 +1458,22 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 }
 
 func (r *Runner) waitServiceDetection(scanResults *result.Result) {
-	if r.fpQueue == nil {
+	// Swap out the queue under the lock so a concurrent onReceive either sees a
+	// live queue or nil, never a half-cleared pointer. The forwarder holds its own
+	// captured reference, so it keeps draining after this.
+	r.fpMu.Lock()
+	q := r.fpQueue
+	r.fpQueue = nil
+	r.fpMu.Unlock()
+	if q == nil {
 		return
 	}
 	// Close the queue (the forwarder drains the remaining targets and then closes
-	// fpTargetCh, which ends the engine) and nil out so the repeated call sites
-	// are idempotent within a run and a reused Runner (SDK) can start a fresh
-	// detection cycle next scan.
-	r.fpQueue.close()
-	r.fpQueue = nil
-	r.fpTargetCh = nil
+	// fpTargetCh, which ends the engine). Only clear fpTargetCh after fpDone so the
+	// forwarder has finished and a reused Runner (SDK) can start a fresh cycle.
+	q.close()
 	<-r.fpDone
+	r.fpTargetCh = nil
 
 	if scanResults != nil {
 		for hostResult := range scanResults.GetIPsPorts() {
@@ -1469,9 +1499,11 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 	)
 
 	if r.options.Verify {
+		r.verifyReplay.Store(true)
 		for hostResult := range scanResults.GetIPsPorts() {
 			r.scanner.OnReceive(hostResult)
 		}
+		r.verifyReplay.Store(false)
 	}
 
 	// In case the user has given an output file, write all the found
@@ -1501,6 +1533,10 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 		}()
 	}
 	csvFileHeaderEnabled := true
+	// The stdout buffer and the file are written by independent CSV writers, so
+	// they each need their own "header not yet written" flag; sharing one made the
+	// file lose its header whenever the stdout buffer consumed it first.
+	csvStdoutHeaderEnabled := true
 	hostPortPrinted := make(map[string]struct{})
 
 	switch {
@@ -1582,9 +1618,9 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 							_, _ = fmt.Fprintf(&buffer, "%s\n", b)
 						} else if r.options.CSV {
 							writer := csv.NewWriter(&buffer)
-							if csvFileHeaderEnabled {
+							if csvStdoutHeaderEnabled {
 								writeCSVHeaders(data, writer, r.options.ExcludeOutputFields)
-								csvFileHeaderEnabled = false
+								csvStdoutHeaderEnabled = false
 							}
 							writeCSVRow(data, writer, r.options.ExcludeOutputFields)
 						}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -451,9 +451,10 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 	defer cancel()
 
 	r.scanStartTime = time.Now()
-	// Reset the CSV header guard so a reused Runner writes a fresh header on
-	// every enumeration instead of omitting it after the first run.
+	// Reset per-enumeration state so a reused Runner (SDK) writes a fresh CSV
+	// header and does not suppress IP:port pairs seen in a previous scan.
 	r.csvHeaderOnce = sync.Once{}
+	r.unique = gcache.New[string, struct{}](defaultUniqueCacheSize).LRU().Build()
 
 	if privileges.IsPrivileged && r.options.ScanType == SynScan {
 		// Set values if those were specified via cli, errors are fatal
@@ -1113,11 +1114,10 @@ func (r *Runner) PickPort(index int) *port.Port {
 
 func (r *Runner) ConnectVerification() {
 	r.scanner.ListenHandler.Phase.Set(scan.Scan)
-	// cap concurrent verification goroutines (and their dials) at the scan rate,
-	// matching the main scan loop. A plain WaitGroup here let the goroutine count
-	// track the number of hosts with open ports, which could spawn an unbounded
-	// number of concurrent dials on large result sets.
-	swg := sizedwaitgroup.New(r.options.Rate)
+	// Cap concurrent verification dials at the same open-file-aware limit used
+	// by the main connect scan, while still pacing with the configured rate.
+	soft := raiseOpenFileLimit()
+	swg := sizedwaitgroup.New(connectConcurrency(r.options.Rate, soft))
 	limiter := ratelimit.New(context.Background(), uint(r.options.Rate), time.Second)
 	defer limiter.Stop()
 
@@ -1327,7 +1327,7 @@ func (r *Runner) SetSourceIP(sourceIP string) error {
 	// Bind the raw transport sockets to the source so the kernel actually emits
 	// packets with it; otherwise the fast/raw send path lets the kernel choose
 	// the source by route and the flag is silently ignored. A non-owned source
-	// (e.g. spoofing) leaves SourceBound false and falls back to the L2 path.
+	// (e.g. spoofing) leaves SourceBound4/SourceBound6 false and falls back to the L2 path.
 	r.scanner.ListenHandler.BindSourceIP(r.scanner.ListenHandler.SourceIp4, r.scanner.ListenHandler.SourceIP6)
 
 	return nil
@@ -1555,6 +1555,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 			r.recoverHostnames(hostResult.IP, hostResult.Ports, dt)
 
 			buffer := bytes.Buffer{}
+			csvWriter := csv.NewWriter(&buffer)
 			for _, host := range dt {
 				buffer.Reset()
 				if host == "ip" {
@@ -1617,12 +1618,11 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 							}
 							_, _ = fmt.Fprintf(&buffer, "%s\n", b)
 						} else if r.options.CSV {
-							writer := csv.NewWriter(&buffer)
 							if csvStdoutHeaderEnabled {
-								writeCSVHeaders(data, writer, r.options.ExcludeOutputFields)
+								writeCSVHeaders(data, csvWriter, r.options.ExcludeOutputFields)
 								csvStdoutHeaderEnabled = false
 							}
-							writeCSVRow(data, writer, r.options.ExcludeOutputFields)
+							writeCSVRow(data, csvWriter, r.options.ExcludeOutputFields)
 						}
 					}
 				}
@@ -1631,8 +1631,7 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 					if r.options.JSON {
 						gologger.Silent().Msgf("%s", buffer.String())
 					} else if r.options.CSV {
-						writer := csv.NewWriter(&buffer)
-						writer.Flush()
+						csvWriter.Flush()
 						gologger.Silent().Msgf("%s", buffer.String())
 					}
 				}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -333,9 +333,10 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 		_ = r.unique.Set(ipPort, struct{}{})
 	}
 
-	// Feed on-the-fly service detection. The queue never blocks the scan path and
-	// never drops targets, so -sV stays complete even when discovery outpaces the
-	// fingerprint workers.
+	// Feed on-the-fly service detection. The queue never drops targets, so -sV
+	// stays complete even when discovery outpaces the fingerprint workers. When
+	// the backlog hits its memory ceiling, push blocks here and backpressure
+	// reaches TCPResultWorker (not the SYN TX path directly).
 	if r.fpQueue != nil {
 		hostname := hostResult.IP
 		for _, h := range dt {
@@ -463,6 +464,15 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 	}
 
 	r.initServiceDetection(ctx)
+	// Always tear down fingerprint workers, including early returns (Load
+	// failure, OnlyHostDiscovery, handleNmap error). waitServiceDetection is
+	// idempotent once fpQueue is nil, so the explicit call sites below remain
+	// safe and still merge results before output.
+	defer func() {
+		if r.scanner != nil {
+			r.waitServiceDetection(r.scanner.ScanResults)
+		}
+	}()
 	r.initUDPProbes()
 
 	if r.options.Stream {
@@ -739,7 +749,11 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 			}
 
 			// Retries are performed regardless of the previous scan results due to network unreliability
+			scanCancelled := false
 			for currentRetry := 0; currentRetry < r.options.Retries; currentRetry++ {
+				if scanCancelled {
+					break
+				}
 				if currentRetry < r.options.ResumeCfg.Retry {
 					gologger.Debug().Msgf("Skipping Retry: %d\n", currentRetry)
 					continue
@@ -769,6 +783,14 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 					r.runFastTx(ctx, b, int64(Range), portsCount, targets, tgtIdx, synSender, payload, shouldUseRawPackets)
 				} else {
 					for index := int64(0); index < int64(Range); index++ {
+						select {
+						case <-ctx.Done():
+							scanCancelled = true
+						default:
+						}
+						if scanCancelled {
+							break
+						}
 						// Distributed sharding: each node only handles its slice of
 						// the index space. The shared seed makes the slices disjoint.
 						if !r.options.inShard(index) {
@@ -852,6 +874,14 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 
 				// handle the ip:port combination
 				for twpIndex, targetWithPort := range targetsWithPort {
+					select {
+					case <-ctx.Done():
+						scanCancelled = true
+					default:
+					}
+					if scanCancelled {
+						break
+					}
 					// shard the explicit ip:port targets the same way as the
 					// generated (host, port) space.
 					if !r.options.inShard(int64(twpIndex)) {
@@ -1373,9 +1403,10 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 
 	resultCh := engine.FingerprintStream(ctx, r.fpTargetCh)
 
-	// Forward queued targets into the engine. The unbounded queue absorbs bursts
-	// from fast discovery; this goroutine blocks on the engine channel instead
-	// of dropping, and closes fpTargetCh once the queue is closed and drained.
+	// Forward queued targets into the engine. The bounded queue absorbs bursts
+	// from fast discovery (with backpressure at capacity); this goroutine blocks
+	// on the engine channel instead of dropping, and closes fpTargetCh once the
+	// queue is closed and drained.
 	go func() {
 		for {
 			t, ok := r.fpQueue.pop()
@@ -1414,11 +1445,13 @@ func (r *Runner) waitServiceDetection(scanResults *result.Result) {
 	r.fpTargetCh = nil
 	<-r.fpDone
 
-	for hostResult := range scanResults.GetIPsPorts() {
-		for _, p := range hostResult.Ports {
-			key := net.JoinHostPort(hostResult.IP, strconv.Itoa(p.Port))
-			if svc, ok := r.fpServices[key]; ok {
-				p.Service = svc
+	if scanResults != nil {
+		for hostResult := range scanResults.GetIPsPorts() {
+			for _, p := range hostResult.Ports {
+				key := net.JoinHostPort(hostResult.IP, strconv.Itoa(p.Port))
+				if svc, ok := r.fpServices[key]; ok {
+					p.Service = svc
+				}
 			}
 		}
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -750,6 +750,16 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 			}
 
 			Range := targetsCount * portsCount
+
+			// Multi-core transmit senders are opened once and reused across all
+			// retries; opening/closing every worker socket per retry was pure churn.
+			useFastTx := synSender != nil && r.options.TxWorkers > 1 && !r.options.Resume
+			var txSenders []*SYNSender
+			if useFastTx {
+				txSenders = r.buildTxSenders(synSender, int64(Range))
+				defer closeTxSenders(txSenders)
+			}
+
 			if r.options.EnableProgressBar {
 				r.stats.AddStatic("ports", portsCount)
 				r.stats.AddStatic("hosts", targetsCount)
@@ -791,12 +801,12 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 				r.options.ResumeCfg.Unlock()
 
 				b := blackrock.New(int64(Range), currentSeed)
-				if synSender != nil && r.options.TxWorkers > 1 && !r.options.Resume {
+				if useFastTx {
 					// Multi-core transmit: fan the fast SYN sends across N
 					// workers, each with its own socket, batch and rate slice.
 					// Resume relies on serial per-index bookkeeping, so it falls
 					// back to the single-worker loop below.
-					r.runFastTx(ctx, b, int64(Range), portsCount, targets, tgtIdx, synSender, payload, shouldUseRawPackets)
+					r.runFastTx(ctx, b, int64(Range), portsCount, targets, tgtIdx, txSenders, payload, shouldUseRawPackets)
 					// runFastTx returns early on cancellation; propagate it so we do
 					// not re-open the worker sockets for every remaining retry.
 					select {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -800,22 +800,48 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 				r.options.ResumeCfg.Seed = currentSeed
 				r.options.ResumeCfg.Unlock()
 
-				b := blackrock.New(int64(Range), currentSeed)
-				if useFastTx {
-					// Multi-core transmit: fan the fast SYN sends across N
-					// workers, each with its own socket, batch and rate slice.
-					// Resume relies on serial per-index bookkeeping, so it falls
-					// back to the single-worker loop below.
-					r.runFastTx(ctx, b, int64(Range), portsCount, targets, tgtIdx, txSenders, payload, shouldUseRawPackets)
-					// runFastTx returns early on cancellation; propagate it so we do
-					// not re-open the worker sockets for every remaining retry.
-					select {
-					case <-ctx.Done():
-						scanCancelled = true
-					default:
+				// Scan in priority tiers, permuting within each tier rather than
+				// across the whole range, so the most likely open ports stay early
+				// regardless of how wide the range is. A single-tier plan reproduces
+				// the previous uniform ordering exactly. See porttiers.go.
+				tiers := buildPortTiers(r.scanner.Ports, !r.options.NoPortPriority)
+				if tiers.totalTiers() > 1 {
+					gologger.Debug().Msgf("Scanning in %d priority tiers\n", tiers.totalTiers())
+				}
+
+				// indexBase keeps the index space contiguous across tiers, so shard
+				// slicing and resume bookkeeping stay monotonic and disjoint.
+				var indexBase int64
+				for _, tierPortIdx := range tiers {
+					if scanCancelled {
+						break
 					}
-				} else {
-					for index := int64(0); index < int64(Range); index++ {
+					tierPortsCount := int64(len(tierPortIdx))
+					if tierPortsCount == 0 {
+						continue
+					}
+					tierRange := int64(targetsCount) * tierPortsCount
+					b := blackrock.New(tierRange, currentSeed)
+
+					if useFastTx {
+						// Multi-core transmit: fan the fast SYN sends across N
+						// workers, each with its own socket, batch and rate slice.
+						// Resume relies on serial per-index bookkeeping, so it falls
+						// back to the single-worker loop below.
+						r.runFastTx(ctx, b, tierRange, indexBase, tierPortIdx, targets, tgtIdx, txSenders, payload, shouldUseRawPackets)
+						// runFastTx returns early on cancellation; propagate it so we do
+						// not re-open the worker sockets for every remaining retry.
+						select {
+						case <-ctx.Done():
+							scanCancelled = true
+						default:
+						}
+						indexBase += tierRange
+						continue
+					}
+
+					for local := int64(0); local < tierRange; local++ {
+						index := indexBase + local
 						select {
 						case <-ctx.Done():
 							scanCancelled = true
@@ -829,9 +855,9 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 						if !r.options.inShard(index) {
 							continue
 						}
-						xxx := b.Shuffle(index)
-						ipIndex := xxx / int64(portsCount)
-						portIndex := int(xxx % int64(portsCount))
+						xxx := b.Shuffle(local)
+						ipIndex := xxx / tierPortsCount
+						portIndex := tierPortIdx[int(xxx%tierPortsCount)]
 
 						// fast IPv4 generation (uint32 math) when the fast sender is
 						// active; otherwise fall back to the big.Int-based PickIP.
@@ -903,6 +929,7 @@ func (r *Runner) RunEnumeration(pctx context.Context) error {
 							r.stats.IncrementCounter("packets", 1)
 						}
 					}
+					indexBase += tierRange
 				}
 
 				// handle the ip:port combination

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1439,7 +1439,15 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 				close(ch)
 				return
 			}
-			ch <- t
+			// The engine stops draining ch once ctx is cancelled; select on
+			// ctx.Done() so a full channel can't block this forwarder forever
+			// (leaking the goroutine and its retained target backlog).
+			select {
+			case ch <- t:
+			case <-ctx.Done():
+				close(ch)
+				return
+			}
 		}
 	}()
 
@@ -1513,24 +1521,31 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 
 		// create path if not existing
 		outputFolder := filepath.Dir(output)
+		outputReady := true
 		if !fileutil.FolderExists(outputFolder) {
 			mkdirErr := os.MkdirAll(outputFolder, 0700)
 			if mkdirErr != nil {
 				gologger.Error().Msgf("Could not create output folder %s: %s\n", outputFolder, mkdirErr)
-				return
+				outputReady = false
 			}
 		}
 
-		file, err = os.Create(output)
-		if err != nil {
-			gologger.Error().Msgf("Could not create file %s: %s\n", output, err)
-			return
-		}
-		defer func() {
-			if err := file.Close(); err != nil {
-				gologger.Error().Msgf("Could not close file %s: %s\n", output, err)
+		// A failure to create the primary output file must not abort the whole
+		// function: under -oA the XML/greppable writers below can still succeed,
+		// so leave file nil and fall through instead of returning.
+		if outputReady {
+			file, err = os.Create(output)
+			if err != nil {
+				gologger.Error().Msgf("Could not create file %s: %s\n", output, err)
+				file = nil
+			} else {
+				defer func() {
+					if err := file.Close(); err != nil {
+						gologger.Error().Msgf("Could not close file %s: %s\n", output, err)
+					}
+				}()
 			}
-		}()
+		}
 	}
 	csvFileHeaderEnabled := true
 	// The stdout buffer and the file are written by independent CSV writers, so
@@ -1642,6 +1657,9 @@ func (r *Runner) handleOutput(scanResults *result.Result) {
 						err = WriteJSONOutputWithMac(host, hostResult.IP, hostResult.MacAddress, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, r.options.ExcludeOutputFields, file)
 					} else if r.options.CSV {
 						err = WriteCsvOutputWithMac(host, hostResult.IP, hostResult.MacAddress, hostResult.Ports, r.options.OutputCDN, isCDNIP, cdnName, csvFileHeaderEnabled, r.options.ExcludeOutputFields, file)
+						// Flip immediately after the first CSV write: multiple
+						// hostnames for one IP would otherwise each re-emit the header.
+						csvFileHeaderEnabled = false
 					} else {
 						err = WriteHostOutput(host, hostResult.Ports, r.options.OutputCDN, cdnName, file)
 					}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1125,6 +1125,13 @@ func TestConcurrentSYNScans(t *testing.T) {
 }
 
 func TestNewRunner_ScanTypeSyncAfterFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The fallback is triggered by raw capture failing on a bogus interface.
+		// Windows CI has npcap and resolves capture independently of the given
+		// name, so raw infra comes up and no fallback happens. The fallback
+		// propagation itself is platform independent and covered on linux/macos.
+		t.Skip("raw capture availability and interface handling differ on windows")
+	}
 	origRouter := scan.PkgRouter
 	origPriv := privileges.IsPrivileged
 	origIface := scan.NetworkInterface

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -845,11 +845,22 @@ func TestRunnerHostDiscovery(t *testing.T) {
 func TestWaitServiceDetectionReusableAcrossRuns(t *testing.T) {
 	r := &Runner{}
 	// Two consecutive scans on the same Runner (SDK reuse). Each run sets up a
-	// fresh fpTargetCh + drain goroutine the way initServiceDetection does; the
-	// second run must not deadlock waiting on fpDone.
+	// fresh queue + forwarder + drain goroutine the way initServiceDetection
+	// does; the second run must not deadlock waiting on fpDone.
 	for i := 0; i < 2; i++ {
+		r.fpQueue = newFpQueue()
 		r.fpTargetCh = make(chan fingerprint.Target, 1)
 		r.fpDone = make(chan struct{})
+		go func(q *fpQueue, ch chan fingerprint.Target) {
+			for {
+				tgt, ok := q.pop()
+				if !ok {
+					close(ch)
+					return
+				}
+				ch <- tgt
+			}
+		}(r.fpQueue, r.fpTargetCh)
 		go func(ch chan fingerprint.Target, done chan struct{}) {
 			for range ch {
 			}
@@ -866,6 +877,7 @@ func TestWaitServiceDetectionReusableAcrossRuns(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatalf("run %d: waitServiceDetection deadlocked on reuse", i)
 		}
+		require.Nil(t, r.fpQueue, "fpQueue must be cleared so the next run can recreate it")
 		require.Nil(t, r.fpTargetCh, "fpTargetCh must be cleared so the next run can recreate it")
 	}
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/projectdiscovery/naabu/v2/pkg/fingerprint"
 	"github.com/projectdiscovery/naabu/v2/pkg/port"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
 	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
@@ -839,6 +840,34 @@ func TestRunnerHostDiscovery(t *testing.T) {
 	}
 	err = runner.Close()
 	require.NoError(t, err)
+}
+
+func TestWaitServiceDetectionReusableAcrossRuns(t *testing.T) {
+	r := &Runner{}
+	// Two consecutive scans on the same Runner (SDK reuse). Each run sets up a
+	// fresh fpTargetCh + drain goroutine the way initServiceDetection does; the
+	// second run must not deadlock waiting on fpDone.
+	for i := 0; i < 2; i++ {
+		r.fpTargetCh = make(chan fingerprint.Target, 1)
+		r.fpDone = make(chan struct{})
+		go func(ch chan fingerprint.Target, done chan struct{}) {
+			for range ch {
+			}
+			close(done)
+		}(r.fpTargetCh, r.fpDone)
+
+		got := make(chan struct{})
+		go func() {
+			r.waitServiceDetection(result.NewResult())
+			close(got)
+		}()
+		select {
+		case <-got:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("run %d: waitServiceDetection deadlocked on reuse", i)
+		}
+		require.Nil(t, r.fpTargetCh, "fpTargetCh must be cleared so the next run can recreate it")
+	}
 }
 
 func TestOnReceiveKeepsUnseenPortsOnPartialDuplicate(t *testing.T) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -841,6 +841,24 @@ func TestRunnerHostDiscovery(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestOnReceiveKeepsUnseenPortsOnPartialDuplicate(t *testing.T) {
+	runner := newConnectRunner(t)
+	runner.options.DisableStdout = true
+
+	ip := "192.168.1.10"
+	// First event records port 80.
+	runner.onReceive(&result.HostResult{IP: ip, Ports: []*port.Port{{Port: 80, Protocol: protocol.TCP}}})
+	require.True(t, runner.unique.Has(net.JoinHostPort(ip, "80")), "port 80 must be recorded")
+
+	// Second event mixes an already-seen port (80) with a new one (443).
+	// The duplicate must not cause the new port to be dropped.
+	runner.onReceive(&result.HostResult{IP: ip, Ports: []*port.Port{
+		{Port: 80, Protocol: protocol.TCP},
+		{Port: 443, Protocol: protocol.TCP},
+	}})
+	require.True(t, runner.unique.Has(net.JoinHostPort(ip, "443")), "new port 443 must still be recorded despite the leading duplicate")
+}
+
 func TestHostsForIPNoStoreFastPath(t *testing.T) {
 	options := &Options{
 		Host:      []string{"192.168.1.0/24"},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -841,6 +841,60 @@ func TestRunnerHostDiscovery(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHostsForIPNoStoreFastPath(t *testing.T) {
+	options := &Options{
+		Host:      []string{"192.168.1.0/24"},
+		Ports:     "80",
+		ScanType:  ConnectScan,
+		IPVersion: []string{"4"},
+	}
+	runner, err := NewRunner(options)
+	require.NoError(t, err)
+	defer func() { _ = runner.Close() }()
+	require.NoError(t, runner.Load())
+
+	// Pure CIDR input must not flag hostname mapping.
+	require.False(t, runner.hasHostnames.Load(), "pure CIDR input must not set hasHostnames")
+
+	// Fast path returns the IP directly without consulting the store, even for
+	// an IP never added to the ranger.
+	dt, err := runner.hostsForIP("203.0.113.7")
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.7"}, dt)
+
+	// recoverHostnames is a no-op on the fast path.
+	in := []string{"203.0.113.7"}
+	runner.recoverHostnames("203.0.113.7", []*port.Port{{Port: 80, Protocol: protocol.TCP}}, in)
+	require.Equal(t, []string{"203.0.113.7"}, in)
+}
+
+func TestHostsForIPUsesStoreWhenHostnames(t *testing.T) {
+	options := &Options{
+		Host:      []string{"192.168.1.0/24"},
+		Ports:     "80",
+		ScanType:  ConnectScan,
+		IPVersion: []string{"4"},
+	}
+	runner, err := NewRunner(options)
+	require.NoError(t, err)
+	defer func() { _ = runner.Close() }()
+	require.NoError(t, runner.Load())
+
+	// Simulate a hostname-bearing scan and the corresponding store entries.
+	runner.hasHostnames.Store(true)
+	require.NoError(t, runner.scanner.IPRanger.AddHostWithMetadata("203.0.113.7", "example.com"))
+	require.NoError(t, runner.scanner.IPRanger.AddHostWithMetadata("203.0.113.7:80", "example.com:80"))
+
+	dt, err := runner.hostsForIP("203.0.113.7")
+	require.NoError(t, err)
+	require.Contains(t, dt, "example.com")
+
+	// ip:port recovery rewrites a bare IP with the recorded hostname.
+	rec := []string{"203.0.113.7"}
+	runner.recoverHostnames("203.0.113.7", []*port.Port{{Port: 80, Protocol: protocol.TCP}}, rec)
+	require.Equal(t, []string{"example.com"}, rec)
+}
+
 // TestRunnerGetIPs tests IP preprocessing methods
 func TestRunnerGetIPs(t *testing.T) {
 	options := &Options{

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1115,20 +1115,21 @@ func TestConcurrentSYNScans(t *testing.T) {
 func TestNewRunner_ScanTypeSyncAfterFallback(t *testing.T) {
 	origRouter := scan.PkgRouter
 	origPriv := privileges.IsPrivileged
-	origHandlers := scan.ListenHandlers
+	origIface := scan.NetworkInterface
 	defer func() {
 		scan.PkgRouter = origRouter
 		privileges.IsPrivileged = origPriv
-		scan.ListenHandlers = origHandlers
+		scan.NetworkInterface = origIface
 	}()
 
-	// Force the fallback: router exists + privileged + all handlers busy
+	// Force the fallback: privileged SYN scan whose raw infrastructure cannot
+	// come up (bogus capture interface) -> Acquire errors -> connect fallback.
 	scan.PkgRouter = origRouter
 	if scan.PkgRouter == nil {
 		scan.PkgRouter = stubRouter{}
 	}
 	privileges.IsPrivileged = true
-	scan.ListenHandlers = []*scan.ListenHandler{{Busy: true, Phase: &scan.Phase{}}}
+	scan.NetworkInterface = "naabu-nonexistent-iface0"
 
 	options := &Options{
 		Host:     []string{"127.0.0.1"},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -895,6 +895,29 @@ func TestHostsForIPUsesStoreWhenHostnames(t *testing.T) {
 	require.Equal(t, []string{"example.com"}, rec)
 }
 
+func TestFinalJSONCSVToStdout(t *testing.T) {
+	cases := []struct {
+		name string
+		opts *Options
+		want bool
+	}{
+		{"plain live", &Options{JSON: false, CSV: false}, false},
+		{"json live", &Options{JSON: true}, false},
+		{"csv live", &Options{CSV: true}, false},
+		{"service version json", &Options{JSON: true, ServiceVersion: true}, true},
+		{"service version plain", &Options{ServiceVersion: true}, true},
+		{"nmap json deferred", &Options{JSON: true, NmapCLI: "nmap -sV"}, true},
+		{"nmap csv deferred", &Options{CSV: true, NmapCLI: "nmap -sV"}, true},
+		{"nmap without json/csv", &Options{NmapCLI: "nmap -sV"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Runner{options: tc.opts}
+			require.Equal(t, tc.want, r.finalJSONCSVToStdout())
+		})
+	}
+}
+
 // TestRunnerGetIPs tests IP preprocessing methods
 func TestRunnerGetIPs(t *testing.T) {
 	options := &Options{

--- a/pkg/runner/shard.go
+++ b/pkg/runner/shard.go
@@ -1,0 +1,54 @@
+package runner
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// shardDefaultSeed is the fixed blackrock seed used when sharding is enabled but
+// the user did not pass an explicit -seed. All nodes must agree on the seed for
+// their slices to be disjoint and jointly complete, so a constant is the safe
+// default.
+const shardDefaultSeed = int64(0x6e6161627520)
+
+// parseShard parses a masscan-style "index/total" shard descriptor (1-based).
+func parseShard(s string) (index, total int, err error) {
+	parts := strings.SplitN(strings.TrimSpace(s), "/", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid shard %q (want index/total, e.g. 1/4)", s)
+	}
+	index, err = strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid shard index %q: %w", parts[0], err)
+	}
+	total, err = strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid shard total %q: %w", parts[1], err)
+	}
+	if total < 1 || index < 1 || index > total {
+		return 0, 0, fmt.Errorf("invalid shard %d/%d (require 1 <= index <= total)", index, total)
+	}
+	return index, total, nil
+}
+
+// inShard reports whether a 0-based position in the scan space belongs to this
+// node's shard. When sharding is disabled (ShardTotal <= 1) everything is in.
+func (options *Options) inShard(pos int64) bool {
+	if options.ShardTotal <= 1 {
+		return true
+	}
+	return int(pos%int64(options.ShardTotal)) == options.Shard-1
+}
+
+// shardSeed returns the blackrock seed to use, preferring an explicit -seed,
+// then the fixed shard seed when sharding, then the supplied random seed.
+func (options *Options) shardSeed(randomSeed int64) int64 {
+	if options.Seed != 0 {
+		return options.Seed
+	}
+	if options.ShardTotal > 1 {
+		return shardDefaultSeed
+	}
+	return randomSeed
+}

--- a/pkg/runner/shard.go
+++ b/pkg/runner/shard.go
@@ -44,7 +44,7 @@ func (options *Options) inShard(pos int64) bool {
 // shardSeed returns the blackrock seed to use, preferring an explicit -seed,
 // then the fixed shard seed when sharding, then the supplied random seed.
 func (options *Options) shardSeed(randomSeed int64) int64 {
-	if options.Seed != 0 {
+	if options.SeedSet {
 		return options.Seed
 	}
 	if options.ShardTotal > 1 {

--- a/pkg/runner/shard_test.go
+++ b/pkg/runner/shard_test.go
@@ -1,0 +1,71 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseShard(t *testing.T) {
+	idx, total, err := parseShard("2/4")
+	require.NoError(t, err)
+	require.Equal(t, 2, idx)
+	require.Equal(t, 4, total)
+
+	idx, total, err = parseShard(" 1 / 3 ")
+	require.NoError(t, err)
+	require.Equal(t, 1, idx)
+	require.Equal(t, 3, total)
+}
+
+func TestParseShardErrors(t *testing.T) {
+	for _, s := range []string{"", "4", "1/0", "0/4", "5/4", "a/4", "1/b", "-1/4"} {
+		_, _, err := parseShard(s)
+		require.Error(t, err, "expected error for %q", s)
+	}
+}
+
+// TestInShardPartitionsCompletelyAndDisjointly verifies every index in the
+// space is claimed by exactly one shard, with no gaps or overlaps.
+func TestInShardPartitionsCompletelyAndDisjointly(t *testing.T) {
+	const total = 4
+	const space = int64(1000)
+
+	claims := make([]int, space)
+	for shard := 1; shard <= total; shard++ {
+		o := &Options{Shard: shard, ShardTotal: total}
+		for i := int64(0); i < space; i++ {
+			if o.inShard(i) {
+				claims[i]++
+			}
+		}
+	}
+	for i := int64(0); i < space; i++ {
+		require.Equal(t, 1, claims[i], "index %d must be claimed exactly once", i)
+	}
+}
+
+func TestInShardDisabled(t *testing.T) {
+	o := &Options{} // ShardTotal == 0
+	for i := int64(0); i < 100; i++ {
+		require.True(t, o.inShard(i))
+	}
+	o = &Options{Shard: 1, ShardTotal: 1}
+	for i := int64(0); i < 100; i++ {
+		require.True(t, o.inShard(i))
+	}
+}
+
+func TestShardSeed(t *testing.T) {
+	// Explicit seed always wins.
+	o := &Options{Seed: 42, ShardTotal: 4, Shard: 1}
+	require.EqualValues(t, 42, o.shardSeed(999))
+
+	// Sharding without explicit seed uses the fixed shared seed.
+	o = &Options{ShardTotal: 4, Shard: 1}
+	require.Equal(t, shardDefaultSeed, o.shardSeed(999))
+
+	// No sharding, no explicit seed: random seed passes through.
+	o = &Options{}
+	require.EqualValues(t, 999, o.shardSeed(999))
+}

--- a/pkg/runner/shard_test.go
+++ b/pkg/runner/shard_test.go
@@ -58,8 +58,12 @@ func TestInShardDisabled(t *testing.T) {
 
 func TestShardSeed(t *testing.T) {
 	// Explicit seed always wins.
-	o := &Options{Seed: 42, ShardTotal: 4, Shard: 1}
+	o := &Options{Seed: 42, SeedSet: true, ShardTotal: 4, Shard: 1}
 	require.EqualValues(t, 42, o.shardSeed(999))
+
+	// An explicit seed of 0 is honored rather than treated as "unset".
+	o = &Options{Seed: 0, SeedSet: true, ShardTotal: 4, Shard: 1}
+	require.EqualValues(t, 0, o.shardSeed(999))
 
 	// Sharding without explicit seed uses the fixed shared seed.
 	o = &Options{ShardTotal: 4, Shard: 1}

--- a/pkg/runner/smartscan.go
+++ b/pkg/runner/smartscan.go
@@ -181,7 +181,7 @@ func (r *Runner) scanSinglePortOnTargets(ctx context.Context, targets []*net.IPN
 
 		// fast IPv4 path: uint32 arithmetic, no big.Int
 		if useFastPath {
-			dstIP, ip, isV4 := tgtIdx.pickIPv4(ipIndex)
+			dstIP, ip, srcSum, isV4 := tgtIdx.pickIPv4(ipIndex)
 			if !isV4 {
 				// IPv6: fall back to standard path for this target.
 				ipStr := r.PickIP(targets, ipIndex)
@@ -216,7 +216,7 @@ func (r *Runner) scanSinglePortOnTargets(ctx context.Context, targets []*net.IPN
 			}
 
 			r.limiter.Take()
-			if err := sender.send(dstIP, uint16(p.Port)); err != nil {
+			if err := sender.send(dstIP, srcSum, uint16(p.Port)); err != nil {
 				gologger.Debug().Msgf("fast send error %s:%d: %s\n", ip, p.Port, err)
 			}
 			if r.options.EnableProgressBar {

--- a/pkg/runner/smartscan.go
+++ b/pkg/runner/smartscan.go
@@ -428,30 +428,84 @@ func (pq *portQueue) len() int {
 	return len(pq.items)
 }
 
-func buildPopularityRank() map[int]int {
-	rank := make(map[int]int, 1200)
-	idx := 1
-	for _, segment := range strings.Split(NmapTop1000, ",") {
+// mostCommonOpenPorts lists TCP ports in descending order of how often they are
+// actually found open, which is the ordering a popularity rank needs.
+//
+// This cannot be derived from NmapTop100/NmapTop1000: both are stored as
+// numerically sorted port lists, so they record *membership* of the top-N set
+// but carry no frequency information. Walking them in order therefore yields a
+// port-number rank, not a popularity rank - which used to give port 1 (tcpmux,
+// effectively never open) the single highest priority while HTTPS sat at rank 75
+// and 8080 at rank 728.
+var mostCommonOpenPorts = []int{
+	80, 23, 443, 21, 22, 25, 3389, 110, 445, 139,
+	143, 53, 135, 3306, 8080, 1723, 111, 995, 993, 5900,
+}
+
+// expandPortListOrdered expands a comma/range port string preserving the order
+// in which ports appear, so callers can derive a stable rank from it.
+func expandPortListOrdered(list string) []int {
+	ports := make([]int, 0, 1024)
+	for _, segment := range strings.Split(list, ",") {
 		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
 		if strings.Contains(segment, "-") {
-			parts := strings.Split(segment, "-")
-			start, err1 := strconv.Atoi(parts[0])
-			end, err2 := strconv.Atoi(parts[1])
-			if err1 != nil || err2 != nil {
+			parts := strings.SplitN(segment, "-", 2)
+			start, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+			end, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+			if err1 != nil || err2 != nil || end < start {
 				continue
 			}
 			for p := start; p <= end; p++ {
-				rank[p] = idx
-				idx++
+				ports = append(ports, p)
 			}
-		} else {
-			p, err := strconv.Atoi(segment)
-			if err != nil {
+			continue
+		}
+		p, err := strconv.Atoi(segment)
+		if err != nil {
+			continue
+		}
+		ports = append(ports, p)
+	}
+	return ports
+}
+
+// buildPopularityRank assigns each known port a rank, 1 being most likely open.
+// Priority is derived as 1/rank, so lower ranks must mean genuinely more common
+// ports.
+//
+// Ranking is tiered, because real frequency data is only available for the head
+// of the distribution:
+//
+//	tier 1 - mostCommonOpenPorts, in true frequency order
+//	tier 2 - remaining members of the nmap top-100 set
+//	tier 3 - remaining members of the nmap top-1000 set
+//
+// Within tiers 2 and 3 ports keep their numeric order. That is not a frequency
+// ordering, but the tier itself carries the signal and inventing an order would
+// be worse than admitting we do not have one.
+func buildPopularityRank() map[int]int {
+	rank := make(map[int]int, 1200)
+	idx := 1
+
+	assign := func(ports []int) {
+		for _, p := range ports {
+			if p < 1 || p > 65535 {
+				continue
+			}
+			if _, seen := rank[p]; seen {
 				continue
 			}
 			rank[p] = idx
 			idx++
 		}
 	}
+
+	assign(mostCommonOpenPorts)
+	assign(expandPortListOrdered(NmapTop100))
+	assign(expandPortListOrdered(NmapTop1000))
+
 	return rank
 }

--- a/pkg/runner/smartscan_rank_test.go
+++ b/pkg/runner/smartscan_rank_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildPopularityRank feeds priority = 1/rank, so a lower rank must mean a port
+// that is genuinely more often open. Before this was tiered, the rank came from
+// walking the numerically sorted NmapTop1000 string, which made it a port-number
+// rank: port 1 ranked first and HTTPS ranked 75th.
+func TestBuildPopularityRankOrdersByFrequencyNotPortNumber(t *testing.T) {
+	rank := buildPopularityRank()
+
+	t.Run("most common ports hold the head of the ranking", func(t *testing.T) {
+		for i, p := range mostCommonOpenPorts {
+			require.Equal(t, i+1, rank[p], "port %d should hold rank %d", p, i+1)
+		}
+	})
+
+	t.Run("common services outrank obscure low ports", func(t *testing.T) {
+		// port 1 (tcpmux) and 3 (compressnet) are in the top-1000 set by
+		// membership but are effectively never open.
+		for _, obscure := range []int{1, 3, 4, 6, 7, 9, 13, 17} {
+			for _, common := range []int{80, 443, 22, 3389, 8080, 3306} {
+				require.Less(t, rank[common], rank[obscure],
+					"port %d must outrank obscure port %d", common, obscure)
+			}
+		}
+	})
+
+	t.Run("top-100 members outrank top-1000-only members", func(t *testing.T) {
+		top100 := make(map[int]struct{})
+		for _, p := range expandPortListOrdered(NmapTop100) {
+			top100[p] = struct{}{}
+		}
+		worstTop100, bestTop1000Only := 0, 1<<30
+		for p := range top100 {
+			if rank[p] > worstTop100 {
+				worstTop100 = rank[p]
+			}
+		}
+		for _, p := range expandPortListOrdered(NmapTop1000) {
+			if _, ok := top100[p]; ok {
+				continue
+			}
+			if rank[p] < bestTop1000Only {
+				bestTop1000Only = rank[p]
+			}
+		}
+		require.Less(t, worstTop100, bestTop1000Only,
+			"every top-100 port must rank ahead of every top-1000-only port")
+	})
+
+	t.Run("ranks are dense and unique", func(t *testing.T) {
+		seen := make(map[int]int, len(rank))
+		for p, r := range rank {
+			require.NotContains(t, seen, r, "rank %d assigned to both %d and %d", r, seen[r], p)
+			seen[r] = p
+		}
+		require.Len(t, rank, len(expandPortListOrdered(NmapTop1000)),
+			"tiering must not add or drop ports relative to the top-1000 set")
+	})
+}
+
+func TestExpandPortListOrdered(t *testing.T) {
+	require.Equal(t, []int{80, 443, 8080}, expandPortListOrdered("80,443,8080"))
+	require.Equal(t, []int{20, 21, 22, 443}, expandPortListOrdered("20-22,443"))
+	require.Equal(t, []int{80}, expandPortListOrdered(" 80 , , bogus "))
+	require.Empty(t, expandPortListOrdered("500-400"), "reversed ranges are ignored")
+}

--- a/pkg/runner/targets.go
+++ b/pkg/runner/targets.go
@@ -174,6 +174,13 @@ func (r *Runner) AddTarget(target string) error {
 
 	host, port, hasPort := getPort(target)
 
+	// A non-IP host means real hostname output mapping is required, so the
+	// output path must consult the IP->hostname store. Pure IP/CIDR/ASN scans
+	// never reach here and keep the flag false, enabling the no-store fast path.
+	if !iputil.IsIP(host) {
+		r.hasHostnames.Store(true)
+	}
+
 	targetToResolve := target
 	if hasPort {
 		targetToResolve = host

--- a/pkg/runner/targets.go
+++ b/pkg/runner/targets.go
@@ -162,6 +162,9 @@ func (r *Runner) AddTarget(target string) error {
 					gologger.Debug().Msgf("reverse ptr failed for %s: %s\n", target, err)
 				} else {
 					metadata = strings.Trim(names[0], ".")
+					// a resolved PTR name means output must consult the
+					// IP->hostname store, so the no-store fast path is off.
+					r.hasHostnames.Store(true)
 				}
 			}
 			err := r.scanner.IPRanger.AddHostWithMetadata(target, metadata)

--- a/pkg/runner/timing.go
+++ b/pkg/runner/timing.go
@@ -19,8 +19,10 @@ var timingTemplates = map[int]timingPreset{
 	1: {rate: 100, retries: 1, timeout: 4 * time.Second, warmup: 4, threads: 10},
 	2: {rate: 400, retries: 2, timeout: 3 * time.Second, warmup: 3, threads: 15},
 	3: {rate: DefaultRateSynScan, retries: DefaultRetriesSynScan, timeout: DefaultPortTimeoutSynScan, warmup: defaultWarmUpTime, threads: DefaultThreadsNum},
-	4: {rate: 10000, retries: 2, timeout: 500 * time.Millisecond, warmup: 1, threads: 50},
-	5: {rate: 30000, retries: 1, timeout: 300 * time.Millisecond, warmup: 1, threads: 100},
+	// timeouts stay >= 500ms: GetTimeout() floors anything below that, which
+	// would otherwise silently clamp an aggressive preset back up to 1s.
+	4: {rate: 10000, retries: 2, timeout: 700 * time.Millisecond, warmup: 1, threads: 50},
+	5: {rate: 30000, retries: 1, timeout: 500 * time.Millisecond, warmup: 1, threads: 100},
 }
 
 // applyTimingTemplate applies the selected timing template, but only to knobs

--- a/pkg/runner/timing.go
+++ b/pkg/runner/timing.go
@@ -1,0 +1,49 @@
+package runner
+
+import "time"
+
+// timingPreset bundles the tuning knobs a timing template controls.
+type timingPreset struct {
+	rate    int
+	retries int
+	timeout time.Duration
+	warmup  int
+	threads int
+}
+
+// timingTemplates map nmap-style -T levels (0 paranoid .. 5 insane) to naabu
+// tuning. T3 mirrors naabu's historical defaults so the default behaviour is
+// unchanged when no template is given.
+var timingTemplates = map[int]timingPreset{
+	0: {rate: 10, retries: 1, timeout: 5 * time.Second, warmup: 5, threads: 5},
+	1: {rate: 100, retries: 1, timeout: 4 * time.Second, warmup: 4, threads: 10},
+	2: {rate: 400, retries: 2, timeout: 3 * time.Second, warmup: 3, threads: 15},
+	3: {rate: DefaultRateSynScan, retries: DefaultRetriesSynScan, timeout: DefaultPortTimeoutSynScan, warmup: defaultWarmUpTime, threads: DefaultThreadsNum},
+	4: {rate: 10000, retries: 2, timeout: 500 * time.Millisecond, warmup: 1, threads: 50},
+	5: {rate: 30000, retries: 1, timeout: 300 * time.Millisecond, warmup: 1, threads: 100},
+}
+
+// applyTimingTemplate applies the selected timing template, but only to knobs
+// the user left at their compile-time default - an explicitly set -rate /
+// -retries / -timeout / -warm-up-time / -c always wins over the template.
+func (options *Options) applyTimingTemplate() {
+	preset, ok := timingTemplates[options.TimingTemplate]
+	if !ok {
+		return
+	}
+	if options.Rate == DefaultRateSynScan {
+		options.Rate = preset.rate
+	}
+	if options.Retries == DefaultRetriesSynScan {
+		options.Retries = preset.retries
+	}
+	if options.Timeout == DefaultPortTimeoutSynScan {
+		options.Timeout = preset.timeout
+	}
+	if options.WarmUpTime == defaultWarmUpTime {
+		options.WarmUpTime = preset.warmup
+	}
+	if options.Threads == DefaultThreadsNum {
+		options.Threads = preset.threads
+	}
+}

--- a/pkg/runner/timing.go
+++ b/pkg/runner/timing.go
@@ -26,26 +26,36 @@ var timingTemplates = map[int]timingPreset{
 }
 
 // applyTimingTemplate applies the selected timing template, but only to knobs
-// the user left at their compile-time default - an explicitly set -rate /
-// -retries / -timeout / -warm-up-time / -c always wins over the template.
-func (options *Options) applyTimingTemplate() {
+// the user did not explicitly set - an explicitly set -rate / -retries /
+// -timeout / -warm-up-time / -c always wins over the template. setFlags holds the
+// long/short names the user actually provided on the CLI or via config, so a flag
+// set to a value that happens to equal the compile-time default is still honored.
+func (options *Options) applyTimingTemplate(setFlags map[string]struct{}) {
 	preset, ok := timingTemplates[options.TimingTemplate]
 	if !ok {
 		return
 	}
-	if options.Rate == DefaultRateSynScan {
+	set := func(names ...string) bool {
+		for _, n := range names {
+			if _, ok := setFlags[n]; ok {
+				return true
+			}
+		}
+		return false
+	}
+	if !set("rate") {
 		options.Rate = preset.rate
 	}
-	if options.Retries == DefaultRetriesSynScan {
+	if !set("retries") {
 		options.Retries = preset.retries
 	}
-	if options.Timeout == DefaultPortTimeoutSynScan {
+	if !set("timeout") {
 		options.Timeout = preset.timeout
 	}
-	if options.WarmUpTime == defaultWarmUpTime {
+	if !set("warm-up-time") {
 		options.WarmUpTime = preset.warmup
 	}
-	if options.Threads == DefaultThreadsNum {
+	if !set("c") {
 		options.Threads = preset.threads
 	}
 }

--- a/pkg/runner/timing_test.go
+++ b/pkg/runner/timing_test.go
@@ -1,0 +1,62 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func defaultTimedOptions() *Options {
+	return &Options{
+		Rate:       DefaultRateSynScan,
+		Retries:    DefaultRetriesSynScan,
+		Timeout:    DefaultPortTimeoutSynScan,
+		WarmUpTime: defaultWarmUpTime,
+		Threads:    DefaultThreadsNum,
+	}
+}
+
+func TestTimingTemplateT3IsNoOp(t *testing.T) {
+	o := defaultTimedOptions()
+	o.TimingTemplate = 3
+	o.applyTimingTemplate()
+	require.Equal(t, DefaultRateSynScan, o.Rate)
+	require.Equal(t, DefaultRetriesSynScan, o.Retries)
+	require.Equal(t, DefaultPortTimeoutSynScan, o.Timeout)
+	require.Equal(t, defaultWarmUpTime, o.WarmUpTime)
+	require.Equal(t, DefaultThreadsNum, o.Threads)
+}
+
+func TestTimingTemplateAggressiveOverridesDefaults(t *testing.T) {
+	o := defaultTimedOptions()
+	o.TimingTemplate = 5
+	o.applyTimingTemplate()
+	require.Equal(t, 30000, o.Rate)
+	require.Equal(t, 1, o.Retries)
+	require.Equal(t, 300*time.Millisecond, o.Timeout)
+	require.Equal(t, 1, o.WarmUpTime)
+	require.Equal(t, 100, o.Threads)
+}
+
+func TestTimingTemplateRespectsExplicitFlags(t *testing.T) {
+	o := defaultTimedOptions()
+	o.TimingTemplate = 5
+	// User explicitly set rate and timeout to non-default values.
+	o.Rate = 7777
+	o.Timeout = 2 * time.Second
+	o.applyTimingTemplate()
+	require.Equal(t, 7777, o.Rate, "explicit rate must win over template")
+	require.Equal(t, 2*time.Second, o.Timeout, "explicit timeout must win over template")
+	// Knobs left at default still take the template value.
+	require.Equal(t, 1, o.Retries)
+	require.Equal(t, 100, o.Threads)
+}
+
+func TestTimingTemplateOutOfRangeIsNoOp(t *testing.T) {
+	o := defaultTimedOptions()
+	o.TimingTemplate = 9
+	o.applyTimingTemplate()
+	require.Equal(t, DefaultRateSynScan, o.Rate)
+	require.Equal(t, DefaultThreadsNum, o.Threads)
+}

--- a/pkg/runner/timing_test.go
+++ b/pkg/runner/timing_test.go
@@ -34,9 +34,22 @@ func TestTimingTemplateAggressiveOverridesDefaults(t *testing.T) {
 	o.applyTimingTemplate()
 	require.Equal(t, 30000, o.Rate)
 	require.Equal(t, 1, o.Retries)
-	require.Equal(t, 300*time.Millisecond, o.Timeout)
+	require.Equal(t, 500*time.Millisecond, o.Timeout)
 	require.Equal(t, 1, o.WarmUpTime)
 	require.Equal(t, 100, o.Threads)
+}
+
+// TestTimingTemplatesNotClampedByGetTimeout guards against presets whose
+// timeout falls below the GetTimeout() floor and would be silently raised.
+func TestTimingTemplatesNotClampedByGetTimeout(t *testing.T) {
+	for level := 0; level <= 5; level++ {
+		o := defaultTimedOptions()
+		o.ScanType = SynScan
+		o.TimingTemplate = level
+		o.applyTimingTemplate()
+		require.Equalf(t, o.Timeout, o.GetTimeout(),
+			"template T%d timeout %s must survive the GetTimeout floor", level, o.Timeout)
+	}
 }
 
 func TestTimingTemplateRespectsExplicitFlags(t *testing.T) {

--- a/pkg/runner/timing_test.go
+++ b/pkg/runner/timing_test.go
@@ -20,7 +20,7 @@ func defaultTimedOptions() *Options {
 func TestTimingTemplateT3IsNoOp(t *testing.T) {
 	o := defaultTimedOptions()
 	o.TimingTemplate = 3
-	o.applyTimingTemplate()
+	o.applyTimingTemplate(nil)
 	require.Equal(t, DefaultRateSynScan, o.Rate)
 	require.Equal(t, DefaultRetriesSynScan, o.Retries)
 	require.Equal(t, DefaultPortTimeoutSynScan, o.Timeout)
@@ -31,7 +31,7 @@ func TestTimingTemplateT3IsNoOp(t *testing.T) {
 func TestTimingTemplateAggressiveOverridesDefaults(t *testing.T) {
 	o := defaultTimedOptions()
 	o.TimingTemplate = 5
-	o.applyTimingTemplate()
+	o.applyTimingTemplate(nil)
 	require.Equal(t, 30000, o.Rate)
 	require.Equal(t, 1, o.Retries)
 	require.Equal(t, 500*time.Millisecond, o.Timeout)
@@ -46,7 +46,7 @@ func TestTimingTemplatesNotClampedByGetTimeout(t *testing.T) {
 		o := defaultTimedOptions()
 		o.ScanType = SynScan
 		o.TimingTemplate = level
-		o.applyTimingTemplate()
+		o.applyTimingTemplate(nil)
 		require.Equalf(t, o.Timeout, o.GetTimeout(),
 			"template T%d timeout %s must survive the GetTimeout floor", level, o.Timeout)
 	}
@@ -58,7 +58,7 @@ func TestTimingTemplateRespectsExplicitFlags(t *testing.T) {
 	// User explicitly set rate and timeout to non-default values.
 	o.Rate = 7777
 	o.Timeout = 2 * time.Second
-	o.applyTimingTemplate()
+	o.applyTimingTemplate(map[string]struct{}{"rate": {}, "timeout": {}})
 	require.Equal(t, 7777, o.Rate, "explicit rate must win over template")
 	require.Equal(t, 2*time.Second, o.Timeout, "explicit timeout must win over template")
 	// Knobs left at default still take the template value.
@@ -66,10 +66,24 @@ func TestTimingTemplateRespectsExplicitFlags(t *testing.T) {
 	require.Equal(t, 100, o.Threads)
 }
 
+// TestTimingTemplateHonorsExplicitDefaultValue ensures a flag the user set to a
+// value that happens to equal the compile-time default still wins over the
+// template. The previous value-comparison logic silently overrode it.
+func TestTimingTemplateHonorsExplicitDefaultValue(t *testing.T) {
+	o := defaultTimedOptions()
+	o.TimingTemplate = 5
+	// User explicitly passed -c <DefaultThreadsNum>; it must not be bumped to 100.
+	o.Threads = DefaultThreadsNum
+	o.applyTimingTemplate(map[string]struct{}{"c": {}})
+	require.Equal(t, DefaultThreadsNum, o.Threads, "explicit -c equal to default must win over template")
+	// Knobs the user did not set still take the template value.
+	require.Equal(t, 30000, o.Rate)
+}
+
 func TestTimingTemplateOutOfRangeIsNoOp(t *testing.T) {
 	o := defaultTimedOptions()
 	o.TimingTemplate = 9
-	o.applyTimingTemplate()
+	o.applyTimingTemplate(nil)
 	require.Equal(t, DefaultRateSynScan, o.Rate)
 	require.Equal(t, DefaultThreadsNum, o.Threads)
 }

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -60,7 +60,7 @@ func (options *Options) ValidateOptions() error {
 	}
 
 	if options.TxWorkers < 0 || options.TxWorkers > 256 {
-		return fmt.Errorf("invalid tx-workers %d (valid range 1-256)", options.TxWorkers)
+		return fmt.Errorf("invalid tx-workers %d (valid range 0-256, 0 = default)", options.TxWorkers)
 	}
 
 	if options.Rate == 0 {

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -59,6 +59,10 @@ func (options *Options) ValidateOptions() error {
 		return fmt.Errorf("invalid shard %d/%d (require 1 <= index <= total)", options.Shard, options.ShardTotal)
 	}
 
+	if options.TxWorkers < 0 || options.TxWorkers > 256 {
+		return fmt.Errorf("invalid tx-workers %d (valid range 1-256)", options.TxWorkers)
+	}
+
 	if options.Rate == 0 {
 		return errkit.Wrap(errZeroValue, "rate")
 	} else if !privileges.IsPrivileged && options.Rate == DefaultRateSynScan {

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -55,6 +55,10 @@ func (options *Options) ValidateOptions() error {
 		return fmt.Errorf("invalid timing template %d (valid range 0-5)", options.TimingTemplate)
 	}
 
+	if options.ShardTotal != 0 && (options.ShardTotal < 1 || options.Shard < 1 || options.Shard > options.ShardTotal) {
+		return fmt.Errorf("invalid shard %d/%d (require 1 <= index <= total)", options.Shard, options.ShardTotal)
+	}
+
 	if options.Rate == 0 {
 		return errkit.Wrap(errZeroValue, "rate")
 	} else if !privileges.IsPrivileged && options.Rate == DefaultRateSynScan {

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -195,6 +195,26 @@ func (options *Options) ValidateOptions() error {
 }
 
 // configureOutput configures the output on the screen
+// expandOutputAll turns -oA <base> into the three concrete output targets
+// (<base>.json, <base>.xml, <base>.gnmap). Explicitly set -o/-oX/-oG win so the
+// user can override any single target.
+func (options *Options) expandOutputAll() {
+	base := strings.TrimSpace(options.OutputAll)
+	if base == "" {
+		return
+	}
+	if options.Output == "" {
+		options.Output = base + ".json"
+		options.JSON = true
+	}
+	if options.XMLOutput == "" {
+		options.XMLOutput = base + ".xml"
+	}
+	if options.GrepOutput == "" {
+		options.GrepOutput = base + ".gnmap"
+	}
+}
+
 func (options *Options) configureOutput() {
 	if options.Verbose {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelVerbose)

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -51,6 +51,10 @@ func (options *Options) ValidateOptions() error {
 		return errTwoOutputMode
 	}
 
+	if options.TimingTemplate < 0 || options.TimingTemplate > 5 {
+		return fmt.Errorf("invalid timing template %d (valid range 0-5)", options.TimingTemplate)
+	}
+
 	if options.Rate == 0 {
 		return errkit.Wrap(errZeroValue, "rate")
 	} else if !privileges.IsPrivileged && options.Rate == DefaultRateSynScan {

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -204,8 +204,14 @@ func (options *Options) expandOutputAll() {
 		return
 	}
 	if options.Output == "" {
-		options.Output = base + ".json"
-		options.JSON = true
+		// Honor an explicit -csv so -oA does not force JSON and then trip the
+		// "json and csv both specified" validation error.
+		if options.CSV {
+			options.Output = base + ".csv"
+		} else {
+			options.Output = base + ".json"
+			options.JSON = true
+		}
 	}
 	if options.XMLOutput == "" {
 		options.XMLOutput = base + ".xml"

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -59,6 +59,19 @@ func (options *Options) ValidateOptions() error {
 		return fmt.Errorf("invalid shard %d/%d (require 1 <= index <= total)", options.Shard, options.ShardTotal)
 	}
 
+	// Sharding partitions the (host, port) index space, but the smart-scan and
+	// stream paths do not consult inShard, so combining them would make every
+	// node scan the full space (duplicated work, not a partition). Reject it
+	// rather than silently mis-sharding.
+	if options.ShardTotal > 1 {
+		if options.SmartScan {
+			return fmt.Errorf("-shard is not supported with -smart-scan")
+		}
+		if options.Stream {
+			return fmt.Errorf("-shard is not supported with -stream")
+		}
+	}
+
 	if options.TxWorkers < 0 || options.TxWorkers > 256 {
 		return fmt.Errorf("invalid tx-workers %d (valid range 0-256, 0 = default)", options.TxWorkers)
 	}

--- a/pkg/runner/validate_test.go
+++ b/pkg/runner/validate_test.go
@@ -25,6 +25,55 @@ func TestOptions(t *testing.T) {
 	assert.EqualError(t, options.ValidateOptions(), "connect payload can only be used with connect scan")
 }
 
+func TestValidateTimingShardTxRanges(t *testing.T) {
+	base := Options{
+		Host:     []string{"example.com"},
+		Rate:     1000,
+		DnsOrder: "l",
+		ScanType: ConnectScan,
+	}
+
+	t.Run("valid defaults", func(t *testing.T) {
+		o := base
+		assert.Nil(t, o.ValidateOptions())
+	})
+	t.Run("timing too high", func(t *testing.T) {
+		o := base
+		o.TimingTemplate = 6
+		assert.ErrorContains(t, o.ValidateOptions(), "timing template")
+	})
+	t.Run("timing negative", func(t *testing.T) {
+		o := base
+		o.TimingTemplate = -1
+		assert.ErrorContains(t, o.ValidateOptions(), "timing template")
+	})
+	t.Run("shard index out of range", func(t *testing.T) {
+		o := base
+		o.Shard, o.ShardTotal = 5, 4
+		assert.ErrorContains(t, o.ValidateOptions(), "invalid shard")
+	})
+	t.Run("shard index zero", func(t *testing.T) {
+		o := base
+		o.Shard, o.ShardTotal = 0, 4
+		assert.ErrorContains(t, o.ValidateOptions(), "invalid shard")
+	})
+	t.Run("valid shard", func(t *testing.T) {
+		o := base
+		o.Shard, o.ShardTotal = 2, 4
+		assert.Nil(t, o.ValidateOptions())
+	})
+	t.Run("tx workers too high", func(t *testing.T) {
+		o := base
+		o.TxWorkers = 300
+		assert.ErrorContains(t, o.ValidateOptions(), "tx-workers")
+	})
+	t.Run("tx workers negative", func(t *testing.T) {
+		o := base
+		o.TxWorkers = -1
+		assert.ErrorContains(t, o.ValidateOptions(), "tx-workers")
+	})
+}
+
 func TestDnsOrderValidation(t *testing.T) {
 	base := Options{
 		Host:     []string{"example.com"},

--- a/pkg/scan/icmp.go
+++ b/pkg/scan/icmp.go
@@ -108,6 +108,13 @@ func PingIcmpEchoRequestAsync(ip string) {
 		destAddr = &net.UDPAddr{IP: destinationIP, Zone: networkInterface.Name}
 	}
 
+	// packetListener is nil when the matching icmp socket failed to open at
+	// init (logged at debug) or when ip is neither v4 nor v6; without this
+	// guard the WriteTo below panics on a nil PacketConn.
+	if packetListener == nil || destAddr == nil {
+		return
+	}
+
 	data, err := m.Marshal(nil)
 	if err != nil {
 		return

--- a/pkg/scan/icmp.go
+++ b/pkg/scan/icmp.go
@@ -97,6 +97,9 @@ func PingIcmpEchoRequestAsync(ip string) {
 	case iputil.IsIPv6(ip):
 		m.Type = ipv6.ICMPTypeEchoRequest
 		packetListener = icmpConn6
+		if PkgRouter == nil {
+			return
+		}
 		networkInterface, _, _, err := PkgRouter.Route(destinationIP)
 		if networkInterface == nil {
 			err = fmt.Errorf("could not send ICMP Echo Request packet to %s: no interface with outbout source ipv6 found", destinationIP)

--- a/pkg/scan/ndp.go
+++ b/pkg/scan/ndp.go
@@ -38,6 +38,11 @@ func PingNdpRequestAsync(ip string) {
 	if err != nil {
 		return
 	}
+	// icmpConn6 is nil when the ip6:icmp socket failed to open at init;
+	// guard against the nil-pointer WriteTo below.
+	if icmpConn6 == nil {
+		return
+	}
 	retries := 0
 send:
 	if retries >= maxRetries {

--- a/pkg/scan/ndp.go
+++ b/pkg/scan/ndp.go
@@ -15,6 +15,11 @@ import (
 
 // PingNdpRequestAsync asynchronous to the target ip address
 func PingNdpRequestAsync(ip string) {
+	// PkgRouter/icmpConn6 are nil when routing or the ip6:icmp socket failed to
+	// initialize; guard before dereferencing so this cannot panic.
+	if PkgRouter == nil || icmpConn6 == nil {
+		return
+	}
 	networkInterface, _, _, err := PkgRouter.Route(net.ParseIP(ip))
 	if networkInterface == nil {
 		err = errors.New("Could not send PingNdp Request packet to " + ip + ": no interface with outbound source found")

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -30,10 +30,19 @@ type State int
 const (
 	maxRetries     = 10
 	sendDelayMsec  = 10
-	chanSize       = 1000  //nolint
-	packetSendSize = 2500  //nolint
-	snaplen        = 65536 //nolint
-	readtimeout    = 1500  //nolint
+	chanSize       = 1000 //nolint
+	packetSendSize = 2500 //nolint
+	// snaplen only needs to cover ethernet + IPv6 + TCP/IP options; we read
+	// transport headers, never payloads. On Linux the AF_PACKET ring sizes its
+	// frame slots from snaplen, so a small value lets the capture buffer hold
+	// far more packets and survive reply bursts from large port ranges.
+	snaplen = 256 //nolint
+	// pcapBufferSize is the kernel capture buffer per handle. The default is a
+	// few MB; a SYN scan over thousands of ports triggers a burst of RST/SYN-ACK
+	// replies, and an undersized buffer silently drops them. masscan/zmap use
+	// large buffers for the same reason.
+	pcapBufferSize = 16 * 1024 * 1024
+	readtimeout    = 1500 //nolint
 
 	// icmpWriteWorkers controls how many goroutines drain icmpPacketSend.
 	// A single worker serialises every WriteTo retry-sleep and made

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -104,12 +104,15 @@ type Scanner struct {
 	ScanType             string
 	ListenHandler        *ListenHandler
 	OnReceive            result.ResultFn
-	workersWg            sync.WaitGroup
+	workersWg sync.WaitGroup
 	// cancelWorkers cancels the context that drives the result workers so that
 	// Close can release them even when the scan context has not been cancelled
 	// yet (e.g. Close called out of order or on early teardown). Without it
 	// Close blocks forever on workersWg.Wait.
 	cancelWorkers context.CancelFunc
+	// closeOnce makes Close idempotent so a second call does not panic on the
+	// already-niled ListenHandler or double-cancel.
+	closeOnce sync.Once
 	// UDPProbeProvider supplies per-port UDP payloads when the
 	// scanner runs in -uP mode. Keeping it on the Scanner (rather
 	// than as a package-global) lets independent runners coexist in
@@ -221,14 +224,16 @@ func NewScanner(options *Options) (*Scanner, error) {
 
 // Close the scanner and terminate all workers
 func (s *Scanner) Close() error {
-	if s.cancelWorkers != nil {
-		s.cancelWorkers()
-	}
-	s.workersWg.Wait()
-	if s.ListenHandler != nil {
-		s.ListenHandler.Busy = false
-		s.ListenHandler = nil
-	}
+	s.closeOnce.Do(func() {
+		if s.cancelWorkers != nil {
+			s.cancelWorkers()
+		}
+		s.workersWg.Wait()
+		if s.ListenHandler != nil {
+			s.ListenHandler.Release()
+			s.ListenHandler = nil
+		}
+	})
 
 	return nil
 }

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -321,13 +321,13 @@ func (s *Scanner) TCPResultWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case ip := <-s.ListenHandler.TcpChan:
-			srcIP4WithPort := net.JoinHostPort(ip.ipv4, ip.port.String())
-			srcIP6WithPort := net.JoinHostPort(ip.ipv6, ip.port.String())
-			isIPInRange := s.IPRanger.ContainsAny(srcIP4WithPort, srcIP6WithPort, ip.ipv4, ip.ipv6)
-			if !isIPInRange {
-				gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s\n", ip.ipv4, ip.ipv6)
-				continue
-			}
+			// Reply authenticity is enforced upstream by the SYN-cookie check
+			// in the raw read path: a SYN-ACK only reaches this channel if its
+			// Ack matched the cookie we encoded into the probe's sequence
+			// number. That is a stronger guarantee than a target-set membership
+			// lookup (which also accepts unrelated in-range traffic) and it
+			// avoids the per-response disk-backed Hosts lookups, so no
+			// IPRanger.ContainsAny check is needed here.
 
 			if s.OnReceive != nil {
 				singlePort := []*port.Port{ip.port}

--- a/pkg/scan/scan_common.go
+++ b/pkg/scan/scan_common.go
@@ -30,11 +30,17 @@ var (
 	NumberOfHandlers = 1
 	tcpsequencer     = NewTCPSequencer()
 
-	// listenHandlersMu serialises pool claim/return. Without it two
-	// concurrent NewScanner calls (embedded/parallel use) can race on the
-	// Busy flag and hand the same ListenHandler to both, sharing its source
-	// port, channels and phase.
-	listenHandlersMu sync.Mutex
+	// listenHandlersMu guards the on-demand ListenHandlers registry against the
+	// global pcap/icmp readers that iterate it concurrently with Acquire and
+	// Release.
+	listenHandlersMu sync.RWMutex
+
+	// buildHandlerFn and ensureRawInfraFn are wired by the raw-socket build
+	// (scan_raw.go) so Acquire here can create handlers on demand without this
+	// file referencing platform-constrained symbols. They are nil on platforms
+	// without raw-socket support, where Acquire falls back to a plain handler.
+	buildHandlerFn   func() (*ListenHandler, error)
+	ensureRawInfraFn func() bool
 )
 
 type ListenHandler struct {
@@ -59,19 +65,24 @@ func NewListenHandler() *ListenHandler {
 }
 
 func Acquire(options *Options) (*ListenHandler, error) {
-	// Only attempt to use pooled raw-socket handlers for explicit SYN scans
-	// where the raw packet infrastructure is available and we have privileges.
-	if PkgRouter != nil && privileges.IsPrivileged && options.ScanType == TypeSyn {
-		listenHandlersMu.Lock()
-		defer listenHandlersMu.Unlock()
-		for _, listenHandler := range ListenHandlers {
-			if !listenHandler.Busy {
-				listenHandler.Phase = &Phase{}
-				listenHandler.Busy = true
-				return listenHandler, nil
-			}
+	// Privileged SYN scans get a freshly built raw-socket handler with its own
+	// source port, channels and drain workers. Building on demand (rather than
+	// from a fixed pre-allocated pool) means nothing is allocated until a SYN
+	// scan actually runs, there is no fixed concurrency cap, and Release can
+	// fully tear the handler down afterwards.
+	if PkgRouter != nil && privileges.IsPrivileged && options.ScanType == TypeSyn && buildHandlerFn != nil {
+		if ensureRawInfraFn != nil && !ensureRawInfraFn() {
+			return nil, errors.New("could not initialize raw scan infrastructure")
 		}
-		return nil, errors.New("no free handlers")
+		h, err := buildHandlerFn()
+		if err != nil {
+			return nil, err
+		}
+		h.Busy = true
+		listenHandlersMu.Lock()
+		ListenHandlers = append(ListenHandlers, h)
+		listenHandlersMu.Unlock()
+		return h, nil
 	}
 
 	h := NewListenHandler()
@@ -79,14 +90,32 @@ func Acquire(options *Options) (*ListenHandler, error) {
 	return h, nil
 }
 
+// Release returns a handler at the end of a scan: it is removed from the
+// registry the readers consult and its raw sockets are closed, which also stops
+// its drain workers. Safe to call on a plain (non-raw) handler.
 func (l *ListenHandler) Release() {
 	listenHandlersMu.Lock()
-	defer listenHandlersMu.Unlock()
+	for i, h := range ListenHandlers {
+		if h == l {
+			ListenHandlers = append(ListenHandlers[:i], ListenHandlers[i+1:]...)
+			break
+		}
+	}
+	listenHandlersMu.Unlock()
+
 	l.Busy = false
-	// Keep a valid (idle) Phase rather than nil: a released handler stays in
-	// the pool and the global pcap reader still dereferences Phase for any
-	// stray packet that matches its port, which would panic on nil.
 	l.Phase = &Phase{}
+	l.teardown()
+}
+
+// teardown closes the handler's raw sockets. Closing the conns unblocks and
+// terminates the per-handler drain goroutines started in buildListenHandler.
+func (l *ListenHandler) teardown() {
+	for _, c := range []*net.IPConn{l.TcpConn4, l.UdpConn4, l.TcpConn6, l.UdpConn6} {
+		if c != nil {
+			_ = c.Close()
+		}
+	}
 }
 
 func init() {

--- a/pkg/scan/scan_common.go
+++ b/pkg/scan/scan_common.go
@@ -44,11 +44,16 @@ var (
 )
 
 type ListenHandler struct {
-	Busy                                   bool
-	Phase                                  *Phase
-	SourceHW                               net.HardwareAddr
-	SourceIp4                              net.IP
-	SourceIP6                              net.IP
+	Busy      bool
+	Phase     *Phase
+	SourceHW  net.HardwareAddr
+	SourceIp4 net.IP
+	SourceIP6 net.IP
+	// SourceBound reports that the raw transport sockets were successfully bound
+	// to SourceIp4/SourceIP6, so the kernel emits packets with that source. When
+	// set, the faithful-but-fragile L2 (ethernet) send path is skipped in favour
+	// of the bound fast/raw path.
+	SourceBound                            bool
 	Port                                   int
 	TcpConn4, UdpConn4, TcpConn6, UdpConn6 *net.IPConn
 	TcpChan, UdpChan, HostDiscoveryChan    chan *PkgResult

--- a/pkg/scan/scan_common.go
+++ b/pkg/scan/scan_common.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"errors"
 	"net"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
@@ -28,6 +29,12 @@ var (
 	InitScanner      func(s *Scanner) error
 	NumberOfHandlers = 1
 	tcpsequencer     = NewTCPSequencer()
+
+	// listenHandlersMu serialises pool claim/return. Without it two
+	// concurrent NewScanner calls (embedded/parallel use) can race on the
+	// Busy flag and hand the same ListenHandler to both, sharing its source
+	// port, channels and phase.
+	listenHandlersMu sync.Mutex
 )
 
 type ListenHandler struct {
@@ -55,6 +62,8 @@ func Acquire(options *Options) (*ListenHandler, error) {
 	// Only attempt to use pooled raw-socket handlers for explicit SYN scans
 	// where the raw packet infrastructure is available and we have privileges.
 	if PkgRouter != nil && privileges.IsPrivileged && options.ScanType == TypeSyn {
+		listenHandlersMu.Lock()
+		defer listenHandlersMu.Unlock()
 		for _, listenHandler := range ListenHandlers {
 			if !listenHandler.Busy {
 				listenHandler.Phase = &Phase{}
@@ -71,8 +80,13 @@ func Acquire(options *Options) (*ListenHandler, error) {
 }
 
 func (l *ListenHandler) Release() {
+	listenHandlersMu.Lock()
+	defer listenHandlersMu.Unlock()
 	l.Busy = false
-	l.Phase = nil
+	// Keep a valid (idle) Phase rather than nil: a released handler stays in
+	// the pool and the global pcap reader still dereferences Phase for any
+	// stray packet that matches its port, which would panic on nil.
+	l.Phase = &Phase{}
 }
 
 func init() {

--- a/pkg/scan/scan_common.go
+++ b/pkg/scan/scan_common.go
@@ -49,11 +49,11 @@ type ListenHandler struct {
 	SourceHW  net.HardwareAddr
 	SourceIp4 net.IP
 	SourceIP6 net.IP
-	// SourceBound reports that the raw transport sockets were successfully bound
-	// to SourceIp4/SourceIP6, so the kernel emits packets with that source. When
-	// set, the faithful-but-fragile L2 (ethernet) send path is skipped in favour
-	// of the bound fast/raw path.
-	SourceBound                            bool
+	// SourceBound4/SourceBound6 report that the corresponding raw transport sockets
+	// were successfully bound to SourceIp4/SourceIP6 so the kernel emits packets
+	// with that source. Tracked per family so a successful IPv6 bind cannot make
+	// the IPv4 path skip L2 fallback (or vice versa).
+	SourceBound4, SourceBound6              bool
 	Port                                   int
 	TcpConn4, UdpConn4, TcpConn6, UdpConn6 *net.IPConn
 	TcpChan, UdpChan, HostDiscoveryChan    chan *PkgResult

--- a/pkg/scan/scan_common.go
+++ b/pkg/scan/scan_common.go
@@ -57,6 +57,13 @@ type ListenHandler struct {
 	Port                                   int
 	TcpConn4, UdpConn4, TcpConn6, UdpConn6 *net.IPConn
 	TcpChan, UdpChan, HostDiscoveryChan    chan *PkgResult
+	// done is closed by teardown so the shared reader can deliver replies with a
+	// blocking send (no result dropped while the handler is alive) yet abandon the
+	// send the moment the handler is released, instead of stalling every handler.
+	// doneOnce is a pointer so the transmit-worker handler copy in newWorkerSYNSender
+	// does not copy a lock value.
+	done     chan struct{}
+	doneOnce *sync.Once
 	// UDPProbeProvider is the per-handler probe source used by the
 	// raw UDP send path. It is copied here from the owning Scanner so
 	// sendAsyncUDP4/6 do not need a Scanner reference; nil means "no
@@ -66,7 +73,7 @@ type ListenHandler struct {
 }
 
 func NewListenHandler() *ListenHandler {
-	return &ListenHandler{Phase: &Phase{}}
+	return &ListenHandler{Phase: &Phase{}, done: make(chan struct{}), doneOnce: &sync.Once{}}
 }
 
 func Acquire(options *Options) (*ListenHandler, error) {
@@ -109,13 +116,19 @@ func (l *ListenHandler) Release() {
 	listenHandlersMu.Unlock()
 
 	l.Busy = false
-	l.Phase = &Phase{}
+	// Phase is intentionally left as-is: handlers are built fresh per scan and
+	// discarded after Release, and the shared reader may still hold this handler
+	// in an in-flight snapshot, so reassigning Phase here would be an unsynchronized
+	// write racing that reader's Phase.Is check.
 	l.teardown()
 }
 
 // teardown closes the handler's raw sockets. Closing the conns unblocks and
 // terminates the per-handler drain goroutines started in buildListenHandler.
 func (l *ListenHandler) teardown() {
+	if l.done != nil && l.doneOnce != nil {
+		l.doneOnce.Do(func() { close(l.done) })
+	}
 	for _, c := range []*net.IPConn{l.TcpConn4, l.UdpConn4, l.TcpConn6, l.UdpConn6} {
 		if c != nil {
 			_ = c.Close()

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -226,7 +226,7 @@ func sendAsyncTCP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 	// Windows cannot open raw IPPROTO_TCP sockets; always send via Npcap L2.
 	usePcap := listenHandler.TcpConn4 == nil || (hasSourceIp && listenHandler.SourceHW != nil)
 	var iface *net.Interface
-	if hasSourceIp && listenHandler.SourceHW != nil {
+	if hasSourceIp && listenHandler.SourceHW != nil && !listenHandler.SourceBound {
 		// NOTE(dwisiswant0): Only attempt to use ethernet framing if we have
 		// both source IP and HW.
 		itf, gateway, _, err := PkgRouter.RouteWithSrc(listenHandler.SourceHW, listenHandler.SourceIp4, ip4.DstIP)
@@ -696,6 +696,77 @@ func sendWithHandler(destIP string, iface *net.Interface, l ...gopacket.Serializ
 	}
 
 	return nil
+}
+
+// BindSourceIP rebinds the raw v4/v6 transport sockets to the given source
+// addresses so the kernel emits packets with that source. The fast SYN sender
+// and the plain raw send only write the transport header and otherwise let the
+// kernel pick the source by route, so without this an explicit -source-ip is
+// ignored. A nil address (or one this host does not own) leaves that family on
+// its original 0.0.0.0/:: socket. Affected drain workers are restarted.
+//
+// It is a no-op on plain (non-raw) handlers that have no transport sockets.
+func (l *ListenHandler) BindSourceIP(v4, v6 net.IP) {
+	if v4 != nil && l.TcpConn4 != nil {
+		if l.rebind4(v4) {
+			l.SourceBound = true
+		}
+	}
+	if v6 != nil && l.TcpConn6 != nil {
+		if l.rebind6(v6) {
+			l.SourceBound = true
+		}
+	}
+}
+
+func (l *ListenHandler) rebind4(ip net.IP) bool {
+	tcp, err := net.ListenIP("ip4:tcp", &net.IPAddr{IP: ip})
+	if err != nil {
+		gologger.Warning().Msgf("could not bind source ip %s, using route source: %s\n", ip, err)
+		return false
+	}
+	udp, err := net.ListenIP("ip4:udp", &net.IPAddr{IP: ip})
+	if err != nil {
+		_ = tcp.Close()
+		gologger.Warning().Msgf("could not bind source ip %s, using route source: %s\n", ip, err)
+		return false
+	}
+	if l.TcpConn4 != nil {
+		_ = l.TcpConn4.Close()
+	}
+	if l.UdpConn4 != nil {
+		_ = l.UdpConn4.Close()
+	}
+	l.TcpConn4 = tcp
+	l.UdpConn4 = udp
+	go l.TcpReadWorker4()
+	go l.UdpReadWorker4()
+	return true
+}
+
+func (l *ListenHandler) rebind6(ip net.IP) bool {
+	tcp, err := net.ListenIP("ip6:tcp", &net.IPAddr{IP: ip})
+	if err != nil {
+		gologger.Warning().Msgf("could not bind source ip %s, using route source: %s\n", ip, err)
+		return false
+	}
+	udp, err := net.ListenIP("ip6:udp", &net.IPAddr{IP: ip})
+	if err != nil {
+		_ = tcp.Close()
+		gologger.Warning().Msgf("could not bind source ip %s, using route source: %s\n", ip, err)
+		return false
+	}
+	if l.TcpConn6 != nil {
+		_ = l.TcpConn6.Close()
+	}
+	if l.UdpConn6 != nil {
+		_ = l.UdpConn6.Close()
+	}
+	l.TcpConn6 = tcp
+	l.UdpConn6 = udp
+	go l.TcpReadWorker6()
+	go l.UdpReadWorker6()
+	return true
 }
 
 func (l *ListenHandler) TcpReadWorker4() {

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -417,18 +417,14 @@ func sendAsyncTCP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		NextHeader: layers.IPProtocolTCP,
 	}
 
-	_, _, sourceIP, err := PkgRouter.Route(ip6.DstIP)
-	if err != nil {
-		gologger.Debug().Msgf("could not find route to host %s:%d: %s\n", ip, p.Port, err)
-		return
-	} else if sourceIP == nil {
-		gologger.Debug().Msgf("could not find correct source ipv6 for %s:%d\n", ip, p.Port)
-		return
-	}
-
 	if listenHandler.SourceIP6 != nil {
 		ip6.SrcIP = listenHandler.SourceIP6
 	} else {
+		sourceIP := sourceIP6For(ip6.DstIP)
+		if sourceIP == nil {
+			gologger.Debug().Msgf("could not find correct source ipv6 for %s:%d\n", ip, p.Port)
+			return
+		}
 		ip6.SrcIP = sourceIP
 	}
 
@@ -438,10 +434,14 @@ func sendAsyncTCP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		OptionData:   []byte{0x05, 0xB4},
 	}
 
-	seq := tcpsequencer.Next()
+	// SYN uses a cookie so the receive path can verify the returning SYN-ACK;
+	// other flags use the monotonic sequencer. Computing only the one needed
+	// avoids a wasted atomic increment on the SYN hot path.
+	var seq uint32
 	if pkgFlag == Syn {
-		// SYN cookie: lets the receive path verify the returning SYN-ACK.
 		seq = SynCookie(ip6.DstIP, uint16(p.Port), uint16(listenHandler.Port))
+	} else {
+		seq = tcpsequencer.Next()
 	}
 
 	tcp := layers.TCP{
@@ -459,8 +459,7 @@ func sendAsyncTCP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		tcp.ACK = true
 	}
 
-	err = tcp.SetNetworkLayerForChecksum(&ip6)
-	if err != nil {
+	if err := tcp.SetNetworkLayerForChecksum(&ip6); err != nil {
 		gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
 	} else {
 		if listenHandler.TcpConn6 == nil {
@@ -468,8 +467,7 @@ func sendAsyncTCP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 			return
 		}
 
-		err = sendWithConn(ip, listenHandler.TcpConn6, &tcp)
-		if err != nil {
+		if err := sendWithConnAddr(&net.IPAddr{IP: ip6.DstIP}, listenHandler.TcpConn6, &tcp); err != nil {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 		}
 	}
@@ -484,18 +482,14 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		NextHeader: layers.IPProtocolUDP,
 	}
 
-	_, _, sourceIP, err := PkgRouter.Route(ip6.DstIP)
-	if err != nil {
-		gologger.Debug().Msgf("could not find route to host %s:%d: %s\n", ip, p.Port, err)
-		return
-	} else if sourceIP == nil {
-		gologger.Debug().Msgf("could not find correct source ipv6 for %s:%d\n", ip, p.Port)
-		return
-	}
-
 	if listenHandler.SourceIP6 != nil {
 		ip6.SrcIP = listenHandler.SourceIP6
 	} else {
+		sourceIP := sourceIP6For(ip6.DstIP)
+		if sourceIP == nil {
+			gologger.Debug().Msgf("could not find correct source ipv6 for %s:%d\n", ip, p.Port)
+			return
+		}
 		ip6.SrcIP = sourceIP
 	}
 
@@ -504,8 +498,7 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		DstPort: layers.UDPPort(p.Port),
 	}
 
-	err = udp.SetNetworkLayerForChecksum(&ip6)
-	if err != nil {
+	if err := udp.SetNetworkLayerForChecksum(&ip6); err != nil {
 		gologger.Debug().Msgf("Can not set network layer for %s:%d port: %s\n", ip, p.Port, err)
 	} else {
 		if listenHandler.UdpConn6 == nil {
@@ -513,8 +506,7 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 			return
 		}
 
-		err = sendWithConn(ip, listenHandler.UdpConn6, listenHandler.udpLayersWithProbe(&udp, p.Port)...)
-		if err != nil {
+		if err := sendWithConnAddr(&net.IPAddr{IP: ip6.DstIP}, listenHandler.UdpConn6, listenHandler.udpLayersWithProbe(&udp, p.Port)...); err != nil {
 			gologger.Debug().Msgf("Can not send packet to %s:%d port: %s\n", ip, p.Port, err)
 		}
 	}
@@ -604,6 +596,13 @@ var defaultSerializeOptions = gopacket.SerializeOptions{
 
 // send sends the given layers as a single packet on the network.
 func sendWithConn(destIP string, conn net.PacketConn, l ...gopacket.SerializableLayer) error {
+	return sendWithConnAddr(&net.IPAddr{IP: net.ParseIP(destIP)}, conn, l...)
+}
+
+// sendWithConnAddr is sendWithConn with an already-parsed destination, letting
+// callers that hold the parsed net.IP (e.g. the IPv6 path, which needs it for
+// the checksum) avoid a second net.ParseIP per packet.
+func sendWithConnAddr(addr *net.IPAddr, conn net.PacketConn, l ...gopacket.SerializableLayer) error {
 	var err error
 
 	buf := gopacket.NewSerializeBuffer()
@@ -611,7 +610,6 @@ func sendWithConn(destIP string, conn net.PacketConn, l ...gopacket.Serializable
 		return err
 	}
 	data := buf.Bytes()
-	addr := &net.IPAddr{IP: net.ParseIP(destIP)}
 
 	for retries := 0; retries < maxRetries; retries++ {
 		_, err = conn.WriteTo(data, addr)
@@ -623,10 +621,50 @@ func sendWithConn(destIP string, conn net.PacketConn, l ...gopacket.Serializable
 	}
 
 	if err != nil {
-		return fmt.Errorf("could not send packet to %s: %s", destIP, err)
+		return fmt.Errorf("could not send packet to %s: %s", addr.IP, err)
 	}
 
 	return nil
+}
+
+// src6CacheCap bounds the IPv6 source-route cache so a scan over many distinct
+// /64s cannot grow it without limit.
+const src6CacheCap = 1 << 16
+
+var (
+	src6CacheMu sync.RWMutex
+	src6Cache   = map[[8]byte]net.IP{}
+)
+
+// sourceIP6For returns the source IPv6 address the kernel uses to reach dst.
+// The result is cached per /64, so the per-packet send path does a cheap map
+// read instead of a routing-table lookup once the prefix is warm. Returns nil
+// when no route is found (not cached, so a transient failure can recover).
+func sourceIP6For(dst net.IP) net.IP {
+	ip16 := dst.To16()
+	if ip16 == nil || PkgRouter == nil {
+		return nil
+	}
+	var key [8]byte
+	copy(key[:], ip16[:8])
+
+	src6CacheMu.RLock()
+	src, ok := src6Cache[key]
+	src6CacheMu.RUnlock()
+	if ok {
+		return src
+	}
+
+	_, _, s, err := PkgRouter.Route(dst)
+	if err != nil || s == nil {
+		return nil
+	}
+	src6CacheMu.Lock()
+	if len(src6Cache) < src6CacheCap {
+		src6Cache[key] = s
+	}
+	src6CacheMu.Unlock()
+	return s
 }
 
 func sendWithHandler(destIP string, iface *net.Interface, l ...gopacket.SerializableLayer) error {

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -42,62 +42,77 @@ type Handlers struct {
 }
 
 func init() {
-	if PkgRouter == nil || !privileges.IsPrivileged {
-		return
-	}
+	// Only wire the indirection used by Acquire/Release in scan_common.go
+	// (which is not build-constrained, so it cannot reference these raw-socket
+	// symbols directly). No sockets, goroutines or pcap handles are created at
+	// import time anymore: everything is brought up lazily on the first SYN
+	// scan via ensureRawInfra.
+	buildHandlerFn = buildListenHandler
+	ensureRawInfraFn = ensureRawInfra
+}
 
-	transportPacketSend = make(chan *PkgSend, packetSendSize)
+var (
+	rawInfraOnce sync.Once
+	rawInfraOK   bool
+)
 
-	var err error
-	icmpConn4, err = icmp.ListenPacket("ip4:icmp", "0.0.0.0")
-	if err != nil {
-		gologger.Debug().Msgf("could not setup ip4:icmp: %s", err)
-	}
-
-	icmpConn6, err = icmp.ListenPacket("ip6:icmp", "::")
-	if err != nil {
-		gologger.Debug().Msgf("could not setup ip6:icmp: %s", err)
-	}
-
-	icmpPacketSend = make(chan *PkgSend, packetSendSize)
-	ethernetPacketSend = make(chan *PkgSend, packetSendSize)
-
-	// pre-reserve up to 10 ports
-	for i := 0; i < NumberOfHandlers; i++ {
-		listenHandler, err := buildListenHandler()
-		if err != nil {
-			gologger.Debug().Msgf("could not build listen handler: %s", err)
-			ListenHandlers = nil
+// ensureRawInfra lazily brings up the process-wide raw scan infrastructure
+// (icmp sockets, pcap capture, write/read workers) the first time a privileged
+// SYN scan needs it. Handlers are still created on demand per scan; the capture
+// filter is port-independent (flag based) so newly acquired handlers require no
+// filter changes and any number of scans can run in parallel.
+func ensureRawInfra() bool {
+	rawInfraOnce.Do(func() {
+		if PkgRouter == nil || !privileges.IsPrivileged {
 			return
 		}
 
-		ListenHandlers = append(ListenHandlers, listenHandler)
-	}
+		transportPacketSend = make(chan *PkgSend, packetSendSize)
 
-	handlers = &Handlers{
-		InterfaceHandle: make(map[string]*pcap.Handle),
-	}
-	if err := SetupHandlers(); err != nil {
-		gologger.Error().Msgf("could not setup handlers: %s\n", err)
-		ListenHandlers = nil
-		return
-	}
-	if len(handlers.TransportActive)+len(handlers.LoopbackHandlers) == 0 {
-		gologger.Error().Msgf("could not open any pcap capture interface (is Npcap/libpcap installed?)")
-		ListenHandlers = nil
-		return
-	}
-	go TransportReadWorker()
-	go TransportWriteWorker()
-	// Spawn multiple ICMP write workers: ranging over icmpPacketSend from
-	// several goroutines is safe, and concurrent WriteTo on the shared
-	// icmpConn4/icmpConn6 is supported by net.PacketConn. With one worker
-	// the per-host retry-sleep inside PingIcmp*RequestAsync serialises the
-	// whole scan; fanning out lets those sleeps overlap. See #1672.
-	for i := 0; i < icmpWriteWorkers; i++ {
-		go ICMPWriteWorker()
-	}
-	go EthernetWriteWorker(ethernetPacketSend)
+		var err error
+		icmpConn4, err = icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+		if err != nil {
+			gologger.Debug().Msgf("could not setup ip4:icmp: %s", err)
+		}
+		icmpConn6, err = icmp.ListenPacket("ip6:icmp", "::")
+		if err != nil {
+			gologger.Debug().Msgf("could not setup ip6:icmp: %s", err)
+		}
+
+		icmpPacketSend = make(chan *PkgSend, packetSendSize)
+		ethernetPacketSend = make(chan *PkgSend, packetSendSize)
+
+		handlers = &Handlers{
+			InterfaceHandle: make(map[string]*pcap.Handle),
+		}
+		if err := SetupHandlers(); err != nil {
+			gologger.Error().Msgf("could not setup handlers: %s\n", err)
+			return
+		}
+		if len(handlers.TransportActive)+len(handlers.LoopbackHandlers) == 0 {
+			gologger.Error().Msgf("could not open any pcap capture interface (is Npcap/libpcap installed?)")
+			return
+		}
+		go TransportReadWorker()
+		go TransportWriteWorker()
+		// One reader per icmp family routes replies to whichever handlers are
+		// currently in the host-discovery phase. A single shared reader avoids
+		// multiple per-scan handlers stealing each other's replies off the
+		// shared conn.
+		go icmpReadWorker4()
+		go icmpReadWorker6()
+		// Spawn multiple ICMP write workers: ranging over icmpPacketSend from
+		// several goroutines is safe, and concurrent WriteTo on the shared
+		// icmpConn4/icmpConn6 is supported by net.PacketConn. With one worker
+		// the per-host retry-sleep inside PingIcmp*RequestAsync serialises the
+		// whole scan; fanning out lets those sleeps overlap. See #1672.
+		for i := 0; i < icmpWriteWorkers; i++ {
+			go ICMPWriteWorker()
+		}
+		go EthernetWriteWorker(ethernetPacketSend)
+		rawInfraOK = true
+	})
+	return rawInfraOK
 }
 
 func buildListenHandler() (*ListenHandler, error) {
@@ -132,8 +147,9 @@ func buildListenHandler() (*ListenHandler, error) {
 
 	listenHandler.UdpConn6, _ = net.ListenIP("ip6:udp", &net.IPAddr{IP: net.ParseIP("::")})
 
-	go listenHandler.ICMPReadWorker4()
-	go listenHandler.ICMPReadWorker6()
+	// icmp replies are handled by the process-global icmpReadWorker4/6; these
+	// per-handler workers only drain the raw transport sockets so their kernel
+	// receive buffers do not fill. They exit when Release closes the conns.
 	if listenHandler.TcpConn4 != nil {
 		go listenHandler.TcpReadWorker4()
 	}
@@ -504,16 +520,35 @@ func sendAsyncUDP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 	}
 }
 
-// ICMPReadWorker4 reads packets from the network layer
-func (l *ListenHandler) ICMPReadWorker4() {
+// dispatchHostDiscovery delivers a host-discovery result (icmp/arp reply) to
+// every handler currently in the host-discovery phase. Sends are non-blocking
+// so a slow or torn-down handler cannot stall the shared reader, and the
+// snapshot is taken under the pool read lock so it composes with on-demand
+// Acquire/Release.
+func dispatchHostDiscovery(res *PkgResult) {
+	listenHandlersMu.RLock()
+	defer listenHandlersMu.RUnlock()
+	for _, l := range ListenHandlers {
+		if l.Phase != nil && l.Phase.Is(HostDiscovery) {
+			select {
+			case l.HostDiscoveryChan <- res:
+			default:
+			}
+		}
+	}
+}
+
+// icmpReadWorker4 reads ipv4 icmp replies from the shared conn and fans them
+// out to the handlers doing host discovery.
+func icmpReadWorker4() {
+	if icmpConn4 == nil {
+		return
+	}
 	data := make([]byte, 1500)
 	for {
-		if icmpConn4 == nil {
-			return
-		}
 		n, addr, err := icmpConn4.ReadFrom(data)
 		if err != nil {
-			continue
+			return
 		}
 
 		rm, err := icmp.ParseMessage(ProtocolICMP, data[:n])
@@ -523,13 +558,14 @@ func (l *ListenHandler) ICMPReadWorker4() {
 
 		switch rm.Type {
 		case ipv4.ICMPTypeEchoReply, ipv4.ICMPTypeTimestampReply:
-			l.HostDiscoveryChan <- &PkgResult{ipv4: addr.String()}
+			dispatchHostDiscovery(&PkgResult{ipv4: addr.String()})
 		}
 	}
 }
 
-// ICMPReadWorker6 reads packets from the network layer
-func (l *ListenHandler) ICMPReadWorker6() {
+// icmpReadWorker6 reads ipv6 icmp replies from the shared conn and fans them
+// out to the handlers doing host discovery.
+func icmpReadWorker6() {
 	if icmpConn6 == nil {
 		return
 	}
@@ -537,7 +573,7 @@ func (l *ListenHandler) ICMPReadWorker6() {
 	for {
 		n, addr, err := icmpConn6.ReadFrom(data)
 		if err != nil {
-			continue
+			return
 		}
 
 		rm, err := icmp.ParseMessage(ProtocolIPv6ICMP, data[:n])
@@ -556,7 +592,7 @@ func (l *ListenHandler) ICMPReadWorker6() {
 			if idx := strings.Index(ip, "%"); idx > 0 {
 				ip = ip[:idx]
 			}
-			l.HostDiscoveryChan <- &PkgResult{ipv6: ip}
+			dispatchHostDiscovery(&PkgResult{ipv6: ip})
 		}
 	}
 }
@@ -630,7 +666,9 @@ func (l *ListenHandler) TcpReadWorker4() {
 	}
 	data := make([]byte, 4096)
 	for {
-		_, _, _ = l.TcpConn4.ReadFrom(data)
+		if _, _, err := l.TcpConn4.ReadFrom(data); err != nil {
+			return
+		}
 	}
 }
 
@@ -640,7 +678,9 @@ func (l *ListenHandler) TcpReadWorker6() {
 	}
 	data := make([]byte, 4096)
 	for {
-		_, _, _ = l.TcpConn6.ReadFrom(data)
+		if _, _, err := l.TcpConn6.ReadFrom(data); err != nil {
+			return
+		}
 	}
 }
 
@@ -650,7 +690,9 @@ func (l *ListenHandler) UdpReadWorker4() {
 	}
 	data := make([]byte, 4096)
 	for {
-		_, _, _ = l.UdpConn4.ReadFrom(data)
+		if _, _, err := l.UdpConn4.ReadFrom(data); err != nil {
+			return
+		}
 	}
 }
 func (l *ListenHandler) UdpReadWorker6() {
@@ -659,7 +701,9 @@ func (l *ListenHandler) UdpReadWorker6() {
 	}
 	data := make([]byte, 4096)
 	for {
-		_, _, _ = l.UdpConn6.ReadFrom(data)
+		if _, _, err := l.UdpConn6.ReadFrom(data); err != nil {
+			return
+		}
 	}
 }
 
@@ -707,8 +751,6 @@ func SetupHandlerUnix(interfaceName, bpfFilter string, protocols ...protocol.Pro
 			return err
 		}
 
-		// Strict BPF filter
-		// + Destination port equals to sender socket source port
 		err = handle.SetBPFFilter(bpfFilter)
 		if err != nil {
 			return err
@@ -738,6 +780,8 @@ func TransportReadWorker() {
 	var wgread sync.WaitGroup
 
 	transportReaderCallback := func(tcp layers.TCP, udp layers.UDP, srcIP4, srcIP6 string) {
+		listenHandlersMu.RLock()
+		defer listenHandlersMu.RUnlock()
 		for _, listenHandler := range ListenHandlers {
 			// We consider only incoming packets
 			tcpPortMatches := tcp.DstPort == layers.TCPPort(listenHandler.Port)
@@ -942,9 +986,7 @@ func TransportReadWorker() {
 							srcIP4 := net.IP(arp.SourceProtAddress)
 							srcMAC := net.HardwareAddr(arp.SourceHwAddress).String()
 
-							for _, listenHandler := range ListenHandlers {
-								listenHandler.HostDiscoveryChan <- &PkgResult{ipv4: ToString(srcIP4), mac: srcMAC}
-							}
+							dispatchHostDiscovery(&PkgResult{ipv4: ToString(srcIP4), mac: srcMAC})
 						}
 					}
 				}
@@ -993,12 +1035,14 @@ func SetupHandlers() error {
 }
 
 func SetupHandler(interfaceName string) error {
-	var portFilters []string
-	for _, listenHandler := range ListenHandlers {
-		portFilters = append(portFilters, fmt.Sprintf("dst port %d", listenHandler.Port))
-	}
-
-	bpfFilter := fmt.Sprintf("(%s) and (tcp or udp)", strings.Join(portFilters, " or "))
+	// Port-independent capture. Handlers are created on demand, so their source
+	// ports cannot be baked into the filter (and runtime SetBPFFilter is not
+	// safe against the live reader). Capture inbound TCP that carries ACK or
+	// RST - SYN-ACK for open ports, RST/RST-ACK for closed ports and TCP host
+	// discovery - plus UDP, while excluding our own outgoing pure-SYN probes.
+	// The reader still routes each packet to the owning handler by destination
+	// port, so any number of handlers share this one filter.
+	bpfFilter := "(tcp and (tcp[tcpflags] & (tcp-ack|tcp-rst) != 0)) or udp"
 	err := SetupHandlerUnix(interfaceName, bpfFilter, protocol.TCP)
 	if err != nil {
 		return err

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -735,6 +735,12 @@ func SetupHandlerUnix(interfaceName, bpfFilter string, protocols ...protocol.Pro
 		if err != nil {
 			return err
 		}
+		// Best-effort: a large capture buffer keeps reply bursts from large port
+		// ranges from overflowing the kernel ring and silently dropping
+		// SYN-ACKs. Failure is non-fatal; the handle keeps the OS default.
+		if err = inactive.SetBufferSize(pcapBufferSize); err != nil {
+			gologger.Debug().Msgf("could not set pcap buffer size on %s: %s", interfaceName, err)
+		}
 
 		switch proto {
 		case protocol.TCP, protocol.UDP:
@@ -891,18 +897,24 @@ func TransportReadWorker() {
 				parser4NoMac, parser6NoMac,
 			)
 
-			decoded := []gopacket.LayerType{}
+			decoded := make([]gopacket.LayerType, 0, 8)
 
-			packetSource := gopacket.NewPacketSource(handler, handler.LinkType())
-			packetSource.DecodeOptions = gopacket.DecodeOptions{
-				Lazy:   true,
-				NoCopy: true,
-			}
-			for packet := range packetSource.Packets() {
-				data := packet.Data()
+			// Read straight off the handle (zero-copy) instead of
+			// gopacket.PacketSource.Packets(), which allocates a *gopacket.Packet
+			// and hops through an extra goroutine+channel for every packet. On a
+			// SYN scan every reply lands here, so this is the receive hot path.
+			for {
+				data, _, err := handler.ZeroCopyReadPacketData()
+				if err != nil {
+					if errors.Is(err, pcap.NextErrorTimeoutExpired) {
+						continue
+					}
+					// EOF or a closed handle ends the reader; any other error is
+					// treated as fatal to avoid spinning on a broken handle.
+					return
+				}
 				for _, parser := range parsers {
-					err := parser.DecodeLayers(data, &decoded)
-					if err != nil {
+					if err := parser.DecodeLayers(data, &decoded); err != nil {
 						continue
 					}
 					hasTransport := false

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -748,10 +748,12 @@ func TransportReadWorker() {
 				gologger.Debug().Msgf("Discarding Transport packet from non target ips: ip4=%s ip6=%s tcp_dport=%d udp_dport=%d\n", srcIP4, srcIP6, tcp.DstPort, udp.DstPort)
 			case listenHandler.Phase.Is(HostDiscovery):
 				proto := protocol.TCP
+				srcPort := int(tcp.SrcPort)
 				if udpPortMatches {
 					proto = protocol.UDP
+					srcPort = int(udp.SrcPort)
 				}
-				listenHandler.HostDiscoveryChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(tcp.SrcPort), Protocol: proto}}
+				listenHandler.HostDiscoveryChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: srcPort, Protocol: proto}}
 			case tcpPortMatches && tcp.SYN && tcp.ACK:
 				if !verifySynCookie(srcIP4, srcIP6, uint16(tcp.SrcPort), uint16(tcp.DstPort), tcp.Ack) {
 					gologger.Debug().Msgf("Discarding SYN-ACK with invalid cookie: ip4=%s ip6=%s port=%d\n", srcIP4, srcIP6, tcp.SrcPort)
@@ -869,16 +871,26 @@ func TransportReadWorker() {
 					if !hasTransport {
 						continue
 					}
+					// tcp/udp are reused across packets by the parser and absent
+					// layers keep their previous value; forward only the transport
+					// layer actually present in this packet so the callback can't
+					// match on a stale port from an earlier packet.
 					var srcIP4, srcIP6 string
+					var tcpForCb layers.TCP
+					var udpForCb layers.UDP
 					for _, layerType := range decoded {
 						switch layerType {
 						case layers.LayerTypeIPv4:
 							srcIP4 = ToString(ip4.SrcIP)
 						case layers.LayerTypeIPv6:
 							srcIP6 = ToString(ip6.SrcIP)
+						case layers.LayerTypeTCP:
+							tcpForCb = tcp
+						case layers.LayerTypeUDP:
+							udpForCb = udp
 						}
 					}
-					transportReaderCallback(tcp, udp, srcIP4, srcIP6)
+					transportReaderCallback(tcpForCb, udpForCb, srcIP4, srcIP6)
 					break
 				}
 			}

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -1092,7 +1092,12 @@ func SetupHandler(interfaceName string) error {
 	// discovery - plus UDP, while excluding our own outgoing pure-SYN probes.
 	// The reader still routes each packet to the owning handler by destination
 	// port, so any number of handlers share this one filter.
-	bpfFilter := "(tcp and (tcp[tcpflags] & (tcp-ack|tcp-rst) != 0)) or udp"
+	// tcp[tcpflags] is an IPv4-only BPF accessor (classic BPF cannot walk the
+	// IPv6 extension-header chain), so the flag test is scoped to ip and IPv6
+	// TCP replies are captured with a plain "ip6 and tcp". Outgoing pure-SYN
+	// probes still get filtered: for IPv4 by the flag mask, and for IPv6 by the
+	// reader, which only acts on SYN-ACKs whose dst port is a live handler port.
+	bpfFilter := "(ip and tcp and (tcp[tcpflags] & (tcp-ack|tcp-rst) != 0)) or (ip6 and tcp) or udp"
 	err := SetupHandlerUnix(interfaceName, bpfFilter, protocol.TCP)
 	if err != nil {
 		return err

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -293,11 +293,17 @@ func sendAsyncTCP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		OptionData:   []byte{0x05, 0xB4},
 	}
 
+	seq := tcpsequencer.Next()
+	if pkgFlag == Syn {
+		// SYN cookie: lets the receive path verify the returning SYN-ACK.
+		seq = SynCookie(ip4.DstIP, uint16(p.Port), uint16(listenHandler.Port))
+	}
+
 	tcp := layers.TCP{
 		SrcPort: layers.TCPPort(listenHandler.Port),
 		DstPort: layers.TCPPort(p.Port),
 		Window:  1024,
-		Seq:     tcpsequencer.Next(),
+		Seq:     seq,
 		Options: []layers.TCPOption{tcpOption},
 	}
 
@@ -416,11 +422,17 @@ func sendAsyncTCP6(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 		OptionData:   []byte{0x05, 0xB4},
 	}
 
+	seq := tcpsequencer.Next()
+	if pkgFlag == Syn {
+		// SYN cookie: lets the receive path verify the returning SYN-ACK.
+		seq = SynCookie(ip6.DstIP, uint16(p.Port), uint16(listenHandler.Port))
+	}
+
 	tcp := layers.TCP{
 		SrcPort: layers.TCPPort(listenHandler.Port),
 		DstPort: layers.TCPPort(p.Port),
 		Window:  1024,
-		Seq:     tcpsequencer.Next(),
+		Seq:     seq,
 		Options: []layers.TCPOption{tcpOption},
 	}
 
@@ -741,6 +753,10 @@ func TransportReadWorker() {
 				}
 				listenHandler.HostDiscoveryChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(tcp.SrcPort), Protocol: proto}}
 			case tcpPortMatches && tcp.SYN && tcp.ACK:
+				if !verifySynCookie(srcIP4, srcIP6, uint16(tcp.SrcPort), uint16(tcp.DstPort), tcp.Ack) {
+					gologger.Debug().Msgf("Discarding SYN-ACK with invalid cookie: ip4=%s ip6=%s port=%d\n", srcIP4, srcIP6, tcp.SrcPort)
+					continue
+				}
 				listenHandler.TcpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(tcp.SrcPort), Protocol: protocol.TCP}}
 			case udpPortMatches && udp.Length > 0: // needs a better matching of udp payloads
 				listenHandler.UdpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(udp.SrcPort), Protocol: protocol.UDP}}

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -52,8 +52,8 @@ func init() {
 }
 
 var (
-	rawInfraOnce sync.Once
-	rawInfraOK   bool
+	rawInfraMu sync.Mutex
+	rawInfraOK bool
 )
 
 // ensureRawInfra lazily brings up the process-wide raw scan infrastructure
@@ -62,57 +62,90 @@ var (
 // filter is port-independent (flag based) so newly acquired handlers require no
 // filter changes and any number of scans can run in parallel.
 func ensureRawInfra() bool {
-	rawInfraOnce.Do(func() {
-		if PkgRouter == nil || !privileges.IsPrivileged {
-			return
-		}
+	rawInfraMu.Lock()
+	defer rawInfraMu.Unlock()
 
-		transportPacketSend = make(chan *PkgSend, packetSendSize)
+	// Guard on success rather than sync.Once so a transient setup failure (e.g. a
+	// momentarily bad interface) does not permanently disable raw scanning for
+	// the rest of a long-lived process; a later scan can retry from scratch.
+	if rawInfraOK {
+		return true
+	}
+	if PkgRouter == nil || !privileges.IsPrivileged {
+		return false
+	}
 
-		var err error
-		icmpConn4, err = icmp.ListenPacket("ip4:icmp", "0.0.0.0")
-		if err != nil {
-			gologger.Debug().Msgf("could not setup ip4:icmp: %s", err)
-		}
-		icmpConn6, err = icmp.ListenPacket("ip6:icmp", "::")
-		if err != nil {
-			gologger.Debug().Msgf("could not setup ip6:icmp: %s", err)
-		}
+	transportPacketSend = make(chan *PkgSend, packetSendSize)
 
-		icmpPacketSend = make(chan *PkgSend, packetSendSize)
-		ethernetPacketSend = make(chan *PkgSend, packetSendSize)
+	var err error
+	icmpConn4, err = icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		gologger.Debug().Msgf("could not setup ip4:icmp: %s", err)
+	}
+	icmpConn6, err = icmp.ListenPacket("ip6:icmp", "::")
+	if err != nil {
+		gologger.Debug().Msgf("could not setup ip6:icmp: %s", err)
+	}
 
-		handlers = &Handlers{
-			InterfaceHandle: make(map[string]*pcap.Handle),
+	icmpPacketSend = make(chan *PkgSend, packetSendSize)
+	ethernetPacketSend = make(chan *PkgSend, packetSendSize)
+
+	handlers = &Handlers{
+		InterfaceHandle: make(map[string]*pcap.Handle),
+	}
+	if err := SetupHandlers(); err != nil {
+		gologger.Error().Msgf("could not setup handlers: %s\n", err)
+		// SetupHandlers cleans up its own partial pcap handles; drop the rest of
+		// the half-initialized state so the next call retries cleanly.
+		if icmpConn4 != nil {
+			_ = icmpConn4.Close()
+			icmpConn4 = nil
 		}
-		if err := SetupHandlers(); err != nil {
-			gologger.Error().Msgf("could not setup handlers: %s\n", err)
-			return
+		if icmpConn6 != nil {
+			_ = icmpConn6.Close()
+			icmpConn6 = nil
 		}
-		if len(handlers.TransportActive)+len(handlers.LoopbackHandlers) == 0 {
-			gologger.Error().Msgf("could not open any pcap capture interface (is Npcap/libpcap installed?)")
-			return
+		transportPacketSend = nil
+		icmpPacketSend = nil
+		ethernetPacketSend = nil
+		handlers = nil
+		return false
+	}
+	if len(handlers.TransportActive)+len(handlers.LoopbackHandlers) == 0 {
+		gologger.Error().Msgf("could not open any pcap capture interface (is Npcap/libpcap installed?)")
+		if icmpConn4 != nil {
+			_ = icmpConn4.Close()
+			icmpConn4 = nil
 		}
-		go TransportReadWorker()
-		go TransportWriteWorker()
-		// One reader per icmp family routes replies to whichever handlers are
-		// currently in the host-discovery phase. A single shared reader avoids
-		// multiple per-scan handlers stealing each other's replies off the
-		// shared conn.
-		go icmpReadWorker4()
-		go icmpReadWorker6()
-		// Spawn multiple ICMP write workers: ranging over icmpPacketSend from
-		// several goroutines is safe, and concurrent WriteTo on the shared
-		// icmpConn4/icmpConn6 is supported by net.PacketConn. With one worker
-		// the per-host retry-sleep inside PingIcmp*RequestAsync serialises the
-		// whole scan; fanning out lets those sleeps overlap. See #1672.
-		for i := 0; i < icmpWriteWorkers; i++ {
-			go ICMPWriteWorker()
+		if icmpConn6 != nil {
+			_ = icmpConn6.Close()
+			icmpConn6 = nil
 		}
-		go EthernetWriteWorker(ethernetPacketSend)
-		rawInfraOK = true
-	})
-	return rawInfraOK
+		transportPacketSend = nil
+		icmpPacketSend = nil
+		ethernetPacketSend = nil
+		handlers = nil
+		return false
+	}
+	go TransportReadWorker()
+	go TransportWriteWorker()
+	// One reader per icmp family routes replies to whichever handlers are
+	// currently in the host-discovery phase. A single shared reader avoids
+	// multiple per-scan handlers stealing each other's replies off the
+	// shared conn.
+	go icmpReadWorker4()
+	go icmpReadWorker6()
+	// Spawn multiple ICMP write workers: ranging over icmpPacketSend from
+	// several goroutines is safe, and concurrent WriteTo on the shared
+	// icmpConn4/icmpConn6 is supported by net.PacketConn. With one worker
+	// the per-host retry-sleep inside PingIcmp*RequestAsync serialises the
+	// whole scan; fanning out lets those sleeps overlap. See #1672.
+	for i := 0; i < icmpWriteWorkers; i++ {
+		go ICMPWriteWorker()
+	}
+	go EthernetWriteWorker(ethernetPacketSend)
+	rawInfraOK = true
+	return true
 }
 
 func buildListenHandler() (*ListenHandler, error) {
@@ -769,48 +802,57 @@ func (l *ListenHandler) rebind6(ip net.IP) bool {
 	return true
 }
 
+// The drain workers capture their socket into a local before looping: rebind4/
+// rebind6 can swap l.TcpConn*/l.UdpConn* under them, so reading the field every
+// iteration would race the swap and could make an old worker start draining the
+// freshly bound socket. Pinning the local keeps each worker bound to the socket
+// it started on, which is closed on rebind/teardown so the worker then exits.
 func (l *ListenHandler) TcpReadWorker4() {
-	if l.TcpConn4 == nil {
+	conn := l.TcpConn4
+	if conn == nil {
 		return
 	}
 	data := make([]byte, 4096)
 	for {
-		if _, _, err := l.TcpConn4.ReadFrom(data); err != nil {
+		if _, _, err := conn.ReadFrom(data); err != nil {
 			return
 		}
 	}
 }
 
 func (l *ListenHandler) TcpReadWorker6() {
-	if l.TcpConn6 == nil {
+	conn := l.TcpConn6
+	if conn == nil {
 		return
 	}
 	data := make([]byte, 4096)
 	for {
-		if _, _, err := l.TcpConn6.ReadFrom(data); err != nil {
+		if _, _, err := conn.ReadFrom(data); err != nil {
 			return
 		}
 	}
 }
 
 func (l *ListenHandler) UdpReadWorker4() {
-	if l.UdpConn4 == nil {
+	conn := l.UdpConn4
+	if conn == nil {
 		return
 	}
 	data := make([]byte, 4096)
 	for {
-		if _, _, err := l.UdpConn4.ReadFrom(data); err != nil {
+		if _, _, err := conn.ReadFrom(data); err != nil {
 			return
 		}
 	}
 }
 func (l *ListenHandler) UdpReadWorker6() {
-	if l.UdpConn6 == nil {
+	conn := l.UdpConn6
+	if conn == nil {
 		return
 	}
 	data := make([]byte, 4096)
 	for {
-		if _, _, err := l.UdpConn6.ReadFrom(data); err != nil {
+		if _, _, err := conn.ReadFrom(data); err != nil {
 			return
 		}
 	}

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -257,9 +257,12 @@ func sendAsyncTCP4(listenHandler *ListenHandler, ip string, p *port.Port, pkgFla
 
 	hasSourceIp := listenHandler.SourceIp4 != nil
 	// Windows cannot open raw IPPROTO_TCP sockets; always send via Npcap L2.
-	usePcap := listenHandler.TcpConn4 == nil || (hasSourceIp && listenHandler.SourceHW != nil)
+	// Bound sources stay on the raw IP socket path — SourceHW alone must not
+	// force Ethernet framing after a successful BindSourceIP.
+	usePcap := listenHandler.TcpConn4 == nil ||
+		(hasSourceIp && listenHandler.SourceHW != nil && !listenHandler.SourceBound4)
 	var iface *net.Interface
-	if hasSourceIp && listenHandler.SourceHW != nil && !listenHandler.SourceBound {
+	if hasSourceIp && listenHandler.SourceHW != nil && !listenHandler.SourceBound4 {
 		// NOTE(dwisiswant0): Only attempt to use ethernet framing if we have
 		// both source IP and HW.
 		itf, gateway, _, err := PkgRouter.RouteWithSrc(listenHandler.SourceHW, listenHandler.SourceIp4, ip4.DstIP)
@@ -670,25 +673,26 @@ func sendWithConnAddr(addr *net.IPAddr, conn net.PacketConn, l ...gopacket.Seria
 }
 
 // src6CacheCap bounds the IPv6 source-route cache so a scan over many distinct
-// /64s cannot grow it without limit.
+// destinations cannot grow it without limit.
 const src6CacheCap = 1 << 16
 
 var (
 	src6CacheMu sync.RWMutex
-	src6Cache   = map[[8]byte]net.IP{}
+	src6Cache   = map[[16]byte]net.IP{}
 )
 
 // sourceIP6For returns the source IPv6 address the kernel uses to reach dst.
-// The result is cached per /64, so the per-packet send path does a cheap map
-// read instead of a routing-table lookup once the prefix is warm. Returns nil
-// when no route is found (not cached, so a transient failure can recover).
+// The result is cached per exact destination: more-specific routes / policy
+// routing can select different sources within a single /64, so prefix caching
+// would checksum against the wrong source. Returns nil when no route is found
+// (not cached, so a transient failure can recover).
 func sourceIP6For(dst net.IP) net.IP {
 	ip16 := dst.To16()
 	if ip16 == nil || PkgRouter == nil {
 		return nil
 	}
-	var key [8]byte
-	copy(key[:], ip16[:8])
+	var key [16]byte
+	copy(key[:], ip16)
 
 	src6CacheMu.RLock()
 	src, ok := src6Cache[key]
@@ -750,14 +754,10 @@ func sendWithHandler(destIP string, iface *net.Interface, l ...gopacket.Serializ
 // It is a no-op on plain (non-raw) handlers that have no transport sockets.
 func (l *ListenHandler) BindSourceIP(v4, v6 net.IP) {
 	if v4 != nil && l.TcpConn4 != nil {
-		if l.rebind4(v4) {
-			l.SourceBound = true
-		}
+		l.SourceBound4 = l.rebind4(v4)
 	}
 	if v6 != nil && l.TcpConn6 != nil {
-		if l.rebind6(v6) {
-			l.SourceBound = true
-		}
+		l.SourceBound6 = l.rebind6(v6)
 	}
 }
 

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -573,7 +573,13 @@ func icmpReadWorker4() {
 	for {
 		n, addr, err := icmpConn4.ReadFrom(data)
 		if err != nil {
-			return
+			// Only a closed socket is terminal; this is the single process-global
+			// reader, so bailing on a transient error (e.g. ENOBUFS under load)
+			// would silently disable ICMP host discovery for the process lifetime.
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			continue
 		}
 
 		rm, err := icmp.ParseMessage(ProtocolICMP, data[:n])
@@ -598,7 +604,10 @@ func icmpReadWorker6() {
 	for {
 		n, addr, err := icmpConn6.ReadFrom(data)
 		if err != nil {
-			return
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			continue
 		}
 
 		rm, err := icmp.ParseMessage(ProtocolIPv6ICMP, data[:n])
@@ -962,7 +971,7 @@ func TransportReadWorker() {
 				}
 				select {
 				case listenHandler.HostDiscoveryChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: srcPort, Protocol: proto}}:
-				default:
+				case <-listenHandler.done:
 				}
 			case tcpPortMatches && tcp.SYN && tcp.ACK:
 				if !verifySynCookie(srcIP4, srcIP6, uint16(tcp.SrcPort), uint16(tcp.DstPort), tcp.Ack) {
@@ -971,12 +980,12 @@ func TransportReadWorker() {
 				}
 				select {
 				case listenHandler.TcpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(tcp.SrcPort), Protocol: protocol.TCP}}:
-				default:
+				case <-listenHandler.done:
 				}
 			case udpPortMatches && udp.Length > 0: // needs a better matching of udp payloads
 				select {
 				case listenHandler.UdpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(udp.SrcPort), Protocol: protocol.UDP}}:
-				default:
+				case <-listenHandler.done:
 				}
 			}
 		}

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -937,9 +937,15 @@ func TransportReadWorker() {
 	var wgread sync.WaitGroup
 
 	transportReaderCallback := func(tcp layers.TCP, udp layers.UDP, srcIP4, srcIP6 string) {
+		// Snapshot handlers under the registry lock, then deliver outside it.
+		// Blocking channel sends must not hold listenHandlersMu or Release/Close
+		// can deadlock when a result channel is full (e.g. -sV backpressure).
 		listenHandlersMu.RLock()
-		defer listenHandlersMu.RUnlock()
-		for _, listenHandler := range ListenHandlers {
+		handlersSnap := make([]*ListenHandler, len(ListenHandlers))
+		copy(handlersSnap, ListenHandlers)
+		listenHandlersMu.RUnlock()
+
+		for _, listenHandler := range handlersSnap {
 			// We consider only incoming packets
 			tcpPortMatches := tcp.DstPort == layers.TCPPort(listenHandler.Port)
 			udpPortMatches := udp.DstPort == layers.UDPPort(listenHandler.Port)
@@ -954,15 +960,24 @@ func TransportReadWorker() {
 					proto = protocol.UDP
 					srcPort = int(udp.SrcPort)
 				}
-				listenHandler.HostDiscoveryChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: srcPort, Protocol: proto}}
+				select {
+				case listenHandler.HostDiscoveryChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: srcPort, Protocol: proto}}:
+				default:
+				}
 			case tcpPortMatches && tcp.SYN && tcp.ACK:
 				if !verifySynCookie(srcIP4, srcIP6, uint16(tcp.SrcPort), uint16(tcp.DstPort), tcp.Ack) {
 					gologger.Debug().Msgf("Discarding SYN-ACK with invalid cookie: ip4=%s ip6=%s port=%d\n", srcIP4, srcIP6, tcp.SrcPort)
 					continue
 				}
-				listenHandler.TcpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(tcp.SrcPort), Protocol: protocol.TCP}}
+				select {
+				case listenHandler.TcpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(tcp.SrcPort), Protocol: protocol.TCP}}:
+				default:
+				}
 			case udpPortMatches && udp.Length > 0: // needs a better matching of udp payloads
-				listenHandler.UdpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(udp.SrcPort), Protocol: protocol.UDP}}
+				select {
+				case listenHandler.UdpChan <- &PkgResult{ipv4: srcIP4, ipv6: srcIP6, port: &port.Port{Port: int(udp.SrcPort), Protocol: protocol.UDP}}:
+				default:
+				}
 			}
 		}
 	}

--- a/pkg/scan/scan_raw.go
+++ b/pkg/scan/scan_raw.go
@@ -1065,6 +1065,14 @@ func TransportReadWorker() {
 			// Interfaces without MAC (TUN/TAP)
 			parser4NoMac := gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &ip4, &tcp, &udp)
 			parser6NoMac := gopacket.NewDecodingLayerParser(layers.LayerTypeIPv6, &ip6, &tcp, &udp)
+			// A payload-bearing reply (TCP with data, or a UDP open-port response)
+			// leaves a trailing Payload layer with no decoder, which otherwise makes
+			// DecodeLayers return UnsupportedLayerType and drops the whole packet even
+			// though the transport layer decoded fine. Ignore it: the transport layer
+			// is already in the decoded slice.
+			for _, p := range []*gopacket.DecodingLayerParser{parser4Mac, parser6Mac, parser4NoMac, parser6NoMac} {
+				p.IgnoreUnsupported = true
+			}
 
 			var parsers []*gopacket.DecodingLayerParser
 			parsers = append(parsers,

--- a/pkg/scan/scan_type_test.go
+++ b/pkg/scan/scan_type_test.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/projectdiscovery/naabu/v2/pkg/privileges"
@@ -87,6 +88,50 @@ func TestAcquire_SynScan_FreeHandler_Succeeds(t *testing.T) {
 	assert.True(t, handler.Busy)
 }
 
+func TestAcquireSynScanIsConcurrencySafe(t *testing.T) {
+	origRouter := PkgRouter
+	origPriv := privileges.IsPrivileged
+	origHandlers := ListenHandlers
+	defer func() {
+		PkgRouter = origRouter
+		privileges.IsPrivileged = origPriv
+		ListenHandlers = origHandlers
+	}()
+
+	PkgRouter = &stubRouter{}
+	privileges.IsPrivileged = true
+
+	const n = 50
+	pool := make([]*ListenHandler, n)
+	for i := range pool {
+		pool[i] = &ListenHandler{}
+	}
+	ListenHandlers = pool
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	seen := map[*ListenHandler]int{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h, err := Acquire(&Options{ScanType: TypeSyn})
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			seen[h]++
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, seen, n, "every handler should be claimed exactly once")
+	for h, c := range seen {
+		assert.Equalf(t, 1, c, "handler %p handed out more than once", h)
+	}
+}
+
 func TestNewScanner_SetsConnectScanType(t *testing.T) {
 	scanner, err := NewScanner(&Options{ScanType: TypeConnect})
 	require.NoError(t, err)
@@ -165,7 +210,10 @@ func TestListenHandler_Release(t *testing.T) {
 	h.Busy = true
 	h.Release()
 	assert.False(t, h.Busy)
-	assert.Nil(t, h.Phase)
+	// Release keeps a valid idle Phase so the global pcap reader can safely
+	// dereference it for stray packets while the handler sits in the pool.
+	assert.NotNil(t, h.Phase)
+	assert.True(t, h.Phase.Is(Init))
 }
 
 func TestTypeConstants(t *testing.T) {

--- a/pkg/scan/scan_type_test.go
+++ b/pkg/scan/scan_type_test.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -12,6 +13,30 @@ import (
 
 // stubRouter satisfies routing.Router so we can make PkgRouter non-nil in tests.
 type stubRouter struct{ routing.Router }
+
+// withStubbedRawInfra wires the on-demand handler seam so the SYN Acquire path
+// can be exercised without opening real raw sockets or pcap handles. The build
+// function returns a fresh handler each call (or an error to simulate failure).
+func withStubbedRawInfra(t *testing.T, infraOK bool, build func() (*ListenHandler, error)) {
+	t.Helper()
+	origRouter := PkgRouter
+	origPriv := privileges.IsPrivileged
+	origBuild := buildHandlerFn
+	origEnsure := ensureRawInfraFn
+	origHandlers := ListenHandlers
+	t.Cleanup(func() {
+		PkgRouter = origRouter
+		privileges.IsPrivileged = origPriv
+		buildHandlerFn = origBuild
+		ensureRawInfraFn = origEnsure
+		ListenHandlers = origHandlers
+	})
+	PkgRouter = &stubRouter{}
+	privileges.IsPrivileged = true
+	ListenHandlers = nil
+	ensureRawInfraFn = func() bool { return infraOK }
+	buildHandlerFn = build
+}
 
 func TestAcquire_ConnectScan_AlwaysSucceeds(t *testing.T) {
 	opts := &Options{ScanType: TypeConnect}
@@ -49,87 +74,82 @@ func TestAcquire_NilRouter_SucceedsForAnyScanType(t *testing.T) {
 	}
 }
 
-func TestAcquire_SynScan_NoFreeHandlers_ReturnsError(t *testing.T) {
-	origRouter := PkgRouter
-	origPriv := privileges.IsPrivileged
-	origHandlers := ListenHandlers
-	defer func() {
-		PkgRouter = origRouter
-		privileges.IsPrivileged = origPriv
-		ListenHandlers = origHandlers
-	}()
-
-	PkgRouter = &stubRouter{}
-	privileges.IsPrivileged = true
-	ListenHandlers = []*ListenHandler{{Busy: true, Phase: &Phase{}}}
+func TestAcquire_SynScan_InfraFailure_ReturnsError(t *testing.T) {
+	withStubbedRawInfra(t, false, func() (*ListenHandler, error) {
+		return NewListenHandler(), nil
+	})
 
 	_, err := Acquire(&Options{ScanType: TypeSyn})
-	assert.Error(t, err, "should fail when all handlers are busy for syn scan")
+	assert.Error(t, err, "should fail when raw infrastructure cannot start")
 }
 
-func TestAcquire_SynScan_FreeHandler_Succeeds(t *testing.T) {
-	origRouter := PkgRouter
-	origPriv := privileges.IsPrivileged
-	origHandlers := ListenHandlers
-	defer func() {
-		PkgRouter = origRouter
-		privileges.IsPrivileged = origPriv
-		ListenHandlers = origHandlers
-	}()
+func TestAcquire_SynScan_BuildFailure_ReturnsError(t *testing.T) {
+	withStubbedRawInfra(t, true, func() (*ListenHandler, error) {
+		return nil, errors.New("no privileges")
+	})
 
-	PkgRouter = &stubRouter{}
-	privileges.IsPrivileged = true
-	freeHandler := &ListenHandler{Busy: false}
-	ListenHandlers = []*ListenHandler{freeHandler}
+	_, err := Acquire(&Options{ScanType: TypeSyn})
+	assert.Error(t, err, "build error should propagate")
+}
+
+func TestAcquire_SynScan_BuildsAndRegisters(t *testing.T) {
+	built := &ListenHandler{Phase: &Phase{}}
+	withStubbedRawInfra(t, true, func() (*ListenHandler, error) { return built, nil })
 
 	handler, err := Acquire(&Options{ScanType: TypeSyn})
 	require.NoError(t, err)
-	assert.Same(t, freeHandler, handler, "should return the free handler")
+	assert.Same(t, built, handler, "should return the freshly built handler")
 	assert.True(t, handler.Busy)
+	assert.Contains(t, ListenHandlers, built, "handler must be registered for the readers")
 }
 
 func TestAcquireSynScanIsConcurrencySafe(t *testing.T) {
-	origRouter := PkgRouter
-	origPriv := privileges.IsPrivileged
-	origHandlers := ListenHandlers
-	defer func() {
-		PkgRouter = origRouter
-		privileges.IsPrivileged = origPriv
-		ListenHandlers = origHandlers
-	}()
-
-	PkgRouter = &stubRouter{}
-	privileges.IsPrivileged = true
+	withStubbedRawInfra(t, true, func() (*ListenHandler, error) {
+		return &ListenHandler{Phase: &Phase{}}, nil
+	})
 
 	const n = 50
-	pool := make([]*ListenHandler, n)
-	for i := range pool {
-		pool[i] = &ListenHandler{}
-	}
-	ListenHandlers = pool
-
 	var wg sync.WaitGroup
-	var mu sync.Mutex
-	seen := map[*ListenHandler]int{}
+	got := make([]*ListenHandler, n)
 	for i := 0; i < n; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
-			h, err := Acquire(&Options{ScanType: TypeSyn})
-			if err != nil {
-				return
+			if h, err := Acquire(&Options{ScanType: TypeSyn}); err == nil {
+				got[i] = h
 			}
-			mu.Lock()
-			seen[h]++
-			mu.Unlock()
-		}()
+		}(i)
 	}
 	wg.Wait()
 
-	assert.Len(t, seen, n, "every handler should be claimed exactly once")
-	for h, c := range seen {
-		assert.Equalf(t, 1, c, "handler %p handed out more than once", h)
+	// Every concurrent Acquire gets its own distinct handler, and all are
+	// registered exactly once (no lost updates to the shared slice).
+	seen := map[*ListenHandler]bool{}
+	for _, h := range got {
+		require.NotNil(t, h)
+		assert.Falsef(t, seen[h], "handler %p handed out more than once", h)
+		seen[h] = true
 	}
+	listenHandlersMu.RLock()
+	registered := len(ListenHandlers)
+	listenHandlersMu.RUnlock()
+	assert.Equal(t, n, registered, "all handlers should be registered")
+}
+
+func TestReleaseRemovesFromRegistry(t *testing.T) {
+	origHandlers := ListenHandlers
+	t.Cleanup(func() { ListenHandlers = origHandlers })
+
+	// Distinct ports so testify's value-based Contains can tell them apart.
+	h := &ListenHandler{Phase: &Phase{}, Busy: true, Port: 2}
+	other := &ListenHandler{Phase: &Phase{}, Port: 1}
+	ListenHandlers = []*ListenHandler{other, h}
+
+	h.Release()
+
+	assert.False(t, h.Busy)
+	assert.NotContains(t, ListenHandlers, h, "released handler must be deregistered")
+	assert.Contains(t, ListenHandlers, other, "other handlers must remain")
 }
 
 func TestNewScanner_SetsConnectScanType(t *testing.T) {
@@ -139,19 +159,10 @@ func TestNewScanner_SetsConnectScanType(t *testing.T) {
 }
 
 func TestNewScanner_FallbackFromSynToConnect(t *testing.T) {
-	origRouter := PkgRouter
-	origPriv := privileges.IsPrivileged
-	origHandlers := ListenHandlers
-	defer func() {
-		PkgRouter = origRouter
-		privileges.IsPrivileged = origPriv
-		ListenHandlers = origHandlers
-	}()
-
-	// Set up: router exists, privileged, but all handlers busy -> Acquire fails for SYN
-	PkgRouter = &stubRouter{}
-	privileges.IsPrivileged = true
-	ListenHandlers = []*ListenHandler{{Busy: true, Phase: &Phase{}}}
+	// Privileged SYN scan whose handler build fails must fall back to connect.
+	withStubbedRawInfra(t, true, func() (*ListenHandler, error) {
+		return nil, errors.New("cannot open raw socket")
+	})
 
 	opts := &Options{ScanType: TypeSyn}
 	scanner, err := NewScanner(opts)

--- a/pkg/scan/source6_cache_test.go
+++ b/pkg/scan/source6_cache_test.go
@@ -1,0 +1,78 @@
+package scan
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/projectdiscovery/naabu/v2/pkg/routing"
+	"github.com/stretchr/testify/require"
+)
+
+// countingRouter records how many times Route is called and returns a fixed
+// source IP, so we can assert the /64 cache collapses per-packet lookups.
+type countingRouter struct {
+	routing.Router
+	mu    sync.Mutex
+	calls int
+	src   net.IP
+}
+
+func (c *countingRouter) Route(dst net.IP) (*net.Interface, net.IP, net.IP, error) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	return nil, nil, c.src, nil
+}
+
+func resetSrc6Cache() {
+	src6CacheMu.Lock()
+	src6Cache = map[[8]byte]net.IP{}
+	src6CacheMu.Unlock()
+}
+
+func TestSourceIP6ForCachesPerSlash64(t *testing.T) {
+	orig := PkgRouter
+	t.Cleanup(func() { PkgRouter = orig; resetSrc6Cache() })
+	resetSrc6Cache()
+
+	want := net.ParseIP("2001:db8::1")
+	cr := &countingRouter{src: want}
+	PkgRouter = cr
+
+	// Many distinct addresses inside the same /64 must trigger exactly one
+	// routing lookup and all return the cached source.
+	for i := 0; i < 50; i++ {
+		dst := net.ParseIP("2001:db8::")
+		dst[15] = byte(i)
+		got := sourceIP6For(dst)
+		require.True(t, want.Equal(got), "addr %d: got %v want %v", i, got, want)
+	}
+	require.Equal(t, 1, cr.calls, "same /64 should be looked up once")
+
+	// A different /64 is a separate cache entry, so one more lookup.
+	_ = sourceIP6For(net.ParseIP("2001:db8:1::1"))
+	require.Equal(t, 2, cr.calls)
+}
+
+func TestSourceIP6ForNilRouter(t *testing.T) {
+	orig := PkgRouter
+	t.Cleanup(func() { PkgRouter = orig; resetSrc6Cache() })
+	resetSrc6Cache()
+
+	PkgRouter = nil
+	require.Nil(t, sourceIP6For(net.ParseIP("2001:db8::1")))
+}
+
+func TestSourceIP6ForRouteFailureNotCached(t *testing.T) {
+	orig := PkgRouter
+	t.Cleanup(func() { PkgRouter = orig; resetSrc6Cache() })
+	resetSrc6Cache()
+
+	// nil source from the router must not be cached, so a later success works.
+	failing := &countingRouter{src: nil}
+	PkgRouter = failing
+	require.Nil(t, sourceIP6For(net.ParseIP("2001:db8::1")))
+	require.Nil(t, sourceIP6For(net.ParseIP("2001:db8::1")))
+	require.Equal(t, 2, failing.calls, "failed lookups must not be cached")
+}

--- a/pkg/scan/source6_cache_test.go
+++ b/pkg/scan/source6_cache_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // countingRouter records how many times Route is called and returns a fixed
-// source IP, so we can assert the /64 cache collapses per-packet lookups.
+// source IP, so we can assert the destination cache collapses per-packet lookups.
 type countingRouter struct {
 	routing.Router
 	mu    sync.Mutex
@@ -27,11 +27,11 @@ func (c *countingRouter) Route(dst net.IP) (*net.Interface, net.IP, net.IP, erro
 
 func resetSrc6Cache() {
 	src6CacheMu.Lock()
-	src6Cache = map[[8]byte]net.IP{}
+	src6Cache = map[[16]byte]net.IP{}
 	src6CacheMu.Unlock()
 }
 
-func TestSourceIP6ForCachesPerSlash64(t *testing.T) {
+func TestSourceIP6ForCachesPerDestination(t *testing.T) {
 	orig := PkgRouter
 	t.Cleanup(func() { PkgRouter = orig; resetSrc6Cache() })
 	resetSrc6Cache()
@@ -40,18 +40,15 @@ func TestSourceIP6ForCachesPerSlash64(t *testing.T) {
 	cr := &countingRouter{src: want}
 	PkgRouter = cr
 
-	// Many distinct addresses inside the same /64 must trigger exactly one
-	// routing lookup and all return the cached source.
+	dst := net.ParseIP("2001:db8::10")
 	for i := 0; i < 50; i++ {
-		dst := net.ParseIP("2001:db8::")
-		dst[15] = byte(i)
 		got := sourceIP6For(dst)
-		require.True(t, want.Equal(got), "addr %d: got %v want %v", i, got, want)
+		require.True(t, want.Equal(got), "iter %d: got %v want %v", i, got, want)
 	}
-	require.Equal(t, 1, cr.calls, "same /64 should be looked up once")
+	require.Equal(t, 1, cr.calls, "same destination should be looked up once")
 
-	// A different /64 is a separate cache entry, so one more lookup.
-	_ = sourceIP6For(net.ParseIP("2001:db8:1::1"))
+	// A different destination is a separate cache entry.
+	_ = sourceIP6For(net.ParseIP("2001:db8::11"))
 	require.Equal(t, 2, cr.calls)
 }
 

--- a/pkg/scan/syncookie.go
+++ b/pkg/scan/syncookie.go
@@ -1,0 +1,69 @@
+package scan
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"net"
+)
+
+// synCookieKey is a per-process random key used to derive the TCP sequence
+// number ("SYN cookie") of outbound SYN probes. The matching SYN-ACK echoes
+// it back as Ack = seq+1, which lets the receive path confirm a reply is
+// genuinely ours - rejecting spoofed, injected or stale SYN-ACKs that happen
+// to originate from an address in the target set.
+var synCookieKey = func() uint64 {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to a fixed constant; validation still works for a single
+		// run, it is just predictable across runs.
+		return 0x9E3779B97F4A7C15
+	}
+	return binary.BigEndian.Uint64(b[:])
+}()
+
+// SynCookie derives the 32-bit sequence number for a SYN probe toward
+// dstIP:dstPort sent from local port srcPort. The mix is keyed and
+// non-cryptographic (splitmix64-style finaliser) - chosen for speed on the
+// send hot path; it only needs to be hard to guess blindly, not collision
+// proof.
+func SynCookie(dstIP net.IP, dstPort, srcPort uint16) uint32 {
+	x := synCookieKey
+	if ip4 := dstIP.To4(); ip4 != nil {
+		x ^= uint64(binary.BigEndian.Uint32(ip4))
+	} else if ip16 := dstIP.To16(); ip16 != nil {
+		x ^= binary.BigEndian.Uint64(ip16[0:8])
+		x ^= binary.BigEndian.Uint64(ip16[8:16])
+	}
+	return synCookieMix(x, dstPort, srcPort)
+}
+
+// SynCookie4 is the zero-allocation variant for the fast IPv4 sender.
+func SynCookie4(dstIP [4]byte, dstPort, srcPort uint16) uint32 {
+	x := synCookieKey ^ uint64(binary.BigEndian.Uint32(dstIP[:]))
+	return synCookieMix(x, dstPort, srcPort)
+}
+
+func synCookieMix(x uint64, dstPort, srcPort uint16) uint32 {
+	x ^= uint64(dstPort)<<16 | uint64(srcPort)
+	x *= 0xff51afd7ed558ccd
+	x ^= x >> 33
+	x *= 0xc4ceb9fe1a85ec53
+	x ^= x >> 33
+	return uint32(x)
+}
+
+// verifySynCookie reports whether a received SYN-ACK acknowledges a SYN we
+// actually sent. targetPort is the responder's source port (the port we
+// probed) and ourPort is the local listening port; ack is the SYN-ACK
+// acknowledgement number, which must equal our sent seq+1.
+func verifySynCookie(srcIP4, srcIP6 string, targetPort, ourPort uint16, ack uint32) bool {
+	ipStr := srcIP4
+	if ipStr == "" {
+		ipStr = srcIP6
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	return ack-1 == SynCookie(ip, targetPort, ourPort)
+}

--- a/pkg/scan/syncookie.go
+++ b/pkg/scan/syncookie.go
@@ -14,9 +14,10 @@ import (
 var synCookieKey = func() uint64 {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// Fall back to a fixed constant; validation still works for a single
-		// run, it is just predictable across runs.
-		return 0x9E3779B97F4A7C15
+		// Fail closed: a predictable fallback would defeat spoofed SYN-ACK
+		// rejection. crypto/rand failure is effectively impossible on supported
+		// platforms; abort rather than silently weaken validation.
+		panic("naabu: failed to initialize SYN cookie key: " + err.Error())
 	}
 	return binary.BigEndian.Uint64(b[:])
 }()

--- a/pkg/scan/syncookie_test.go
+++ b/pkg/scan/syncookie_test.go
@@ -1,0 +1,54 @@
+package scan
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSynCookieRoundTrip(t *testing.T) {
+	ip := net.ParseIP("93.184.216.34")
+	const targetPort, ourPort = 443, 54321
+
+	seq := SynCookie(ip, targetPort, ourPort)
+	// A real SYN-ACK acknowledges seq with seq+1.
+	require.True(t, verifySynCookie(ip.String(), "", targetPort, ourPort, seq+1),
+		"valid SYN-ACK must pass cookie verification")
+}
+
+func TestSynCookieRejectsForgery(t *testing.T) {
+	ip := net.ParseIP("93.184.216.34")
+	const targetPort, ourPort = 443, 54321
+	seq := SynCookie(ip, targetPort, ourPort)
+
+	// Wrong ack value.
+	require.False(t, verifySynCookie(ip.String(), "", targetPort, ourPort, seq+2))
+	// Right ack but wrong responder IP.
+	require.False(t, verifySynCookie("8.8.8.8", "", targetPort, ourPort, seq+1))
+	// Right ack but wrong port.
+	require.False(t, verifySynCookie(ip.String(), "", 80, ourPort, seq+1))
+	// Unparseable source address.
+	require.False(t, verifySynCookie("", "", targetPort, ourPort, seq+1))
+}
+
+func TestSynCookie4MatchesSynCookie(t *testing.T) {
+	ip4 := [4]byte{93, 184, 216, 34}
+	ip := net.IPv4(93, 184, 216, 34)
+	const targetPort, ourPort = 8080, 40000
+	require.Equal(t, SynCookie(ip, targetPort, ourPort), SynCookie4(ip4, targetPort, ourPort),
+		"fast IPv4 cookie must equal the generic cookie")
+}
+
+func TestSynCookieWrapAround(t *testing.T) {
+	// Force a cookie of 0xFFFFFFFF to exercise uint32 ack-1 wraparound:
+	// ack = seq+1 = 0, ack-1 must wrap back to 0xFFFFFFFF.
+	ip := net.ParseIP("10.0.0.1")
+	for p := uint16(1); p != 0; p++ {
+		if SynCookie(ip, p, 12345) == 0xFFFFFFFF {
+			require.True(t, verifySynCookie(ip.String(), "", p, 12345, 0))
+			return
+		}
+	}
+	t.Skip("no cookie hit 0xFFFFFFFF in search space")
+}

--- a/pkg/scan/syncookie_test.go
+++ b/pkg/scan/syncookie_test.go
@@ -39,16 +39,3 @@ func TestSynCookie4MatchesSynCookie(t *testing.T) {
 	require.Equal(t, SynCookie(ip, targetPort, ourPort), SynCookie4(ip4, targetPort, ourPort),
 		"fast IPv4 cookie must equal the generic cookie")
 }
-
-func TestSynCookieWrapAround(t *testing.T) {
-	// Force a cookie of 0xFFFFFFFF to exercise uint32 ack-1 wraparound:
-	// ack = seq+1 = 0, ack-1 must wrap back to 0xFFFFFFFF.
-	ip := net.ParseIP("10.0.0.1")
-	for p := uint16(1); p != 0; p++ {
-		if SynCookie(ip, p, 12345) == 0xFFFFFFFF {
-			require.True(t, verifySynCookie(ip.String(), "", p, 12345, 0))
-			return
-		}
-	}
-	t.Skip("no cookie hit 0xFFFFFFFF in search space")
-}

--- a/pkg/scan/workers_test.go
+++ b/pkg/scan/workers_test.go
@@ -109,6 +109,35 @@ func TestCloseWaitsForWorkers(t *testing.T) {
 	}
 }
 
+func TestCloseCancelsWorkersWithoutExternalCancel(t *testing.T) {
+	s := newTestScanner(t)
+	s.ListenHandler.Phase.Set(Scan)
+	// Caller never cancels the context: Close must cancel its own workers,
+	// otherwise workersWg.Wait blocks forever.
+	s.StartWorkers(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		_ = s.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() hung: it must cancel its own workers")
+	}
+	assert.Nil(t, s.ListenHandler)
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	s := newTestScanner(t)
+	s.StartWorkers(context.Background())
+	require.NoError(t, s.Close())
+	// Second call must not panic on the already-niled ListenHandler.
+	require.NoError(t, s.Close())
+}
+
 func TestSequentialScannerReuse(t *testing.T) {
 	handler := &ListenHandler{
 		Phase:              &Phase{},

--- a/pkg/scan/workers_test.go
+++ b/pkg/scan/workers_test.go
@@ -267,12 +267,14 @@ func TestTCPResultWorkerAddsToScanResults(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestTCPResultWorkerDropsOutOfRangeIP(t *testing.T) {
+// TestTCPResultWorkerRecordsCookieValidated documents that the TCP result
+// worker no longer performs an IPRanger membership filter: SYN-ACK
+// authenticity is enforced upstream by the SYN-cookie check, so a result
+// delivered on TcpChan is recorded even when the IP was never added to the
+// ranger. Forgery rejection is covered by TestSynCookieRejectsForgery.
+func TestTCPResultWorkerRecordsCookieValidated(t *testing.T) {
 	s := newTestScanner(t)
 	s.ListenHandler.Phase.Set(Scan)
-
-	err := s.IPRanger.Add("10.0.0.1")
-	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.StartWorkers(ctx)
@@ -284,10 +286,10 @@ func TestTCPResultWorkerDropsOutOfRangeIP(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	assert.False(t, s.ScanResults.IPHasPort("10.0.0.99", &port.Port{Port: 80, Protocol: protocol.TCP}))
+	assert.True(t, s.ScanResults.IPHasPort("10.0.0.99", &port.Port{Port: 80, Protocol: protocol.TCP}))
 
 	cancel()
-	err = s.Close()
+	err := s.Close()
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Reworks the SYN path into a stateless high rate scanner and adds the output, timing and distribution features expected from nmap and masscan. Covered by unit tests with race and privileged docker runs.

- fast sender sends SYN probes through a no serialization raw sender that patches three header fields per packet
- pacer replaces the per packet ratelimit channel with a local budget pacer
- batching sends SYN packets in sendmmsg batches up to the kernel iov limit
- syn cookies encode the target into the SYN sequence so replies are verified without per target state
- no store fast path skips the disk backed ipranger for plain IP and CIDR inputs and relies on the cookie
- timing templates add nmap style T0 to T5 presets
- nmap output writes nmap compatible xml and greppable formats
- oA writes json, xml and greppable together
- sharding splits a scan across nodes with shard index/total
- multicore tx parallelizes raw SYN transmit across workers with tx-workers
- on demand handlers build listen handlers lazily per scan and tear them down after, no fixed pool or cap
- adaptive pacer backs off the send rate on kernel TX buffer exhaustion and recovers gradually
- source bindings bind the raw socket to source-ip so the chosen source and port are emitted on the fast path
- ulimit autotune raises the open file limit and caps connect scan concurrency to it
- faster receive reads replies zero copy with a larger capture buffer
- ipv6 caches the per route source and fixes the bpf filter so ipv6 and loopback replies are captured
- fingerprint backlog queues service detection targets so none are dropped when discovery outruns probing
- loopback source uses the per target source so 127.0.0.1 SYN replies return
- dedup and output fixes tune result dedup and stop json and csv double emission and repeated csv headers
- correctness fixes stale gopacket layer reuse, idempotent scanner close, output dir creation, port dedup, icmp and ndp nil guards, timing floor clamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nmap-compatible XML (`-oX`) and greppable (`-oG`) output, plus `-oA` multi-output expansion.
  * Added scan sharding/reproducible seeding (`--shard`, `--seed`), timing templates (`-T`), and configurable fast transmission worker counts (`--tx-workers`).
* **Bug Fixes**
  * Improved fast SYN sending correctness (routing-aware checksum source handling) and strengthened SYN-cookie support/validation.
  * Enhanced scanner and raw-socket lifecycle reliability (idempotent shutdown, safer ICMP/NDP guards, improved result gating/processing).
* **Chores**
  * Expanded automated test coverage for pacing, sharding, output formatting, queues/backpressure, and scan runner/worker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->