### PR TITLE
fix: don't mark TLS as checked for ports never TLS-probed

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -360,13 +360,21 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 				break
 			}
 		}
+		// TLS is only actually probed on the CONNECT-scan path (scan.ConnectPort,
+		// gated by scan.EnableTLSDetection). Raw SYN scanning never opens a real
+		// connection, and passive (Shodan-sourced) ports are never probed at all,
+		// so p.TLS is just its false zero value on both paths - telling the
+		// fingerprint engine TLSChecked in that case would make it trust a "not
+		// TLS" that was never actually checked, and it would silently stop trying
+		// TLS handshakes against real HTTPS/TLS ports.
+		tlsChecked := !r.options.Passive && !r.options.shouldUseRawPackets()
 		for _, p := range hostResult.Ports {
 			fpq.push(fingerprint.Target{
 				Host:        hostname,
 				IP:          hostResult.IP,
 				Port:        p.Port,
 				TLSDetected: p.TLS, //nolint:staticcheck // deprecated but still set by scan layer
-				TLSChecked:  true,
+				TLSChecked:  tlsChecked,
 			})
 		}
 	}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -900,6 +900,53 @@ func TestOnReceiveKeepsUnseenPortsOnPartialDuplicate(t *testing.T) {
 	require.True(t, runner.unique.Has(net.JoinHostPort(ip, "443")), "new port 443 must still be recorded despite the leading duplicate")
 }
 
+// TestOnReceiveTLSCheckedReflectsScanPath guards against feeding the
+// fingerprint engine a false "TLS already checked" signal. TLSChecked must
+// only be true when the port genuinely went through scan.ConnectPort's TLS
+// handshake (the CONNECT-scan path) - raw SYN scanning and passive
+// (Shodan-sourced) results never open a real connection, so p.TLS is just
+// its unset zero value there, not a confirmed "not TLS".
+func TestOnReceiveTLSCheckedReflectsScanPath(t *testing.T) {
+	origRouter := scan.PkgRouter
+	origPriv := privileges.IsPrivileged
+	defer func() {
+		scan.PkgRouter = origRouter
+		privileges.IsPrivileged = origPriv
+	}()
+	scan.PkgRouter = stubRouter{}
+	privileges.IsPrivileged = true
+
+	tests := []struct {
+		name        string
+		scanType    string
+		passive     bool
+		wantChecked bool
+	}{
+		{"syn scan never performs a real TLS check", SynScan, false, false},
+		{"connect scan performs a real TLS check", ConnectScan, false, true},
+		{"passive results are never TLS-checked even on connect scan type", ConnectScan, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newConnectRunner(t)
+			runner.options.ScanType = tt.scanType
+			runner.options.Passive = tt.passive
+			runner.fpQueue = newFpQueue()
+
+			runner.onReceive(&result.HostResult{
+				IP:    "192.168.1.77",
+				Ports: []*port.Port{{Port: 443, Protocol: protocol.TCP}},
+			})
+
+			tgt, ok := runner.fpQueue.pop()
+			require.True(t, ok, "port must have been queued for fingerprinting")
+			require.Equal(t, tt.wantChecked, tgt.TLSChecked)
+			require.False(t, tgt.TLSDetected, "p.TLS was never set to true on this path")
+		})
+	}
+}
+
 func TestHostsForIPNoStoreFastPath(t *testing.T) {
 	options := &Options{
 		Host:      []string{"192.168.1.0/24"},


### PR DESCRIPTION
Summary

    onReceive unconditionally set fingerprint.Target.TLSChecked = true when queuing a discovered port for -sV, regardless of how the port was actually found.
    TLS is only ever really probed on the CONNECT-scan path (scan.ConnectPort, gated by scan.EnableTLSDetection). Raw SYN scanning never opens a real connection, and passive/Shodan-sourced ports are never probed at all — so p.TLS was just its zero value on those paths, not a confirmed "not TLS".
    Because TLSChecked was hardcoded true, the fingerprint engine trusted that false "not TLS" and skipped its own TLS-handshake fallback (engine.go's detectTLS). Net effect: naabu -s s -sV (SYN scan + service version detection, the fast/recommended combo for root/VPS use) silently failed to identify services on real HTTPS/TLS ports — probes went out in plaintext against a TLS socket and got no usable match, with no error or warning.
    TLSChecked is now only true on the CONNECT-scan path, which is the only path that actually performs the check:
          tlsChecked := !r.options.Passive && !r.options.shouldUseRawPackets()
Test plan

    donego build ./...
    donegofmt -l on changed files — clean
    doneAdded TestOnReceiveTLSCheckedReflectsScanPath covering SYN scan / CONNECT scan / passive-on-connect-type, using the same privileges.IsPrivileged + scan.PkgRouter stubbing pattern as the existing TestNewRunner_ScanTypeSyncAfterFallback test
    donego test ./pkg/runner/... ./pkg/fingerprint/... — pass
    not donego test ./pkg/scan/... — TestPingHosts fails in this sandbox (no outbound ICMP/DNS), confirmed pre-existing by reproducing on a clean checkout of dev with no code changes; unrelated to this diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TLS scan status reporting so it accurately reflects the scan method.
  * Passive and SYN scans no longer incorrectly appear as TLS-checked.

* **Tests**
  * Added coverage to verify TLS status across active, passive, and SYN scan paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->