### PR TITLE
fix: correct log levels for -sV service detection warnings

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1145,7 +1145,7 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 		probeFile = fingerprint.LocateNmapProbes()
 	}
 	if probeFile == "" {
-		gologger.Info().Label("WRN").Msgf("could not find nmap-service-probes, skipping -sV. Install nmap or specify the path with --sV-probes")
+		gologger.Warning().Msgf("could not find nmap-service-probes, skipping -sV. Install nmap or specify the path with --sV-probes")
 		r.options.ServiceVersion = false
 		scan.EnableTLSDetection = false
 		return
@@ -1153,7 +1153,7 @@ func (r *Runner) initServiceDetection(parentCtx context.Context) {
 
 	db, err := r.loadProbeDB(probeFile)
 	if err != nil {
-		gologger.Info().Label("WRN").Msgf("could not load service probes from %s, skipping -sV", probeFile)
+		gologger.Warning().Msgf("could not load service probes from %s, skipping -sV", probeFile)
 		r.options.ServiceVersion = false
 		scan.EnableTLSDetection = false
 		return


### PR DESCRIPTION
## Problem

`initServiceDetection()` in `runner.go` uses `gologger.Info().Label("WRN")`
for both error paths — the same antipattern fixed for `-uP` warnings in
the previous PR. The consequences are identical:

- Both messages are **suppressed when running with `-silent`** because
  gologger filters by level, not by the display label
- A user who runs `naabu -sV -silent` and has no nmap installed gets
  zero feedback — the scan silently skips service detection entirely
- It is inconsistent with every other warning in the codebase

## Fix

Replace both `gologger.Info().Label("WRN")` calls in
`initServiceDetection()` with `gologger.Warning().Msgf()`.

## Testing

```bash
go build ./pkg/runner/
go test ./pkg/runner/
go vet ./pkg/runner/
```

All pass clean.

## Notes

- Only `runner.go` is changed — 2 lines
- No behaviour change for users who have nmap installed
- 

cc @dogancanbakir @Mzack9999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning messages when service probe data is missing or can’t be loaded.
  * Scan behavior remains unchanged, but the issue is now reported with clearer warning severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->