### PR TITLE
fix: error out when all specified ports are excluded instead of falling back to top-100

### DIFF
--- a/pkg/runner/ports.go
+++ b/pkg/runner/ports.go
@@ -93,6 +93,13 @@ func ParsePorts(options *Options) ([]*port.Port, error) {
 
 	// By default scan top 100 ports only
 	if len(ports) == 0 {
+		// The default top-100 list must only apply when no ports were specified
+		// at all. If the user provided ports (-p, -pf or -tp) and the exclusion
+		// list removed them all, scanning top-100 instead would probe ports the
+		// user never asked for, so error out (nmap behaves the same way).
+		if options.Ports != "" || len(options.PortsFile) > 0 || options.TopPorts != "" {
+			return nil, errors.New("no ports to scan: all specified ports were excluded")
+		}
 		portsList, err := parsePortsList(NmapTop100)
 		if err != nil {
 			return nil, fmt.Errorf("could not read ports: %s", err)

--- a/pkg/runner/ports_test.go
+++ b/pkg/runner/ports_test.go
@@ -132,3 +132,46 @@ func TestParsePorts(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 100, len(got))
 }
+
+func TestParsePortsAllSpecifiedPortsExcluded(t *testing.T) {
+	// Ports the user explicitly specified (-p, -pf, -tp) must never be
+	// silently replaced by the default top-100 list when the exclusion list
+	// removes them all: that would probe ports the user never asked for.
+	tests := []struct {
+		name         string
+		ports        string
+		topPorts     string
+		portsFile    goflags.StringSlice
+		excludePorts goflags.StringSlice
+		wantErr      bool
+		wantCount    int
+	}{
+		{"cli ports fully excluded", "80", "", nil, goflags.StringSlice{"80"}, true, 0},
+		{"cli ports fully excluded by range", "80,443", "", nil, goflags.StringSlice{"79-444"}, true, 0},
+		{"cli range fully excluded", "80-90", "", nil, goflags.StringSlice{"79-91"}, true, 0},
+		{"full port range fully excluded", "1-65535", "", nil, goflags.StringSlice{"1-65535"}, true, 0},
+		{"top ports fully excluded", "", "100", nil, goflags.StringSlice{"1-65535"}, true, 0},
+		{"ports file fully excluded", "", "", goflags.StringSlice{"80"}, goflags.StringSlice{"80"}, true, 0},
+		{"cli ports partially excluded", "80,443", "", nil, goflags.StringSlice{"80"}, false, 1},
+		{"top ports partially excluded", "", "100", nil, goflags.StringSlice{"80"}, false, 99},
+		{"exclusions only still default to top-100", "", "", nil, goflags.StringSlice{"80"}, false, 99},
+		{"no ports and no exclusions default to top-100", "", "", nil, nil, false, 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := &Options{
+				Ports:        tt.ports,
+				TopPorts:     tt.topPorts,
+				PortsFile:    tt.portsFile,
+				ExcludePorts: tt.excludePorts,
+			}
+			got, err := ParsePorts(options)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, tt.wantCount, len(got))
+		})
+	}
+}

--- a/pkg/runner/ports_test.go
+++ b/pkg/runner/ports_test.go
@@ -167,7 +167,7 @@ func TestParsePortsAllSpecifiedPortsExcluded(t *testing.T) {
 			}
 			got, err := ParsePorts(options)
 			if tt.wantErr {
-				assert.NotNil(t, err)
+				assert.EqualError(t, err, "no ports to scan: all specified ports were excluded")
 			} else {
 				assert.Nil(t, err)
 			}


### PR DESCRIPTION
When every port the user explicitly specified via `-p`/`-pf`/`-tp` is removed by `-ep`, `ParsePorts` sees an empty merged list and silently applies the "default to top-100" fallback, so the scan probes ~100 ports the user never asked for (or, for `-tp 100 -ep 1-65535`, silently scans nothing and exits 0). For example, with a listener running on `127.0.0.1:8080`:

```console
$ naabu -host 127.0.0.1 -p 5555 -ep 5555
127.0.0.1:8080
127.0.0.1:81
[INF] Found 2 ports on host 127.0.0.1 (127.0.0.1)
```

The user asked only for port 5555 and excluded it, yet the fallback probed and reported two top-100 ports as open, silently exceeding the requested scan scope. This PR keeps the top-100 default strictly for runs where no port specification was given, and returns a clear `no ports to scan: all specified ports were excluded` error otherwise, matching nmap's behavior for an empty port set. Covered by a new table-driven test (`TestParsePortsAllSpecifiedPortsExcluded`, 10 cases) — the full `pkg/runner` suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scanning now reports an error when all user-specified ports are excluded, instead of silently falling back to the default top-100 ports.
  * The default top-100 port selection remains available when no ports are specified, preserving expected scanning behavior.

* **Tests**
  * Added coverage for exclusions involving individual ports, ranges, top ports, port files, and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->