### PR TITLE
fix: don't mark TLS as checked for ports never TLS-probed

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -360,13 +360,21 @@ func (r *Runner) onReceive(hostResult *result.HostResult) {
 				break
 			}
 		}
+		// TLS is only actually probed on the CONNECT-scan path (scan.ConnectPort,
+		// gated by scan.EnableTLSDetection). Raw SYN scanning never opens a real
+		// connection, and passive (Shodan-sourced) ports are never probed at all,
+		// so p.TLS is just its false zero value on both paths - telling the
+		// fingerprint engine TLSChecked in that case would make it trust a "not
+		// TLS" that was never actually checked, and it would silently stop trying
+		// TLS handshakes against real HTTPS/TLS ports.
+		tlsChecked := !r.options.Passive && !r.options.shouldUseRawPackets()
 		for _, p := range hostResult.Ports {
 			fpq.push(fingerprint.Target{
 				Host:        hostname,
 				IP:          hostResult.IP,
 				Port:        p.Port,
 				TLSDetected: p.TLS, //nolint:staticcheck // deprecated but still set by scan layer
-				TLSChecked:  true,
+				TLSChecked:  tlsChecked,
 			})
 		}
 	}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -900,6 +900,53 @@ func TestOnReceiveKeepsUnseenPortsOnPartialDuplicate(t *testing.T) {
 	require.True(t, runner.unique.Has(net.JoinHostPort(ip, "443")), "new port 443 must still be recorded despite the leading duplicate")
 }
 
+// TestOnReceiveTLSCheckedReflectsScanPath guards against feeding the
+// fingerprint engine a false "TLS already checked" signal. TLSChecked must
+// only be true when the port genuinely went through scan.ConnectPort's TLS
+// handshake (the CONNECT-scan path) - raw SYN scanning and passive
+// (Shodan-sourced) results never open a real connection, so p.TLS is just
+// its unset zero value there, not a confirmed "not TLS".
+func TestOnReceiveTLSCheckedReflectsScanPath(t *testing.T) {
+	origRouter := scan.PkgRouter
+	origPriv := privileges.IsPrivileged
+	defer func() {
+		scan.PkgRouter = origRouter
+		privileges.IsPrivileged = origPriv
+	}()
+	scan.PkgRouter = stubRouter{}
+	privileges.IsPrivileged = true
+
+	tests := []struct {
+		name        string
+		scanType    string
+		passive     bool
+		wantChecked bool
+	}{
+		{"syn scan never performs a real TLS check", SynScan, false, false},
+		{"connect scan performs a real TLS check", ConnectScan, false, true},
+		{"passive results are never TLS-checked even on connect scan type", ConnectScan, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newConnectRunner(t)
+			runner.options.ScanType = tt.scanType
+			runner.options.Passive = tt.passive
+			runner.fpQueue = newFpQueue()
+
+			runner.onReceive(&result.HostResult{
+				IP:    "192.168.1.77",
+				Ports: []*port.Port{{Port: 443, Protocol: protocol.TCP}},
+			})
+
+			tgt, ok := runner.fpQueue.pop()
+			require.True(t, ok, "port must have been queued for fingerprinting")
+			require.Equal(t, tt.wantChecked, tgt.TLSChecked)
+			require.False(t, tgt.TLSDetected, "p.TLS was never set to true on this path")
+		})
+	}
+}
+
 func TestHostsForIPNoStoreFastPath(t *testing.T) {
 	options := &Options{
 		Host:      []string{"192.168.1.0/24"},


### PR DESCRIPTION
onReceive unconditionally set fingerprint.Target.TLSChecked = true when queuing a discovered port for -sV, regardless of how the port was found. TLS is only actually probed on the CONNECT-scan path (scan.ConnectPort, gated by scan.EnableTLSDetection); raw SYN scanning never opens a real connection, and passive/Shodan-sourced ports are never probed at all, so p.TLS was just its zero value there. Telling the fingerprint engine TLSChecked in those cases made it trust a "not TLS" that was never checked, silently skipping its own TLS handshake fallback against real HTTPS/TLS ports scanned with -s s -sV.

TLSChecked is now only set when the CONNECT-scan path actually ran the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS detection accuracy across scan types.
  * TLS results are now trusted only when an active TLS check was performed, preventing missed detection on raw SYN and passive scans.

* **Tests**
  * Added coverage verifying TLS-check status for active, SYN, and passive scan paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->